### PR TITLE
feat(registry): add rhf-phone-field

### DIFF
--- a/apps/docs/content/docs/react-hook-form/.gitignore
+++ b/apps/docs/content/docs/react-hook-form/.gitignore
@@ -3,6 +3,7 @@ address-field.mdx
 checkbox-field.mdx
 input-field.mdx
 password-field.mdx
+phone-field.mdx
 query-boundary.mdx
 radio-field.mdx
 select-field.mdx

--- a/packages/registry/items/react-hook-form/phone-field/component.tsx
+++ b/packages/registry/items/react-hook-form/phone-field/component.tsx
@@ -1,0 +1,50 @@
+import type * as React from 'react';
+import type { FieldPath, FieldValues, UseFormRegisterReturn } from 'react-hook-form';
+import { z } from 'zod';
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+
+export const E164_REGEX = /^\+[1-9]\d{1,14}$/;
+
+export const phoneSchema = z.string().regex(E164_REGEX, 'Phone number must be in E.164 format (e.g. +33612345678)');
+
+export interface PhoneFieldProps<T extends FieldValues> extends React.ComponentProps<typeof Input> {
+  register: UseFormRegisterReturn<FieldPath<T>>;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+}
+
+export function PhoneField<T extends FieldValues>({
+  register,
+  label,
+  description,
+  placeholder = '+33612345678',
+  ...props
+}: PhoneFieldProps<T>) {
+  return (
+    <FormField
+      {...register}
+      render={({ field, fieldState }) => {
+        return (
+          <FormItem data-invalid={fieldState.invalid}>
+            {label && <FormLabel>{label}</FormLabel>}
+            <FormControl>
+              <Input
+                {...field}
+                type='tel'
+                inputMode='tel'
+                autoComplete='tel'
+                placeholder={placeholder}
+                aria-invalid={fieldState.invalid}
+                {...props}
+              />
+            </FormControl>
+            <FormMessage className='text-xs text-left' />
+            {description && <FormDescription className='text-xs'>{description}</FormDescription>}
+          </FormItem>
+        );
+      }}
+    />
+  );
+}

--- a/packages/registry/items/react-hook-form/phone-field/default.example.tsx
+++ b/packages/registry/items/react-hook-form/phone-field/default.example.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { PhoneField } from '@/components/ui/shuip/react-hook-form/phone-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const zodSchema = z.object({
+  phone: z.string().regex(/^\+[1-9]\d{1,14}$/, 'Phone number must be in E.164 format (e.g. +33612345678)'),
+});
+
+export default function PhoneFieldExample() {
+  const form = useForm({
+    defaultValues: { phone: '' },
+    resolver: zodResolver(zodSchema),
+  });
+
+  async function onSubmit(values: z.infer<typeof zodSchema>) {
+    try {
+      alert(`Phone: ${values.phone}`);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <PhoneField
+          register={form.register('phone')}
+          label='Phone'
+          description='Use international E.164 format'
+          placeholder='+33612345678'
+        />
+        <SubmitButton>Check</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/phone-field/index.mdx
+++ b/packages/registry/items/react-hook-form/phone-field/index.mdx
@@ -1,0 +1,60 @@
+---
+title: Phone Field
+description: Controlled phone-number input integrated with React Hook Form. Validates against the E.164 international format.
+registryName: rhf-phone-field
+---
+
+`PhoneField` is a controlled phone-number input that connects React Hook Form to the shadcn `Input` primitive. It uses the `tel` input type and `inputMode` so mobile devices surface the numeric keypad, and it ships with a reusable `phoneSchema`/`E164_REGEX` you can drop straight into a Zod schema.
+
+The field validates against the [E.164](https://en.wikipedia.org/wiki/E.164) format: a leading `+`, a country code starting with a non-zero digit, and up to 14 additional digits (e.g. `+33612345678`).
+
+#### Built-in features
+
+- **Type-safe registration**: Uses `register` from React Hook Form
+- **E.164 validation**: Exports `phoneSchema` and `E164_REGEX` for opt-in Zod schemas
+- **Mobile-friendly**: `type='tel'`, `inputMode='tel'`, `autoComplete='tel'`
+- **Zero boilerplate**: `label`, `description`, and `placeholder` as direct props
+
+## Using the exported schema
+
+```tsx
+import { phoneSchema } from '@/components/ui/shuip/react-hook-form/phone-field';
+
+const schema = z.object({
+  phone: phoneSchema,
+});
+```
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'rhf-phone-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    register: {
+      description: 'React Hook Form register function result',
+      type: 'UseFormRegisterReturn',
+    },
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the input',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Placeholder shown when the input is empty',
+      type: 'string?',
+      default: '+33612345678',
+    },
+    props: {
+      description: 'Native HTML input props (disabled, readOnly, etc.)',
+      type: 'React.ComponentProps<typeof Input>?',
+    },
+  }}
+/>

