### PR TITLE
feat(registry): add tsf-form-context item

### DIFF
--- a/apps/docs/content/docs/tanstack-form/.gitignore
+++ b/apps/docs/content/docs/tanstack-form/.gitignore
@@ -1,5 +1,6 @@
 # Auto-generated symlinks — do not commit (created by packages/registry/scripts/generate.ts)
 checkbox-field.mdx
+form-context.mdx
 input-field.mdx
 password-field.mdx
 radio-field.mdx

--- a/packages/registry/items/tanstack-form/form-context/component.tsx
+++ b/packages/registry/items/tanstack-form/form-context/component.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import { createFormHookContexts } from '@tanstack/react-form';
+
+export const { fieldContext, formContext, useFieldContext, useFormContext } = createFormHookContexts();

--- a/packages/registry/items/tanstack-form/form-context/default.example.tsx
+++ b/packages/registry/items/tanstack-form/form-context/default.example.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import {
+  fieldContext,
+  formContext,
+  useFieldContext,
+  useFormContext,
+} from '@/components/ui/shuip/tanstack-form/form-context';
+
+function TextField({ label }: { label: string }) {
+  const field = useFieldContext<string>();
+  const { isValid, errors } = field.state.meta;
+  return (
+    <Field data-invalid={!isValid}>
+      <FieldLabel htmlFor={field.name}>{label}</FieldLabel>
+      <Input
+        id={field.name}
+        name={field.name}
+        value={field.state.value}
+        onChange={(e) => field.handleChange(e.target.value)}
+        onBlur={field.handleBlur}
+        aria-invalid={!isValid}
+      />
+      {!isValid && <FieldError errors={errors.map((message) => ({ message }))} />}
+    </Field>
+  );
+}
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const form = useFormContext();
+  return (
+    <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+      {([canSubmit, isSubmitting]) => (
+        <Button type='submit' disabled={!canSubmit}>
+          {isSubmitting ? 'Submitting…' : children}
+        </Button>
+      )}
+    </form.Subscribe>
+  );
+}
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { TextField },
+  formComponents: { SubmitButton },
+});
+
+const schema = z.object({
+  username: z.string().min(3, 'Username must be at least 3 characters'),
+});
+
+export default function FormContextExample() {
+  const form = useAppForm({
+    defaultValues: { username: '' },
+    validators: { onChange: schema },
+    onSubmit: async ({ value }) => {
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='flex flex-col gap-3'
+    >
+      <form.AppField name='username' children={(field) => <field.TextField label='Username' />} />
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/form-context/index.mdx
+++ b/packages/registry/items/tanstack-form/form-context/index.mdx
@@ -1,0 +1,127 @@
+---
+title: Form Context
+description: Foundation contexts and consumer hooks for building type-safe TanStack Form components via createFormHook.
+registryName: tsf-form-context
+---
+
+`form-context` exports the React contexts and consumer hooks produced by TanStack Form's `createFormHookContexts()`. It is the foundation for the context-bound composition pattern: reusable field and form components read their state from React context instead of receiving the `form` instance as a prop.
+
+This sidesteps the variance problem that arises when `ReactFormApi`'s eleven validator generics need to cross a component boundary — the same problem that forces `form={form as any}` casts in the prop-drilling pattern.
+
+## What you install
+
+```tsx
+// components/ui/shuip/tanstack-form/form-context.tsx
+'use client';
+
+import { createFormHookContexts } from '@tanstack/react-form';
+
+export const { fieldContext, formContext, useFieldContext, useFormContext } = createFormHookContexts();
+```
+
+Four exports:
+
+- **`fieldContext`**, **`formContext`** — pass these to `createFormHook` in your project setup.
+- **`useFieldContext<T>()`** — call inside a field component to read `field` (state, errors, handlers). The generic asserts the field value type.
+- **`useFormContext()`** — call inside a form-level component (submit buttons, layout chrome) to read the form instance.
+
+## Project setup
+
+Create a `lib/form.ts` in your project that calls `createFormHook` once, binding every field and form component you want available globally.
+
+```tsx
+// lib/form.ts
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+
+import { TextField } from '@/components/ui/my-text-field';
+import { SubmitButton } from '@/components/ui/my-submit-button';
+
+export const { useAppForm, withForm, withFieldGroup } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { TextField },
+  formComponents: { SubmitButton },
+});
+```
+
+Consumer usage:
+
+```tsx
+import { useAppForm } from '@/lib/form';
+import { z } from 'zod';
+
+const schema = z.object({ username: z.string().min(3) });
+
+function MyForm() {
+  const form = useAppForm({
+    defaultValues: { username: '' },
+    validators: { onChange: schema },
+    onSubmit: ({ value }) => console.log(value),
+  });
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); form.handleSubmit(); }}>
+      <form.AppField name='username' children={(field) => <field.TextField label='Username' />} />
+      <form.AppForm><form.SubmitButton>Submit</form.SubmitButton></form.AppForm>
+    </form>
+  );
+}
+```
+
+The `name` is autocompleted from `defaultValues`. Validators accept any standard schema (Zod, Valibot, ArkType) or a plain function.
+
+## Building a field component
+
+A field component consumes the field via `useFieldContext`. It never receives `form` or `name` as a prop — both come from the surrounding `<form.AppField>`.
+
+```tsx
+'use client';
+
+import { useFieldContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { Input } from '@/components/ui/input';
+
+export function TextField({ label }: { label: string }) {
+  const field = useFieldContext<string>();
+  return (
+    <label>
+      {label}
+      <Input
+        value={field.state.value}
+        onChange={(e) => field.handleChange(e.target.value)}
+        onBlur={field.handleBlur}
+        aria-invalid={!field.state.meta.isValid}
+      />
+    </label>
+  );
+}
+```
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Example
+
+<ItemExamples registryName='tsf-form-context' />
+
+## Exports
+
+<TypeTable
+  type={{
+    fieldContext: {
+      description: 'React context used by TanStack to thread the field API to children of form.AppField.',
+      type: 'Context<unknown>',
+    },
+    formContext: {
+      description: 'React context used by TanStack to thread the form API to children of form.AppForm.',
+      type: 'Context<unknown>',
+    },
+    useFieldContext: {
+      description: 'Read the current field inside a custom field component. The generic asserts the field value type.',
+      type: '<T>() => FieldApi<T, ...>',
+    },
+    useFormContext: {
+      description: 'Read the current form inside a custom form-level component (submit buttons, layout chrome).',
+      type: '() => FormApi<...>',
+    },
+  }}
+/>


### PR DESCRIPTION
## Summary

Adds a new shuip registry item, `tsf-form-context`, that exports the React contexts and consumer hooks produced by TanStack Form's `createFormHookContexts()`.

It is the foundation for the context-bound composition pattern: reusable field components read state through React context (`useFieldContext`) instead of receiving the `form` instance as a prop. This sidesteps the variance problem of `ReactFormApi`'s eleven validator generics, which is what forces `form={form as any}` casts in consumer code as soon as a `useForm` call carries a Zod schema or any non-`undefined` validator.

## What this PR does

- New item at `packages/registry/items/tanstack-form/form-context/` (component, default example, MDX doc).
- No existing item is touched — pure addition.

## What this PR does NOT do (yet)

This is the **base** of a stacked PR. A follow-up PR will migrate the existing `tsf-*` field components (`input-field`, `checkbox-field`, `textarea-field`, `password-field`, `radio-field`, `select-field`, `submit-button`) to consume `useFieldContext` / `useFormContext` from this new item, removing their `form` prop entirely. That migration is a breaking change and will be a separate review.

## Test plan

- [x] `bun registry:generate` reports `24 items processed` (was 23 on main).
- [x] `bun build:docs` completes; the `/docs/tanstack-form/form-context` route is built.
- [x] `bun check` (biome) clean.
- [ ] Manual check on the rendered docs page: visit `/docs/tanstack-form/form-context` in `bun dev:docs` and confirm the example renders + form submission works.