### PR TITLE
feat(registry): add new components and examples for button and radio form fields

### DIFF
--- a/registry/__index__.ts
+++ b/registry/__index__.ts
@@ -13,61 +13,12 @@ interface RegistryComponent {
 
 export const registryIndex: Record<string, RegistryComponent> = {
 
-    "dialog.confirmation": {
-      name: "dialog.confirmation",
-      category: "dialog",
-      path: "#/registry/ui/dialog.confirmation.tsx",
-      code: "import { Button } from '@/components/ui/button';\nimport {\n  Dialog,\n  DialogContent,\n  DialogDescription,\n  DialogFooter,\n  DialogHeader,\n  DialogTitle,\n  DialogTrigger,\n} from '@/components/ui/dialog';\nimport type { JSX } from 'react';\n\nexport interface DialogConfirmationProps {\n  trigger: JSX.Element;\n  title: string;\n  description: string;\n  labelConfirmButton: string;\n  onConfirm: () => void;\n}\n\nexport function DialogConfirmation({\n  trigger,\n  title,\n  description,\n  labelConfirmButton,\n  onConfirm,\n}: DialogConfirmationProps) {\n  return (\n    <Dialog>\n      <DialogTrigger asChild>{trigger}</DialogTrigger>\n      <DialogContent>\n        <DialogHeader>\n          <DialogTitle>{title}</DialogTitle>\n          <DialogDescription className='md:text-left'>{description}</DialogDescription>\n        </DialogHeader>\n        <DialogFooter>\n          <Button onClick={onConfirm}>{labelConfirmButton}</Button>\n        </DialogFooter>\n      </DialogContent>\n    </Dialog>\n  );\n}\n",
-      component: React.lazy(() => import("#/registry/ui/dialog.confirmation.tsx")),
-      },
-    "button.theme": {
-      name: "button.theme",
-      category: "button",
-      path: "#/registry/ui/button.theme.tsx",
-      code: "import { Button } from '@/components/ui/button';\nimport { Laptop, Moon, Sun } from 'lucide-react';\nimport { useTheme } from 'next-themes';\nimport * as React from 'react';\n\nexport interface ButtonThemeProps {\n  withText?: boolean;\n}\n\nexport default function ButtonTheme({ withText }: ButtonThemeProps) {\n  const { theme, setTheme } = useTheme();\n  const [currentTheme, setCurrentTheme] = React.useState<'system' | 'light' | 'dark'>('system');\n\n  React.useEffect(() => {\n    setCurrentTheme(theme as 'system' | 'light' | 'dark');\n  }, [theme]);\n\n  const cycleTheme = () => {\n    const themes: ('system' | 'light' | 'dark')[] = ['system', 'light', 'dark'];\n    const currentIndex = themes.indexOf(currentTheme);\n    const nextIndex = (currentIndex + 1) % themes.length;\n    setTheme(themes[nextIndex]);\n  };\n\n  return (\n    <Button variant='outline' size={withText ? 'default' : 'icon'} onClick={cycleTheme}>\n      {currentTheme === 'system' && <Laptop className='h-[1.2rem] w-[1.2rem]' />}\n      {currentTheme === 'light' && <Sun className='h-[1.2rem] w-[1.2rem]' />}\n      {currentTheme === 'dark' && <Moon className='h-[1.2rem] w-[1.2rem]' />}\n      {withText && (\n        <span className='ml-2 capitalize'>{currentTheme.charAt(0).toUpperCase() + currentTheme.slice(1)}</span>\n      )}\n      <span className='sr-only'>Toggle theme</span>\n    </Button>\n  );\n}\n",
-      component: React.lazy(() => import("#/registry/ui/button.theme.tsx")),
-      },
-    "hover.item": {
-      name: "hover.item",
-      category: "hover",
-      path: "#/registry/ui/hover.item.tsx",
-      code: "import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';\nimport type React from 'react';\n\nexport interface HoverItemProps {\n  children: string | React.JSX.Element | React.ReactNode; // can be used as children\n  content: string | React.JSX.Element;\n}\n\nexport default function HoverItem({ children, content }: HoverItemProps) {\n  return (\n    <HoverCard>\n      <HoverCardTrigger className='cursor-pointer'>{children}</HoverCardTrigger>\n      <HoverCardContent className='text-sm w-full'>{content}</HoverCardContent>\n    </HoverCard>\n  );\n}\n",
-      component: React.lazy(() => import("#/registry/ui/hover.item.tsx")),
-      },
-    "select.form-field": {
-      name: "select.form-field",
-      category: "select",
-      path: "#/registry/ui/select.form-field.tsx",
-      code: "import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';\nimport { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';\nimport type { Control, Path, PathValue } from 'react-hook-form';\n\nexport interface SelectOption {\n  value: string;\n  label: string;\n}\n\nexport interface SelectFieldProps<T extends Record<string, string>> {\n  control: Control<T>;\n  name: Path<T>;\n  values: SelectOption[];\n  defaultValues?: PathValue<T, Path<T>>;\n  label: string;\n  placeholder: string;\n  description?: string;\n}\n\nexport const SelectField = <TFieldValues extends Record<string, string>>({\n  control,\n  name,\n  values,\n  defaultValues,\n  label,\n  placeholder,\n  description,\n}: SelectFieldProps<TFieldValues>) => {\n  return (\n    <FormField\n      control={control}\n      name={name}\n      defaultValue={defaultValues}\n      render={({ field }) => (\n        <FormItem>\n          <FormLabel>{label}</FormLabel>\n          <Select onValueChange={field.onChange} defaultValue={field.value}>\n            <FormControl>\n              <SelectTrigger>\n                <SelectValue placeholder={placeholder} />\n              </SelectTrigger>\n            </FormControl>\n            <SelectContent>\n              {values.map((item) => (\n                <SelectItem key={item.value} value={item.value}>\n                  {item.label}\n                </SelectItem>\n              ))}\n            </SelectContent>\n          </Select>\n          {description && <FormDescription>{description}</FormDescription>}\n          <FormMessage />\n        </FormItem>\n      )}\n    />\n  );\n};\n",
-      component: React.lazy(() => import("#/registry/ui/select.form-field.tsx")),
-      },
     "button.submit": {
       name: "button.submit",
       category: "button",
       path: "#/registry/ui/button.submit.tsx",
       code: "import { Button } from '@/components/ui/button';\nimport { cn } from '@/lib/utils';\nimport { ReloadIcon } from '@radix-ui/react-icons';\nimport type { JSX, MouseEventHandler } from 'react';\n\nexport interface ButtonSubmitProps {\n  onClick?: MouseEventHandler<HTMLButtonElement>;\n  label: JSX.Element | string;\n  disabled?: boolean;\n  loading?: boolean;\n}\n\nexport default function ButtonSubmit({\n  onClick,\n  label,\n  disabled,\n  loading,\n  ...props\n}: ButtonSubmitProps & React.ComponentProps<'button'>) {\n  return (\n    <Button\n      type='submit'\n      variant={'default'}\n      {...(onClick && { onClick })}\n      disabled={disabled || loading}\n      className={cn('w-full', ...(props?.className ? [props.className] : []))}\n      {...props}\n    >\n      {loading && <ReloadIcon className='mr-2 h-4 w-4 animate-spin' />}\n      {label}\n    </Button>\n  );\n}\n",
       component: React.lazy(() => import("#/registry/ui/button.submit.tsx")),
-      },
-    "skeleton.text": {
-      name: "skeleton.text",
-      category: "skeleton",
-      path: "#/registry/ui/skeleton.text.tsx",
-      code: "import { Skeleton } from '@/components/ui/skeleton';\n\nexport interface SkeletonTextProps {\n  text: string | undefined;\n}\n\nexport const SkeletonText = ({ text }: SkeletonTextProps) => {\n  if (!text) return <Skeleton className='w-20 h-4' />;\n  return text;\n};\n",
-      component: React.lazy(() => import("#/registry/ui/skeleton.text.tsx")),
-      },
-    "radio.form-field": {
-      name: "radio.form-field",
-      category: "radio",
-      path: "#/registry/ui/radio.form-field.tsx",
-      code: "import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';\nimport { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';\nimport type { Control, Path } from 'react-hook-form';\n\nconst RadioField = <TFieldValues extends Record<string, string>>({\n  control,\n  name,\n  label,\n  description,\n  values,\n}: {\n  control: Control<TFieldValues>;\n  name: Path<TFieldValues>;\n  label: string;\n  description?: string;\n  values: string[];\n} & React.ComponentProps<typeof RadioGroup>) => {\n  return (\n    <FormField\n      control={control}\n      name={name}\n      render={({ field }) => (\n        <FormItem className='space-y-1.5'>\n          <FormLabel>{label}</FormLabel>\n          <FormControl>\n            <RadioGroup onValueChange={field.onChange} defaultValue={field.value} className='flex flex-col space-y-1'>\n              {values.map((value: any) => (\n                <FormItem key={value} className='flex items-center space-x-3 space-y-0'>\n                  <FormControl>\n                    <RadioGroupItem value={value} />\n                  </FormControl>\n                  <FormLabel className='font-normal'>{value}</FormLabel>\n                </FormItem>\n              ))}\n            </RadioGroup>\n          </FormControl>\n          {description && <FormDescription>{description}</FormDescription>}\n          <FormMessage className='sm:hidden text-xs text-left' />\n        </FormItem>\n      )}\n    />\n  );\n};\n\nexport default RadioField;\n",
-      component: React.lazy(() => import("#/registry/ui/radio.form-field.tsx")),
-      },
-    "div.title-section": {
-      name: "div.title-section",
-      category: "div",
-      path: "#/registry/ui/div.title-section.tsx",
-      code: "import type { JSX } from 'react';\n\nexport interface TitleSectionProps {\n  title: string;\n  description: string | JSX.Element;\n}\n\nexport default function TitleSection({ title, description }: TitleSectionProps) {\n  return (\n    <div className='text-center -space-y-2 my-6 max-md:text-sm'>\n      <h1 className='text-4xl md:text-5xl font-bold'>{title}</h1>\n      <p className='opacity-80 text-center'>{description}</p>\n    </div>\n  );\n}\n",
-      component: React.lazy(() => import("#/registry/ui/div.title-section.tsx")),
       },
     "button.signout": {
       name: "button.signout",
@@ -76,40 +27,61 @@ export const registryIndex: Record<string, RegistryComponent> = {
       code: "import { Button } from '@/components/ui/button';\nimport { LogOut } from 'lucide-react';\nimport { DialogConfirmation } from './dialog.confirmation';\n\nexport interface ButtonSignoutProps {\n  withLogo: boolean;\n  onConfirm: () => void;\n}\n\nexport default function ButtonSignout({ withLogo, onConfirm }: ButtonSignoutProps) {\n  return (\n    <DialogConfirmation\n      trigger={\n        <Button variant='outline' className='text-destructive' size={withLogo ? 'icon' : 'default'}>\n          {withLogo ? <LogOut /> : 'Sign out'}\n        </Button>\n      }\n      title='Sign out'\n      description='Are you sure you want to sign out?'\n      labelConfirmButton='Sign out'\n      onConfirm={() => onConfirm}\n    />\n  );\n}\n",
       component: React.lazy(() => import("#/registry/ui/button.signout.tsx")),
       },
+    "radio.form-field": {
+      name: "radio.form-field",
+      category: "radio",
+      path: "#/registry/ui/radio.form-field.tsx",
+      code: "import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';\nimport { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';\nimport type { Control, Path } from 'react-hook-form';\n\nconst RadioField = <TFieldValues extends Record<string, string>>({\n  control,\n  name,\n  label,\n  description,\n  values,\n}: {\n  control: Control<TFieldValues>;\n  name: Path<TFieldValues>;\n  label: string;\n  description?: string;\n  values: string[];\n} & React.ComponentProps<typeof RadioGroup>) => {\n  return (\n    <FormField\n      control={control}\n      name={name}\n      render={({ field }) => (\n        <FormItem className='space-y-1.5'>\n          <FormLabel>{label}</FormLabel>\n          <FormControl>\n            <RadioGroup onValueChange={field.onChange} defaultValue={field.value} className='flex flex-col space-y-1'>\n              {values.map((value: any) => (\n                <FormItem key={value} className='flex items-center space-x-3 space-y-0'>\n                  <FormControl>\n                    <RadioGroupItem value={value} />\n                  </FormControl>\n                  <FormLabel className='font-normal'>{value}</FormLabel>\n                </FormItem>\n              ))}\n            </RadioGroup>\n          </FormControl>\n          {description && <FormDescription>{description}</FormDescription>}\n          <FormMessage className='sm:hidden text-xs text-left' />\n        </FormItem>\n      )}\n    />\n  );\n};\n\nexport default RadioField;\n",
+      component: React.lazy(() => import("#/registry/ui/radio.form-field.tsx")),
+      },
+    "dialog.confirmation": {
+      name: "dialog.confirmation",
+      category: "dialog",
+      path: "#/registry/ui/dialog.confirmation.tsx",
+      code: "import { Button } from '@/components/ui/button';\nimport {\n  Dialog,\n  DialogContent,\n  DialogDescription,\n  DialogFooter,\n  DialogHeader,\n  DialogTitle,\n  DialogTrigger,\n} from '@/components/ui/dialog';\nimport type { JSX } from 'react';\n\nexport interface DialogConfirmationProps {\n  trigger: JSX.Element;\n  title: string;\n  description: string;\n  labelConfirmButton: string;\n  onConfirm: () => void;\n}\n\nexport function DialogConfirmation({\n  trigger,\n  title,\n  description,\n  labelConfirmButton,\n  onConfirm,\n}: DialogConfirmationProps) {\n  return (\n    <Dialog>\n      <DialogTrigger asChild>{trigger}</DialogTrigger>\n      <DialogContent>\n        <DialogHeader>\n          <DialogTitle>{title}</DialogTitle>\n          <DialogDescription className='md:text-left'>{description}</DialogDescription>\n        </DialogHeader>\n        <DialogFooter>\n          <Button onClick={onConfirm}>{labelConfirmButton}</Button>\n        </DialogFooter>\n      </DialogContent>\n    </Dialog>\n  );\n}\n",
+      component: React.lazy(() => import("#/registry/ui/dialog.confirmation.tsx")),
+      },
+    "select.form-field": {
+      name: "select.form-field",
+      category: "select",
+      path: "#/registry/ui/select.form-field.tsx",
+      code: "import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';\nimport { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';\nimport type { Control, Path, PathValue } from 'react-hook-form';\n\nexport interface SelectOption {\n  value: string;\n  label: string;\n}\n\nexport interface SelectFieldProps<T extends Record<string, string>> {\n  control: Control<T>;\n  name: Path<T>;\n  values: SelectOption[];\n  defaultValues?: PathValue<T, Path<T>>;\n  label: string;\n  placeholder: string;\n  description?: string;\n}\n\nexport const SelectField = <TFieldValues extends Record<string, string>>({\n  control,\n  name,\n  values,\n  defaultValues,\n  label,\n  placeholder,\n  description,\n}: SelectFieldProps<TFieldValues>) => {\n  return (\n    <FormField\n      control={control}\n      name={name}\n      defaultValue={defaultValues}\n      render={({ field }) => (\n        <FormItem>\n          <FormLabel>{label}</FormLabel>\n          <Select onValueChange={field.onChange} defaultValue={field.value}>\n            <FormControl>\n              <SelectTrigger>\n                <SelectValue placeholder={placeholder} />\n              </SelectTrigger>\n            </FormControl>\n            <SelectContent>\n              {values.map((item) => (\n                <SelectItem key={item.value} value={item.value}>\n                  {item.label}\n                </SelectItem>\n              ))}\n            </SelectContent>\n          </Select>\n          {description && <FormDescription>{description}</FormDescription>}\n          <FormMessage />\n        </FormItem>\n      )}\n    />\n  );\n};\n",
+      component: React.lazy(() => import("#/registry/ui/select.form-field.tsx")),
+      },
+    "hover.item": {
+      name: "hover.item",
+      category: "hover",
+      path: "#/registry/ui/hover.item.tsx",
+      code: "import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';\nimport type React from 'react';\n\nexport interface HoverItemProps {\n  children: string | React.JSX.Element | React.ReactNode; // can be used as children\n  content: string | React.JSX.Element;\n}\n\nexport default function HoverItem({ children, content }: HoverItemProps) {\n  return (\n    <HoverCard>\n      <HoverCardTrigger className='cursor-pointer'>{children}</HoverCardTrigger>\n      <HoverCardContent className='text-sm w-full'>{content}</HoverCardContent>\n    </HoverCard>\n  );\n}\n",
+      component: React.lazy(() => import("#/registry/ui/hover.item.tsx")),
+      },
+    "button.theme": {
+      name: "button.theme",
+      category: "button",
+      path: "#/registry/ui/button.theme.tsx",
+      code: "import { Button } from '@/components/ui/button';\nimport { Laptop, Moon, Sun } from 'lucide-react';\nimport { useTheme } from 'next-themes';\nimport * as React from 'react';\n\nexport interface ButtonThemeProps {\n  withText?: boolean;\n}\n\nexport default function ButtonTheme({ withText }: ButtonThemeProps) {\n  const { theme, setTheme } = useTheme();\n  const [currentTheme, setCurrentTheme] = React.useState<'system' | 'light' | 'dark'>('system');\n\n  React.useEffect(() => {\n    setCurrentTheme(theme as 'system' | 'light' | 'dark');\n  }, [theme]);\n\n  const cycleTheme = () => {\n    const themes: ('system' | 'light' | 'dark')[] = ['system', 'light', 'dark'];\n    const currentIndex = themes.indexOf(currentTheme);\n    const nextIndex = (currentIndex + 1) % themes.length;\n    setTheme(themes[nextIndex]);\n  };\n\n  return (\n    <Button variant='outline' size={withText ? 'default' : 'icon'} onClick={cycleTheme}>\n      {currentTheme === 'system' && <Laptop className='h-[1.2rem] w-[1.2rem]' />}\n      {currentTheme === 'light' && <Sun className='h-[1.2rem] w-[1.2rem]' />}\n      {currentTheme === 'dark' && <Moon className='h-[1.2rem] w-[1.2rem]' />}\n      {withText && (\n        <span className='ml-2 capitalize'>{currentTheme.charAt(0).toUpperCase() + currentTheme.slice(1)}</span>\n      )}\n      <span className='sr-only'>Toggle theme</span>\n    </Button>\n  );\n}\n",
+      component: React.lazy(() => import("#/registry/ui/button.theme.tsx")),
+      },
+    "skeleton.text": {
+      name: "skeleton.text",
+      category: "skeleton",
+      path: "#/registry/ui/skeleton.text.tsx",
+      code: "import { Skeleton } from '@/components/ui/skeleton';\n\nexport interface SkeletonTextProps {\n  text: string | undefined;\n}\n\nexport const SkeletonText = ({ text }: SkeletonTextProps) => {\n  if (!text) return <Skeleton className='w-20 h-4' />;\n  return text;\n};\n",
+      component: React.lazy(() => import("#/registry/ui/skeleton.text.tsx")),
+      },
+    "div.title-section": {
+      name: "div.title-section",
+      category: "div",
+      path: "#/registry/ui/div.title-section.tsx",
+      code: "import type { JSX } from 'react';\n\nexport interface TitleSectionProps {\n  title: string;\n  description: string | JSX.Element;\n}\n\nexport default function TitleSection({ title, description }: TitleSectionProps) {\n  return (\n    <div className='text-center -space-y-2 my-6 max-md:text-sm'>\n      <h1 className='text-4xl md:text-5xl font-bold'>{title}</h1>\n      <p className='opacity-80 text-center'>{description}</p>\n    </div>\n  );\n}\n",
+      component: React.lazy(() => import("#/registry/ui/div.title-section.tsx")),
+      },
     "input.form-field": {
       name: "input.form-field",
       category: "input",
       path: "#/registry/ui/input.form-field.tsx",
-      code: "import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';\nimport { Input } from '@/components/ui/input';\nimport type { Control, Path } from 'react-hook-form';\n\nexport interface InputFieldProps<TFieldValues extends Record<string, string>> {\n  control: Control<TFieldValues>;\n  name: Path<TFieldValues>;\n  label: string;\n  description?: string;\n}\n\nconst InputField = <TFieldValues extends Record<string, string>>({\n  control,\n  name,\n  label,\n  description,\n  ...props\n}: InputFieldProps<TFieldValues> & React.ComponentProps<typeof Input>) => {\n  return (\n    <FormField\n      control={control}\n      name={name}\n      render={({ field }) => {\n        if (!field) {\n          console.error('Field is missing for InputField', name);\n          return <></>;\n        }\n\n        return (\n          <FormItem className='space-y-1.5'>\n            <FormLabel className='flex items-center justify-between'>\n              {label}\n              <FormMessage className='max-sm:hidden text-sm' />\n            </FormLabel>\n            <FormControl>\n              <Input {...field} {...props} />\n            </FormControl>\n            {description && <FormDescription>{description}</FormDescription>}\n            <FormMessage className='sm:hidden text-xs text-left' />\n          </FormItem>\n        );\n      }}\n    />\n  );\n};\n\nexport default InputField;\n",
+      code: "'use client';\n\nimport type React from 'react';\n\nimport { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';\nimport { Input } from '@/components/ui/input';\nimport type { Control, Path } from 'react-hook-form';\nimport { Button } from '@/components/ui/button';\nimport { useState } from 'react';\nimport { Eye, EyeOff } from 'lucide-react';\n\ntype InputFieldProps<T extends Record<string, any>> = {\n  control: Control<T>;\n  name: Path<T>;\n  label: string;\n  description?: string;\n  isNumber?: boolean;\n} & React.ComponentProps<typeof Input>;\n\nconst InputField = <TFieldValues extends Record<string, any>>({\n  control,\n  name,\n  label,\n  description,\n  isNumber = false,\n  ...props\n}: InputFieldProps<TFieldValues>) => {\n  const [showPassword, setShowPassword] = useState(false);\n\n  const getInputType = () => {\n    if (isNumber) return 'number';\n    if (props.type === 'password') {\n      return showPassword ? 'text' : 'password';\n    }\n    return props.type ?? 'text';\n  };\n\n  return (\n    <FormField\n      control={control}\n      name={name}\n      render={({ field }) => {\n        return (\n          <FormItem className='space-y-1.5'>\n            <FormLabel className='flex items-center justify-between'>\n              {label}\n              <FormMessage className='max-sm:hidden text-sm' />\n            </FormLabel>\n            <FormControl>\n              <div className='relative'>\n                <Input\n                  {...field}\n                  {...props}\n                  type={getInputType()}\n                  onChange={(e) => {\n                    const value = e.target.value;\n                    if (isNumber) return field.onChange(value === '' ? '' : Number(value));\n                    return field.onChange(value);\n                  }}\n                />\n                {props.type === 'password' && (\n                  <Button\n                    type='button'\n                    variant='ghost'\n                    size='sm'\n                    className='absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent'\n                    onClick={() => setShowPassword((prev) => !prev)}\n                    tabIndex={-1}\n                    aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}\n                  >\n                    {showPassword ? (\n                      <EyeOff className='h-4 w-4' aria-hidden='true' />\n                    ) : (\n                      <Eye className='h-4 w-4' aria-hidden='true' />\n                    )}\n                    <span className='sr-only'>\n                      {showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}\n                    </span>\n                  </Button>\n                )}\n              </div>\n            </FormControl>\n            {description && <p className='text-muted-foreground text-sm'>{description}</p>}\n            <FormMessage className='sm:hidden text-xs text-left' />\n          </FormItem>\n        );\n      }}\n    />\n  );\n};\n\nexport default InputField;\n",
       component: React.lazy(() => import("#/registry/ui/input.form-field.tsx")),
-      },
-    "dialog.confirmation.example": {
-      name: "dialog.confirmation.example",
-      category: "dialog",
-      path: "#/registry/examples/dialog.confirmation.tsx",
-      code: "import { Button } from '@/components/ui/button';\nimport { DialogConfirmation } from '@/components/ui/shuip/dialog.confirmation';\n\nexport default function DialogConfirmationExample() {\n  return (\n    <DialogConfirmation\n      trigger={<Button>Open confirmation dialog</Button>}\n      title='Confirmation Dialog'\n      description='Are you sure you want to make this action?'\n      labelConfirmButton='Make it'\n      onConfirm={() => alert('Confirmed')}\n    />\n  );\n}\n",
-      component: React.lazy(() => import("#/registry/examples/dialog.confirmation.tsx")),
-      },
-    "button.theme.example": {
-      name: "button.theme.example",
-      category: "button",
-      path: "#/registry/examples/button.theme.tsx",
-      code: "import ButtonTheme from '@/components/ui/shuip/button.theme';\n\nexport default function ButtonThemeExample() {\n  return <ButtonTheme />;\n}\n",
-      component: React.lazy(() => import("#/registry/examples/button.theme.tsx")),
-      },
-    "hover.item.example": {
-      name: "hover.item.example",
-      category: "hover",
-      path: "#/registry/examples/hover.item.tsx",
-      code: "import HoverItem from '@/components/ui/shuip/hover.item';\n\nexport default function HoverItemExample() {\n  return <HoverItem content={'Description'}>Hover me</HoverItem>;\n}\n",
-      component: React.lazy(() => import("#/registry/examples/hover.item.tsx")),
-      },
-    "select.form-field.example": {
-      name: "select.form-field.example",
-      category: "select",
-      path: "#/registry/examples/select.form-field.tsx",
-      code: "import { Form } from '@/components/ui/form';\nimport ButtonSubmit from '@/components/ui/shuip/button.submit';\nimport { SelectField } from '@/components/ui/shuip/select.form-field';\nimport { useZodForm } from 'shext';\nimport { z } from 'zod';\n\nconst zodSchema = z.object({\n  selection: z.enum(['1', '2', '3']),\n});\n\nexport default function SelectFieldExample() {\n  const { form, control, handleSubmit } = useZodForm(zodSchema);\n\n  async function onSubmit(values: z.infer<typeof zodSchema>) {\n    try {\n      alert(`Selection: ${values.selection}`);\n    } catch (error) {\n      console.error(error);\n    }\n  }\n\n  return (\n    <Form {...form}>\n      <form onSubmit={handleSubmit(onSubmit)} className='space-y-4'>\n        <SelectField\n          control={control}\n          placeholder='Select an option'\n          name='selection'\n          label='selection'\n          values={[\n            { label: 'First', value: '1' },\n            { label: 'Second', value: '2' },\n            { label: 'Third', value: '3' },\n          ]}\n        />\n        <ButtonSubmit label='Check' />\n      </form>\n    </Form>\n  );\n}\n",
-      component: React.lazy(() => import("#/registry/examples/select.form-field.tsx")),
       },
     "button.submit.example": {
       name: "button.submit.example",
@@ -118,12 +90,12 @@ export const registryIndex: Record<string, RegistryComponent> = {
       code: "import ButtonSubmit from '@/components/ui/shuip/button.submit';\n\nexport default function ButtonSubmitExample() {\n  return <ButtonSubmit onClick={() => alert('Button clicked')} label='Submit' />;\n}\n",
       component: React.lazy(() => import("#/registry/examples/button.submit.tsx")),
       },
-    "skeleton.text.example": {
-      name: "skeleton.text.example",
-      category: "skeleton",
-      path: "#/registry/examples/skeleton.text.tsx",
-      code: "import { SkeletonText } from '@/components/ui/shuip/skeleton.text';\n\nexport default function SkeletonTextExample() {\n  return <SkeletonText text='Hello' />;\n}\n",
-      component: React.lazy(() => import("#/registry/examples/skeleton.text.tsx")),
+    "button.signout.example": {
+      name: "button.signout.example",
+      category: "button",
+      path: "#/registry/examples/button.signout.tsx",
+      code: "import ButtonSignout from '@/components/ui/shuip/button.signout';\n\nexport default function ButtonSignoutExample() {\n  return <ButtonSignout withLogo onConfirm={() => alert('Signout!')} />;\n}\n",
+      component: React.lazy(() => import("#/registry/examples/button.signout.tsx")),
       },
     "button.theme.text.example": {
       name: "button.theme.text.example",
@@ -139,19 +111,47 @@ export const registryIndex: Record<string, RegistryComponent> = {
       code: "import { Form } from '@/components/ui/form';\nimport ButtonSubmit from '@/components/ui/shuip/button.submit';\nimport RadioField from '@/components/ui/shuip/radio.form-field';\nimport { useZodForm } from 'shext';\nimport { z } from 'zod';\n\nconst zodSchema = z.object({\n  selection: z.enum(['1', '2', '3']),\n});\n\nexport default function RadioFieldExample() {\n  const { form, control, handleSubmit } = useZodForm(zodSchema);\n\n  async function onSubmit(values: z.infer<typeof zodSchema>) {\n    try {\n      alert(`Selection: ${values.selection}`);\n    } catch (error) {\n      console.error(error);\n    }\n  }\n\n  return (\n    <Form {...form}>\n      <form onSubmit={handleSubmit(onSubmit)} className='space-y-4'>\n        <RadioField control={control} name='selection' label='selection' values={['1', '2', '3']} />\n        <ButtonSubmit label='Check' />\n      </form>\n    </Form>\n  );\n}\n",
       component: React.lazy(() => import("#/registry/examples/radio.form-field.tsx")),
       },
+    "dialog.confirmation.example": {
+      name: "dialog.confirmation.example",
+      category: "dialog",
+      path: "#/registry/examples/dialog.confirmation.tsx",
+      code: "import { Button } from '@/components/ui/button';\nimport { DialogConfirmation } from '@/components/ui/shuip/dialog.confirmation';\n\nexport default function DialogConfirmationExample() {\n  return (\n    <DialogConfirmation\n      trigger={<Button>Open confirmation dialog</Button>}\n      title='Confirmation Dialog'\n      description='Are you sure you want to make this action?'\n      labelConfirmButton='Make it'\n      onConfirm={() => alert('Confirmed')}\n    />\n  );\n}\n",
+      component: React.lazy(() => import("#/registry/examples/dialog.confirmation.tsx")),
+      },
+    "select.form-field.example": {
+      name: "select.form-field.example",
+      category: "select",
+      path: "#/registry/examples/select.form-field.tsx",
+      code: "import { Form } from '@/components/ui/form';\nimport ButtonSubmit from '@/components/ui/shuip/button.submit';\nimport { SelectField } from '@/components/ui/shuip/select.form-field';\nimport { useZodForm } from 'shext';\nimport { z } from 'zod';\n\nconst zodSchema = z.object({\n  selection: z.enum(['1', '2', '3']),\n});\n\nexport default function SelectFieldExample() {\n  const { form, control, handleSubmit } = useZodForm(zodSchema);\n\n  async function onSubmit(values: z.infer<typeof zodSchema>) {\n    try {\n      alert(`Selection: ${values.selection}`);\n    } catch (error) {\n      console.error(error);\n    }\n  }\n\n  return (\n    <Form {...form}>\n      <form onSubmit={handleSubmit(onSubmit)} className='space-y-4'>\n        <SelectField\n          control={control}\n          placeholder='Select an option'\n          name='selection'\n          label='selection'\n          values={[\n            { label: 'First', value: '1' },\n            { label: 'Second', value: '2' },\n            { label: 'Third', value: '3' },\n          ]}\n        />\n        <ButtonSubmit label='Check' />\n      </form>\n    </Form>\n  );\n}\n",
+      component: React.lazy(() => import("#/registry/examples/select.form-field.tsx")),
+      },
+    "hover.item.example": {
+      name: "hover.item.example",
+      category: "hover",
+      path: "#/registry/examples/hover.item.tsx",
+      code: "import HoverItem from '@/components/ui/shuip/hover.item';\n\nexport default function HoverItemExample() {\n  return <HoverItem content={'Description'}>Hover me</HoverItem>;\n}\n",
+      component: React.lazy(() => import("#/registry/examples/hover.item.tsx")),
+      },
+    "button.theme.example": {
+      name: "button.theme.example",
+      category: "button",
+      path: "#/registry/examples/button.theme.tsx",
+      code: "import ButtonTheme from '@/components/ui/shuip/button.theme';\n\nexport default function ButtonThemeExample() {\n  return <ButtonTheme />;\n}\n",
+      component: React.lazy(() => import("#/registry/examples/button.theme.tsx")),
+      },
+    "skeleton.text.example": {
+      name: "skeleton.text.example",
+      category: "skeleton",
+      path: "#/registry/examples/skeleton.text.tsx",
+      code: "import { SkeletonText } from '@/components/ui/shuip/skeleton.text';\n\nexport default function SkeletonTextExample() {\n  return <SkeletonText text='Hello' />;\n}\n",
+      component: React.lazy(() => import("#/registry/examples/skeleton.text.tsx")),
+      },
     "div.title-section.example": {
       name: "div.title-section.example",
       category: "div",
       path: "#/registry/examples/div.title-section.tsx",
       code: "import TitleSection from '@/components/ui/shuip/div.title-section';\n\nexport default function TitleSectionExample() {\n  return <TitleSection title='Title' description='Lorem ipsum dolor sit amet consectetur, adipisicing elit.' />;\n}\n",
       component: React.lazy(() => import("#/registry/examples/div.title-section.tsx")),
-      },
-    "button.signout.example": {
-      name: "button.signout.example",
-      category: "button",
-      path: "#/registry/examples/button.signout.tsx",
-      code: "import ButtonSignout from '@/components/ui/shuip/button.signout';\n\nexport default function ButtonSignoutExample() {\n  return <ButtonSignout withLogo onConfirm={() => alert('Signout!')} />;\n}\n",
-      component: React.lazy(() => import("#/registry/examples/button.signout.tsx")),
       },
     "button.submit.loading.example": {
       name: "button.submit.loading.example",
@@ -172,27 +172,27 @@ export const registryIndex: Record<string, RegistryComponent> = {
    * TODO: Need to improve this structure
    */ 
   export const COMPONENT_CATEGORIES:Record<string, Record<string, string[]>> = {
-  "dialog": {
-    "dialog.confirmation": [
-      "dialog.confirmation"
-    ]
-  },
   "button": {
-    "button.theme": [
-      "button.theme",
-      "button.theme.text"
-    ],
     "button.submit": [
       "button.submit",
       "button.submit.loading"
     ],
     "button.signout": [
       "button.signout"
+    ],
+    "button.theme": [
+      "button.theme.text",
+      "button.theme"
     ]
   },
-  "hover": {
-    "hover.item": [
-      "hover.item"
+  "radio": {
+    "radio.form-field": [
+      "radio.form-field"
+    ]
+  },
+  "dialog": {
+    "dialog.confirmation": [
+      "dialog.confirmation"
     ]
   },
   "select": {
@@ -200,14 +200,14 @@ export const registryIndex: Record<string, RegistryComponent> = {
       "select.form-field"
     ]
   },
+  "hover": {
+    "hover.item": [
+      "hover.item"
+    ]
+  },
   "skeleton": {
     "skeleton.text": [
       "skeleton.text"
-    ]
-  },
-  "radio": {
-    "radio.form-field": [
-      "radio.form-field"
     ]
   },
   "div": {

--- a/registry/ui/input.form-field.tsx
+++ b/registry/ui/input.form-field.tsx
@@ -1,31 +1,45 @@
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+'use client';
+
+import type React from 'react';
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import type { Control, Path } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
 
-export interface InputFieldProps<TFieldValues extends Record<string, string>> {
-  control: Control<TFieldValues>;
-  name: Path<TFieldValues>;
+type InputFieldProps<T extends Record<string, any>> = {
+  control: Control<T>;
+  name: Path<T>;
   label: string;
   description?: string;
-}
+  isNumber?: boolean;
+} & React.ComponentProps<typeof Input>;
 
-const InputField = <TFieldValues extends Record<string, string>>({
+const InputField = <TFieldValues extends Record<string, any>>({
   control,
   name,
   label,
   description,
+  isNumber = false,
   ...props
-}: InputFieldProps<TFieldValues> & React.ComponentProps<typeof Input>) => {
+}: InputFieldProps<TFieldValues>) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const getInputType = () => {
+    if (isNumber) return 'number';
+    if (props.type === 'password') {
+      return showPassword ? 'text' : 'password';
+    }
+    return props.type ?? 'text';
+  };
+
   return (
     <FormField
       control={control}
       name={name}
       render={({ field }) => {
-        if (!field) {
-          console.error('Field is missing for InputField', name);
-          return <></>;
-        }
-
         return (
           <FormItem className='space-y-1.5'>
             <FormLabel className='flex items-center justify-between'>
@@ -33,9 +47,40 @@ const InputField = <TFieldValues extends Record<string, string>>({
               <FormMessage className='max-sm:hidden text-sm' />
             </FormLabel>
             <FormControl>
-              <Input {...field} {...props} />
+              <div className='relative'>
+                <Input
+                  {...field}
+                  {...props}
+                  type={getInputType()}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (isNumber) return field.onChange(value === '' ? '' : Number(value));
+                    return field.onChange(value);
+                  }}
+                />
+                {props.type === 'password' && (
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='sm'
+                    className='absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent'
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    tabIndex={-1}
+                    aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+                  >
+                    {showPassword ? (
+                      <EyeOff className='h-4 w-4' aria-hidden='true' />
+                    ) : (
+                      <Eye className='h-4 w-4' aria-hidden='true' />
+                    )}
+                    <span className='sr-only'>
+                      {showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+                    </span>
+                  </Button>
+                )}
+              </div>
             </FormControl>
-            {description && <FormDescription>{description}</FormDescription>}
+            {description && <p className='text-muted-foreground text-sm'>{description}</p>}
             <FormMessage className='sm:hidden text-xs text-left' />
           </FormItem>
         );

--- a/src/components/ui/shuip/input.form-field.tsx
+++ b/src/components/ui/shuip/input.form-field.tsx
@@ -1,8 +1,13 @@
-'use client';
-
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import type { Control, Path } from 'react-hook-form';
+
+export interface InputFieldProps<TFieldValues extends Record<string, string>> {
+  control: Control<TFieldValues>;
+  name: Path<TFieldValues>;
+  label: string;
+  description?: string;
+}
 
 const InputField = <TFieldValues extends Record<string, string>>({
   control,
@@ -10,12 +15,7 @@ const InputField = <TFieldValues extends Record<string, string>>({
   label,
   description,
   ...props
-}: {
-  control: Control<TFieldValues>;
-  name: Path<TFieldValues>;
-  label: string;
-  description?: string;
-} & React.ComponentProps<typeof Input>) => {
+}: InputFieldProps<TFieldValues> & React.ComponentProps<typeof Input>) => {
   return (
     <FormField
       control={control}


### PR DESCRIPTION
- Introduced ButtonSubmit and ButtonSignout components with their respective examples.
- Added RadioField component and example for form handling.
- Updated InputField to support password visibility toggle and number input handling.
- Removed deprecated button.theme component and added button.theme.text example.
- Enhanced registryIndex with new components and examples for better organization.