--- a/packages/registry/items/react-hook-form/phone-field/validation.example.tsx
+++ b/packages/registry/items/react-hook-form/phone-field/validation.example.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { PhoneField } from '@/components/ui/shuip/react-hook-form/phone-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const E164 = /^\+[1-9]\d{1,14}$/;
+
+const zodSchema = z.object({
+  primary: z.string().regex(E164, 'Primary phone must be in E.164 format'),
+  secondary: z.string().regex(E164, 'Secondary phone must be in E.164 format').optional().or(z.literal('')),
+});
+
+export default function PhoneFieldValidationExample() {
+  const form = useForm({
+    defaultValues: { primary: '', secondary: '' },
+    resolver: zodResolver(zodSchema),
+  });
+
+  async function onSubmit(values: z.infer<typeof zodSchema>) {
+    try {
+      alert(`Primary: ${values.primary}\nSecondary: ${values.secondary || '(none)'}`);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <PhoneField
+          register={form.register('primary')}
+          label='Primary phone'
+          description='Required. Include the country code prefix.'
+          placeholder='+12025550123'
+        />
+        <PhoneField
+          register={form.register('secondary')}
+          label='Secondary phone'
+          description='Optional alternate number.'
+          placeholder='+442071838750'
+        />
+        <SubmitButton>Save</SubmitButton>
+      </form>
+    </Form>
+  );
+}


### PR DESCRIPTION
## Summary

- New `rhf-phone-field` registry item: a controlled phone-number input integrated with react-hook-form. Wraps the shadcn `Input` primitive with `type='tel'`, `inputMode='tel'`, and `autoComplete='tel'` for mobile-friendly keypad behavior.
- Exports `phoneSchema` and `E164_REGEX` so consumers can drop validation straight into a Zod schema (mirrors the precedent set by `address-field` exporting `addressSchema` / `AddressData`).
- Two previews shipped: `default.example.tsx` (single phone with a basic zod schema) and `validation.example.tsx` (required primary + optional secondary).

Validates against the [E.164](https://en.wikipedia.org/wiki/E.164) format: a leading `+`, a country code starting with a non-zero digit, and up to 14 additional digits (e.g. `+33612345678`).

This item was produced as the REFACTOR-phase artifact of the companion skill PR (#37), where a fresh subagent followed the `creating-registry-item` skill end-to-end.

## Test plan

- [ ] `bun build:docs` succeeds, generator output reports `[generate] N items processed` with N incremented
- [ ] `/docs/react-hook-form/phone-field` renders the props table and both previews
- [ ] After merge, `npx shadcn@latest add "https://shuip.plvo.dev/r/rhf-phone-field"` installs the component, the `form` and `input` primitives, and the `react-hook-form` / `zod` deps
- [ ] Entering a non-E.164 string in the default preview displays the validation error message
- [ ] `phoneSchema` and `E164_REGEX` are importable from the installed module