### PR TITLE
refactor(rhf-fields)!: migrate to shadcn Field primitive, split InputField/NumberField

### DIFF
--- a/apps/docs/content/docs/react-hook-form/.gitignore
+++ b/apps/docs/content/docs/react-hook-form/.gitignore
@@ -2,6 +2,7 @@
 address-field.mdx
 checkbox-field.mdx
 input-field.mdx
+number-field.mdx
 password-field.mdx
 radio-field.mdx
 select-field.mdx

--- a/packages/registry/items/react-hook-form/address-field/component.tsx
+++ b/packages/registry/items/react-hook-form/address-field/component.tsx
@@ -208,6 +208,8 @@ export function AddressField({
       return;
     }
 
+    fullAddress.field.onBlur();
+
     setTimeout(() => {
       setShowSuggestions(false);
       setSelectedIndex(-1);
@@ -215,10 +217,11 @@ export function AddressField({
   };
 
   const fullAddressInvalid = fullAddress.fieldState.invalid;
+  const id = props.id ?? fullAddress.field.name;
 
   return (
     <Field className='gap-2' data-invalid={fullAddressInvalid}>
-      <FieldLabel htmlFor={fullAddress.field.name} className='flex items-center justify-between'>
+      <FieldLabel htmlFor={id} className='flex items-center justify-between'>
         {label}
         {fullAddressInvalid && (
           <FieldError className='max-sm:hidden text-xs opacity-80' errors={[fullAddress.fieldState.error]} />
@@ -230,10 +233,12 @@ export function AddressField({
             <div className='relative'>
               <Input
                 ref={inputRef}
-                id={fullAddress.field.name}
                 name={fullAddress.field.name}
                 value={fullAddress.field.value ?? ''}
                 placeholder={placeholder}
+                autoComplete='off'
+                {...props}
+                id={id}
                 onChange={(e) => {
                   const value = e.target.value;
                   fullAddress.field.onChange(value);
@@ -242,9 +247,7 @@ export function AddressField({
                 onFocus={handleFocus}
                 onBlur={handleBlur}
                 onKeyDown={handleKeyDown}
-                autoComplete='off'
                 aria-invalid={fullAddressInvalid}
-                {...props}
               />
               <div className='absolute inset-y-0 right-0 flex items-center pr-3'>
                 {isPending ? (

--- a/packages/registry/items/react-hook-form/address-field/component.tsx
+++ b/packages/registry/items/react-hook-form/address-field/component.tsx
@@ -7,7 +7,7 @@ import { useController } from 'react-hook-form';
 import { z } from 'zod';
 import { getPlaceDetails, getPlacesAutocomplete } from '@/actions/shuip/places';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Field, FieldError, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
@@ -214,84 +214,85 @@ export function AddressField({
     }, 150);
   };
 
+  const fullAddressInvalid = fullAddress.fieldState.invalid;
+
   return (
-    <FormField
-      {...lens.focus('fullAddress').interop()}
-      render={({ field, fieldState }) => (
-        <FormItem data-invalid={fieldState.invalid}>
-          <FormLabel className='flex items-center justify-between'>
-            {label}
-            <FormMessage className='max-sm:hidden text-xs opacity-80' />
-          </FormLabel>
-          <div className='relative'>
-            <Popover open={showSuggestions} onOpenChange={setShowSuggestions}>
-              <PopoverTrigger asChild>
-                <FormControl>
-                  <div className='relative'>
-                    <Input
-                      ref={inputRef}
-                      value={field.value ?? ''}
-                      placeholder={placeholder}
-                      onChange={(e) => {
-                        const value = e.target.value;
-                        field.onChange(value);
-                        setSearchQuery(value);
-                      }}
-                      onFocus={handleFocus}
-                      onBlur={handleBlur}
-                      onKeyDown={handleKeyDown}
-                      autoComplete='off'
-                      aria-invalid={fieldState.invalid}
-                      {...props}
-                    />
-                    <div className='absolute inset-y-0 right-0 flex items-center pr-3'>
-                      {isPending ? (
-                        <Loader2 className='size-4 animate-spin text-muted-foreground' />
-                      ) : (
-                        <MapPin className='size-4 text-muted-foreground' />
+    <Field className='gap-2' data-invalid={fullAddressInvalid}>
+      <FieldLabel htmlFor={fullAddress.field.name} className='flex items-center justify-between'>
+        {label}
+        {fullAddressInvalid && (
+          <FieldError className='max-sm:hidden text-xs opacity-80' errors={[fullAddress.fieldState.error]} />
+        )}
+      </FieldLabel>
+      <div className='relative'>
+        <Popover open={showSuggestions} onOpenChange={setShowSuggestions}>
+          <PopoverTrigger asChild>
+            <div className='relative'>
+              <Input
+                ref={inputRef}
+                id={fullAddress.field.name}
+                name={fullAddress.field.name}
+                value={fullAddress.field.value ?? ''}
+                placeholder={placeholder}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  fullAddress.field.onChange(value);
+                  setSearchQuery(value);
+                }}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+                autoComplete='off'
+                aria-invalid={fullAddressInvalid}
+                {...props}
+              />
+              <div className='absolute inset-y-0 right-0 flex items-center pr-3'>
+                {isPending ? (
+                  <Loader2 className='size-4 animate-spin text-muted-foreground' />
+                ) : (
+                  <MapPin className='size-4 text-muted-foreground' />
+                )}
+              </div>
+            </div>
+          </PopoverTrigger>
+          <PopoverContent
+            ref={popoverRef}
+            className='p-0'
+            align='start'
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            style={{ width: 'var(--radix-popover-trigger-width)' }}
+          >
+            <Command className='w-full'>
+              <CommandList className='max-h-60'>
+                <CommandEmpty>{isPending ? 'Searching...' : 'No addresses found'}</CommandEmpty>
+                <CommandGroup>
+                  {suggestions.map((suggestion, index) => (
+                    <CommandItem
+                      key={suggestion.placeId}
+                      value={suggestion.description}
+                      onSelect={() => handleSelectAddress(suggestion)}
+                      className={cn(
+                        'flex items-start space-x-2 p-3 cursor-pointer',
+                        selectedIndex === index && 'bg-accent',
                       )}
-                    </div>
-                  </div>
-                </FormControl>
-              </PopoverTrigger>
-              <PopoverContent
-                ref={popoverRef}
-                className='p-0'
-                align='start'
-                onOpenAutoFocus={(e) => e.preventDefault()}
-                style={{ width: 'var(--radix-popover-trigger-width)' }}
-              >
-                <Command className='w-full'>
-                  <CommandList className='max-h-60'>
-                    <CommandEmpty>{isPending ? 'Searching...' : 'No addresses found'}</CommandEmpty>
-                    <CommandGroup>
-                      {suggestions.map((suggestion, index) => (
-                        <CommandItem
-                          key={suggestion.placeId}
-                          value={suggestion.description}
-                          onSelect={() => handleSelectAddress(suggestion)}
-                          className={cn(
-                            'flex items-start space-x-2 p-3 cursor-pointer',
-                            selectedIndex === index && 'bg-accent',
-                          )}
-                        >
-                          <MapPin className='size-4 mt-0.5 text-muted-foreground flex-shrink-0' />
-                          <div className='flex-1 min-w-0'>
-                            <div className='font-medium text-sm'>{suggestion.mainText}</div>
-                            <div className='text-xs text-muted-foreground truncate'>{suggestion.secondaryText}</div>
-                          </div>
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
-          </div>
-          {description && <p className='text-sm text-muted-foreground'>{description}</p>}
-          <FormMessage className='sm:hidden text-xs text-left opacity-80' />
-        </FormItem>
+                    >
+                      <MapPin className='size-4 mt-0.5 text-muted-foreground flex-shrink-0' />
+                      <div className='flex-1 min-w-0'>
+                        <div className='font-medium text-sm'>{suggestion.mainText}</div>
+                        <div className='text-xs text-muted-foreground truncate'>{suggestion.secondaryText}</div>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
+      {description && <p className='text-sm text-muted-foreground'>{description}</p>}
+      {fullAddressInvalid && (
+        <FieldError className='sm:hidden text-xs text-left opacity-80' errors={[fullAddress.fieldState.error]} />
       )}
-    />
+    </Field>
   );
 }

--- a/packages/registry/items/react-hook-form/checkbox-field/component.tsx
+++ b/packages/registry/items/react-hook-form/checkbox-field/component.tsx
@@ -1,7 +1,8 @@
 import type { Lens } from '@hookform/lenses';
 import type * as React from 'react';
+import { useController } from 'react-hook-form';
 import { Checkbox } from '@/components/ui/checkbox';
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
 
 export interface CheckboxFieldProps extends Omit<React.ComponentProps<typeof Checkbox>, 'checked' | 'onCheckedChange'> {
   lens: Lens<boolean>;
@@ -10,27 +11,26 @@ export interface CheckboxFieldProps extends Omit<React.ComponentProps<typeof Che
 }
 
 export function CheckboxField({ lens, label, description, ...props }: CheckboxFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
+
   return (
-    <FormField
-      {...lens.interop()}
-      render={({ field, fieldState }) => (
-        <FormItem data-invalid={fieldState.invalid}>
-          <FormControl>
-            <div className='flex items-center gap-2'>
-              <Checkbox
-                id={field.name}
-                checked={field.value}
-                onCheckedChange={field.onChange}
-                aria-invalid={fieldState.invalid}
-                {...props}
-              />
-              <FormLabel htmlFor={field.name}>{label}</FormLabel>
-            </div>
-          </FormControl>
-          <FormMessage className='text-xs text-left' />
-          {description && <FormDescription className='text-xs'>{description}</FormDescription>}
-        </FormItem>
-      )}
-    />
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      <div className='flex items-center gap-2'>
+        <Checkbox
+          id={field.name}
+          name={field.name}
+          checked={field.value}
+          onCheckedChange={(checked) => field.onChange(checked === true)}
+          onBlur={field.onBlur}
+          aria-invalid={fieldState.invalid}
+          {...props}
+        />
+        <FieldLabel htmlFor={field.name} className='text-sm cursor-pointer'>
+          {label}
+        </FieldLabel>
+      </div>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
   );
 }

--- a/packages/registry/items/react-hook-form/checkbox-field/component.tsx
+++ b/packages/registry/items/react-hook-form/checkbox-field/component.tsx
@@ -14,20 +14,21 @@ export interface CheckboxFieldProps extends Omit<React.ComponentProps<typeof Che
 
 export function CheckboxField({ lens, label, description, ...props }: CheckboxFieldProps) {
   const { field, fieldState } = useController(lens.interop());
+  const id = props.id ?? field.name;
 
   return (
     <Field className='gap-2' data-invalid={fieldState.invalid}>
       <div className='flex items-center gap-2'>
         <Checkbox
-          id={field.name}
+          {...props}
+          id={id}
           name={field.name}
-          checked={field.value}
+          checked={field.value ?? false}
           onCheckedChange={(checked) => field.onChange(checked === true)}
           onBlur={field.onBlur}
           aria-invalid={fieldState.invalid}
-          {...props}
         />
-        <FieldLabel htmlFor={field.name} className='text-sm cursor-pointer'>
+        <FieldLabel htmlFor={id} className='text-sm cursor-pointer'>
           {label}
         </FieldLabel>
       </div>

--- a/packages/registry/items/react-hook-form/checkbox-field/component.tsx
+++ b/packages/registry/items/react-hook-form/checkbox-field/component.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Lens } from '@hookform/lenses';
 import type * as React from 'react';
 import { useController } from 'react-hook-form';

--- a/packages/registry/items/react-hook-form/input-field/component.tsx
+++ b/packages/registry/items/react-hook-form/input-field/component.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Lens } from '@hookform/lenses';
 import { InfoIcon } from 'lucide-react';
 import type * as React from 'react';

--- a/packages/registry/items/react-hook-form/input-field/index.mdx
+++ b/packages/registry/items/react-hook-form/input-field/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Input Field
-description: Text input component integrated with React Hook Form via typed lens binding from @hookform/lenses. Supports tooltips, InputGroup integration, and numeric polymorphic detection.
+description: Text input component integrated with React Hook Form via typed lens binding from @hookform/lenses. Supports tooltips and InputGroup integration.
 registryName: rhf-input-field
 ---
 
@@ -8,10 +8,11 @@ registryName: rhf-input-field
 
 The field binds to the form via a typed lens from [`@hookform/lenses`](https://github.com/react-hook-form/lenses) — no call-site generic, just `lens.focus('fieldName')` with full autocomplete from your form's value type.
 
+For numeric inputs, use [`NumberField`](/docs/react-hook-form/number-field) instead.
+
 #### Built-in features
 
 - **Typed lens binding**: `lens.focus('name')` autocompletes from your form's value type — no `<MyForm>` generic at the call site
-- **Numeric polymorphic**: auto-detects numeric fields from `type='number'`/`'range'` or a numeric value
 - **Tooltip integration**: optional InfoIcon button with tooltip content via `tooltip` prop
 - **InputGroup ready**: built on shadcn InputGroup for seamless addon integration
 - **Zod validation**: native integration with react-hook-form and Zod via resolver
@@ -36,27 +37,23 @@ const lens = useLens({ control: form.control });
 </Form>
 ```
 
-The `<Form>` wrapper is required — it provides shadcn's `FormProvider` which `FormLabel` and `FormMessage` use internally.
+The `<Form>` wrapper is required — it provides React Hook Form's `FormProvider` context.
 
 ## Less boilerplate
 
 React Hook Form's standard approach uses render props to access field state:
 
 ```tsx
-<FormField
+<Controller
   control={form.control}
   name="email"
-  render={({ field }) => (
-    <FormItem>
-      <FormLabel>Email</FormLabel>
-      <FormControl>
-        <Input placeholder="your@email.com" {...field} />
-      </FormControl>
-      <FormDescription>
-        Your email address
-      </FormDescription>
-      <FormMessage />
-    </FormItem>
+  render={({ field, fieldState }) => (
+    <Field data-invalid={fieldState.invalid}>
+      <FieldLabel htmlFor={field.name}>Email</FieldLabel>
+      <Input {...field} id={field.name} aria-invalid={fieldState.invalid} placeholder="your@email.com" />
+      <FieldDescription>Your email address</FieldDescription>
+      {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+    </Field>
   )}
 />
 ```
@@ -80,40 +77,13 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 
 <ItemExamples registryName={'rhf-input-field'} />
 
-## Numeric fields
-
-`InputField` handles both string and numeric fields. It detects numeric mode when either:
-
-- `props.type` is `'number'` or `'range'`, or
-- the field's current value is a `number` (typically because `defaultValues` declares it as one)
-
-In numeric mode the input renders as `type='number'` and writes back `e.target.valueAsNumber` — empty input becomes `NaN`, which validators can check with `Number.isNaN(value)`. In string mode it passes `e.target.value` through unchanged.
-
-```tsx
-const form = useForm<{ quantity: number; ratio: number }>({
-  defaultValues: { quantity: 1, ratio: 0.5 },
-  resolver: zodResolver(
-    z.object({
-      quantity: z.number().min(1, 'Required'),
-      ratio: z.number().min(0).max(1),
-    }),
-  ),
-});
-const lens = useLens({ control: form.control });
-
-<InputField lens={lens.focus('quantity')} label='Quantity' />
-<InputField lens={lens.focus('ratio')} type='range' label='Ratio' min={0} max={1} step={0.1} />
-```
-
-If the field type is `number | undefined` / `number | null` and the current value starts as `undefined`/`null`, the runtime `typeof` check can't infer numeric mode — set `type='number'` explicitly in that case.
-
 ## Props
 
 <TypeTable
   type={{
     lens: {
-      description: 'Typed lens from useLens (see Setup section). Generic on T extends string | number.',
-      type: 'Lens<T>',
+      description: 'Typed lens from useLens (see Setup section).',
+      type: 'Lens<string>',
     },
     label: {
       description: 'Field label text',
@@ -128,7 +98,7 @@ If the field type is `number | undefined` / `number | null` and the current valu
       type: 'React.ReactNode?',
     },
     props: {
-      description: 'Native HTML input props (type, placeholder, disabled, etc.) — spread on InputGroupInput, except value/onChange which are managed.',
+      description: 'Native HTML input props (placeholder, disabled, etc.) — spread on InputGroupInput, except value/onChange which are managed.',
       type: "Omit<React.ComponentProps<typeof InputGroupInput>, 'value' | 'onChange'>",
     },
   }}

--- a/packages/registry/items/react-hook-form/input-field/validation.example.tsx
+++ b/packages/registry/items/react-hook-form/input-field/validation.example.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { Form } from '@/components/ui/form';
 import { InputField } from '@/components/ui/shuip/react-hook-form/input-field';
+import { NumberField } from '@/components/ui/shuip/react-hook-form/number-field';
 import { SubmitButton } from '@/components/ui/shuip/submit-button';
 
 const zodSchema = z.object({
@@ -52,7 +53,7 @@ export default function RhfInputFieldValidationExample() {
           placeholder='your@email.com'
         />
 
-        <InputField
+        <NumberField
           lens={lens.focus('age')}
           label='Age'
           description='You must be 18 or older to register'

--- a/packages/registry/items/react-hook-form/number-field/component.tsx
+++ b/packages/registry/items/react-hook-form/number-field/component.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Lens } from '@hookform/lenses';
 import { InfoIcon } from 'lucide-react';
 import type * as React from 'react';

--- a/packages/registry/items/react-hook-form/number-field/component.tsx
+++ b/packages/registry/items/react-hook-form/number-field/component.tsx
@@ -6,15 +6,17 @@ import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '@/components/ui/input-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-export interface InputFieldProps extends Omit<React.ComponentProps<typeof InputGroupInput>, 'value' | 'onChange'> {
-  lens: Lens<string>;
+export interface NumberFieldProps extends Omit<React.ComponentProps<typeof InputGroupInput>, 'value' | 'onChange'> {
+  lens: Lens<number>;
   label?: string;
   description?: string;
   tooltip?: React.ReactNode;
 }
 
-export function InputField({ lens, label, description, tooltip, ...props }: InputFieldProps) {
+export function NumberField({ lens, label, description, tooltip, type = 'number', ...props }: NumberFieldProps) {
   const { field, fieldState } = useController(lens.interop());
+
+  const value = Number.isNaN(field.value) ? '' : field.value;
 
   return (
     <Field className='gap-2' data-invalid={fieldState.invalid}>
@@ -24,7 +26,9 @@ export function InputField({ lens, label, description, tooltip, ...props }: Inpu
           {...field}
           {...props}
           id={field.name}
-          value={field.value ?? ''}
+          type={type}
+          value={value}
+          onChange={(e) => field.onChange(e.target.valueAsNumber)}
           aria-invalid={fieldState.invalid}
         />
         {tooltip && (

--- a/packages/registry/items/react-hook-form/number-field/component.tsx
+++ b/packages/registry/items/react-hook-form/number-field/component.tsx
@@ -8,26 +8,29 @@ import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '@/components/ui/input-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-export interface NumberFieldProps extends Omit<React.ComponentProps<typeof InputGroupInput>, 'value' | 'onChange'> {
+export interface NumberFieldProps
+  extends Omit<React.ComponentProps<typeof InputGroupInput>, 'value' | 'onChange' | 'type'> {
   lens: Lens<number>;
   label?: string;
   description?: string;
   tooltip?: React.ReactNode;
+  type?: 'number' | 'range';
 }
 
 export function NumberField({ lens, label, description, tooltip, type = 'number', ...props }: NumberFieldProps) {
   const { field, fieldState } = useController(lens.interop());
+  const id = props.id ?? field.name;
 
-  const value = Number.isNaN(field.value) ? '' : field.value;
+  const value = field.value == null || Number.isNaN(field.value) ? '' : field.value;
 
   return (
     <Field className='gap-2' data-invalid={fieldState.invalid}>
-      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
       <InputGroup>
         <InputGroupInput
           {...field}
           {...props}
-          id={field.name}
+          id={id}
           type={type}
           value={value}
           onChange={(e) => field.onChange(e.target.valueAsNumber)}

--- a/packages/registry/items/react-hook-form/number-field/default.example.tsx
+++ b/packages/registry/items/react-hook-form/number-field/default.example.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { Form } from '@/components/ui/form';
-import { InputField } from '@/components/ui/shuip/react-hook-form/input-field';
+import { NumberField } from '@/components/ui/shuip/react-hook-form/number-field';
 import { SubmitButton } from '@/components/ui/shuip/submit-button';
 
 const zodSchema = z.object({
@@ -15,7 +15,7 @@ const zodSchema = z.object({
 
 type Values = z.infer<typeof zodSchema>;
 
-export default function RhfInputFieldNumericExample() {
+export default function RhfNumberFieldExample() {
   const form = useForm<Values>({
     defaultValues: { quantity: 1, ratio: 0.5 },
     resolver: zodResolver(zodSchema),
@@ -33,14 +33,9 @@ export default function RhfInputFieldNumericExample() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
-        <InputField
-          lens={lens.focus('quantity')}
-          label='Quantity'
-          description='Auto-detected numeric because defaultValues is a number'
-          placeholder='1'
-        />
+        <NumberField lens={lens.focus('quantity')} label='Quantity' description='Integer quantity' placeholder='1' />
 
-        <InputField
+        <NumberField
           lens={lens.focus('ratio')}
           type='range'
           label='Ratio'

--- a/packages/registry/items/react-hook-form/number-field/index.mdx
+++ b/packages/registry/items/react-hook-form/number-field/index.mdx
@@ -1,0 +1,72 @@
+---
+title: Number Field
+description: Numeric input component integrated with React Hook Form via typed lens binding from @hookform/lenses. Writes back valueAsNumber, supports range sliders and tooltips.
+registryName: rhf-number-field
+---
+
+`NumberField` binds a numeric form field (`Lens<number>`) to a `type='number'` or `type='range'` input. The input writes back `e.target.valueAsNumber` so the form state stays correctly typed as `number`. Empty input becomes `NaN`, which validators can check with `Number.isNaN(value)`.
+
+For text fields, use [`InputField`](/docs/react-hook-form/input-field) instead.
+
+#### Built-in features
+
+- **Typed lens binding**: `lens.focus('quantity')` requires a numeric form field — typing is enforced
+- **`valueAsNumber` write-back**: form state stays `number`, not `string`
+- **Range slider support**: pass `type='range'` to render a slider
+- **Tooltip integration**: optional InfoIcon button with tooltip content via `tooltip` prop
+- **InputGroup ready**: built on shadcn InputGroup for seamless addon integration
+- **Zod validation**: native integration with react-hook-form and Zod via resolver
+
+## Setup
+
+```tsx
+import { useLens } from '@hookform/lenses';
+import { useForm } from 'react-hook-form';
+import { Form } from '@/components/ui/form';
+import { NumberField } from '@/components/ui/shuip/react-hook-form/number-field';
+
+const form = useForm<{ quantity: number; ratio: number }>({
+  defaultValues: { quantity: 1, ratio: 0.5 },
+});
+const lens = useLens({ control: form.control });
+
+<Form {...form}>
+  <form onSubmit={form.handleSubmit(onSubmit)}>
+    <NumberField lens={lens.focus('quantity')} label='Quantity' />
+    <NumberField lens={lens.focus('ratio')} type='range' label='Ratio' min={0} max={1} step={0.1} />
+  </form>
+</Form>
+```
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'rhf-number-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    lens: {
+      description: 'Typed lens from useLens, focused on a numeric form field.',
+      type: 'Lens<number>',
+    },
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the input',
+      type: 'string?',
+    },
+    tooltip: {
+      description: 'Tooltip content displayed in an info icon button',
+      type: 'React.ReactNode?',
+    },
+    props: {
+      description: "Native HTML input props (type, min, max, step, etc.) — spread on InputGroupInput, except value/onChange which are managed. Defaults type to 'number'.",
+      type: "Omit<React.ComponentProps<typeof InputGroupInput>, 'value' | 'onChange'>",
+    },
+  }}
+/>

--- a/packages/registry/items/react-hook-form/password-field/component.tsx
+++ b/packages/registry/items/react-hook-form/password-field/component.tsx
@@ -3,7 +3,8 @@
 import type { Lens } from '@hookform/lenses';
 import { Eye, EyeOff, InfoIcon } from 'lucide-react';
 import * as React from 'react';
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { useController } from 'react-hook-form';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '@/components/ui/input-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -15,6 +16,7 @@ export interface PasswordFieldProps extends Omit<React.ComponentProps<typeof Inp
 }
 
 export function PasswordField({ lens, label, description, tooltip, ...props }: PasswordFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
   const [showPassword, setShowPassword] = React.useState(false);
 
   const handleTogglePassword = React.useCallback(() => {
@@ -22,42 +24,37 @@ export function PasswordField({ lens, label, description, tooltip, ...props }: P
   }, []);
 
   return (
-    <FormField
-      {...lens.interop()}
-      render={({ field, fieldState }) => (
-        <FormItem data-invalid={fieldState.invalid}>
-          {label && <FormLabel>{label}</FormLabel>}
-          <FormControl>
-            <InputGroup>
-              <InputGroupInput
-                {...field}
-                type={showPassword ? 'text' : 'password'}
-                placeholder='Enter password'
-                aria-invalid={fieldState.invalid}
-                {...props}
-              />
-              <InputGroupAddon align='inline-end'>
-                <InputGroupButton aria-label='Toggle password' onClick={handleTogglePassword}>
-                  {showPassword ? <EyeOff className='size-4' /> : <Eye className='size-4' />}
-                </InputGroupButton>
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      <InputGroup>
+        <InputGroupInput
+          {...field}
+          id={field.name}
+          type={showPassword ? 'text' : 'password'}
+          placeholder='Enter password'
+          value={field.value ?? ''}
+          aria-invalid={fieldState.invalid}
+          {...props}
+        />
+        <InputGroupAddon align='inline-end'>
+          <InputGroupButton aria-label='Toggle password' onClick={handleTogglePassword}>
+            {showPassword ? <EyeOff className='size-4' /> : <Eye className='size-4' />}
+          </InputGroupButton>
 
-                {tooltip && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <InputGroupButton aria-label='Info' size='icon-xs'>
-                        <InfoIcon />
-                      </InputGroupButton>
-                    </TooltipTrigger>
-                    <TooltipContent>{tooltip}</TooltipContent>
-                  </Tooltip>
-                )}
-              </InputGroupAddon>
-            </InputGroup>
-          </FormControl>
-          <FormMessage className='text-xs text-left opacity-80' />
-          {description && <FormDescription className='text-xs'>{description}</FormDescription>}
-        </FormItem>
-      )}
-    />
+          {tooltip && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InputGroupButton aria-label='Info' size='icon-xs'>
+                  <InfoIcon />
+                </InputGroupButton>
+              </TooltipTrigger>
+              <TooltipContent>{tooltip}</TooltipContent>
+            </Tooltip>
+          )}
+        </InputGroupAddon>
+      </InputGroup>
+      {fieldState.invalid && <FieldError className='text-xs text-left opacity-80' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
   );
 }

--- a/packages/registry/items/react-hook-form/password-field/component.tsx
+++ b/packages/registry/items/react-hook-form/password-field/component.tsx
@@ -18,6 +18,7 @@ export interface PasswordFieldProps extends Omit<React.ComponentProps<typeof Inp
 export function PasswordField({ lens, label, description, tooltip, ...props }: PasswordFieldProps) {
   const { field, fieldState } = useController(lens.interop());
   const [showPassword, setShowPassword] = React.useState(false);
+  const id = props.id ?? field.name;
 
   const handleTogglePassword = React.useCallback(() => {
     setShowPassword((prev) => !prev);
@@ -25,16 +26,16 @@ export function PasswordField({ lens, label, description, tooltip, ...props }: P
 
   return (
     <Field className='gap-2' data-invalid={fieldState.invalid}>
-      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
       <InputGroup>
         <InputGroupInput
           {...field}
-          id={field.name}
-          type={showPassword ? 'text' : 'password'}
           placeholder='Enter password'
+          {...props}
+          id={id}
+          type={showPassword ? 'text' : 'password'}
           value={field.value ?? ''}
           aria-invalid={fieldState.invalid}
-          {...props}
         />
         <InputGroupAddon align='inline-end'>
           <InputGroupButton aria-label='Toggle password' onClick={handleTogglePassword}>

--- a/packages/registry/items/react-hook-form/radio-field/component.tsx
+++ b/packages/registry/items/react-hook-form/radio-field/component.tsx
@@ -1,6 +1,8 @@
 import type { Lens } from '@hookform/lenses';
 import type * as React from 'react';
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { useController } from 'react-hook-form';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 
 export interface RadioFieldProps
@@ -12,36 +14,31 @@ export interface RadioFieldProps
 }
 
 export function RadioField({ lens, options, label, description, ...props }: RadioFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
+
   return (
-    <FormField
-      {...lens.interop()}
-      render={({ field, fieldState }) => (
-        <FormItem className='space-y-1.5' data-invalid={fieldState.invalid}>
-          {label && <FormLabel>{label}</FormLabel>}
-          <FormControl>
-            <RadioGroup
-              {...props}
-              value={field.value ?? ''}
-              onValueChange={field.onChange}
-              className='flex flex-col space-y-1'
-              aria-invalid={fieldState.invalid}
-            >
-              {options.map((value) => (
-                <FormItem key={value} className='flex items-center space-x-3 space-y-0'>
-                  <FormControl>
-                    <RadioGroupItem value={value} id={`${field.name}-${value}`} aria-invalid={fieldState.invalid} />
-                  </FormControl>
-                  <FormLabel htmlFor={`${field.name}-${value}`} className='font-normal'>
-                    {value}
-                  </FormLabel>
-                </FormItem>
-              ))}
-            </RadioGroup>
-          </FormControl>
-          <FormMessage className='text-xs text-left' />
-          {description && <FormDescription className='text-xs'>{description}</FormDescription>}
-        </FormItem>
-      )}
-    />
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel>{label}</FieldLabel>}
+      <RadioGroup
+        name={field.name}
+        value={field.value ?? ''}
+        onValueChange={field.onChange}
+        onBlur={field.onBlur}
+        className='flex flex-col space-y-1'
+        aria-invalid={fieldState.invalid}
+        {...props}
+      >
+        {options.map((value) => (
+          <div key={value} className='flex items-center space-x-3 space-y-0'>
+            <RadioGroupItem id={`${field.name}-${value}`} value={value} aria-invalid={fieldState.invalid} />
+            <Label htmlFor={`${field.name}-${value}`} className='font-normal'>
+              {value}
+            </Label>
+          </div>
+        ))}
+      </RadioGroup>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
   );
 }

--- a/packages/registry/items/react-hook-form/radio-field/component.tsx
+++ b/packages/registry/items/react-hook-form/radio-field/component.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Lens } from '@hookform/lenses';
 import type * as React from 'react';
 import { useController } from 'react-hook-form';

--- a/packages/registry/items/react-hook-form/select-field/component.tsx
+++ b/packages/registry/items/react-hook-form/select-field/component.tsx
@@ -1,17 +1,9 @@
 import type { Lens } from '@hookform/lenses';
 import type { SelectProps } from '@radix-ui/react-select';
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { useController } from 'react-hook-form';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
-/**
- * Key is the label, value is the value
- * @example
- * const options: SelectFieldOption = {
- *   'First': '1',
- *   'Second': '2',
- *   'Third': '3',
- * };
- */
 export type SelectFieldOption = Record<string, string>;
 
 export interface SelectFieldProps extends Omit<SelectProps, 'value' | 'defaultValue' | 'onValueChange'> {
@@ -23,30 +15,25 @@ export interface SelectFieldProps extends Omit<SelectProps, 'value' | 'defaultVa
 }
 
 export function SelectField({ lens, options, label, description, placeholder, ...props }: SelectFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
+
   return (
-    <FormField
-      {...lens.interop()}
-      render={({ field, fieldState }) => (
-        <FormItem data-invalid={fieldState.invalid}>
-          {label && <FormLabel>{label}</FormLabel>}
-          <Select {...props} value={field.value ?? ''} onValueChange={field.onChange}>
-            <FormControl>
-              <SelectTrigger aria-invalid={fieldState.invalid} className='w-full'>
-                <SelectValue placeholder={placeholder} />
-              </SelectTrigger>
-            </FormControl>
-            <SelectContent>
-              {Object.entries(options).map(([label, value]) => (
-                <SelectItem key={label} value={value}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <FormMessage className='text-xs text-left' />
-          {description && <FormDescription className='text-xs'>{description}</FormDescription>}
-        </FormItem>
-      )}
-    />
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      <Select name={field.name} value={field.value ?? ''} onValueChange={field.onChange} {...props}>
+        <SelectTrigger id={field.name} aria-invalid={fieldState.invalid} className='w-full'>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {Object.entries(options).map(([optionLabel, value]) => (
+            <SelectItem key={value} value={value}>
+              {optionLabel}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
   );
 }

--- a/packages/registry/items/react-hook-form/select-field/component.tsx
+++ b/packages/registry/items/react-hook-form/select-field/component.tsx
@@ -28,7 +28,7 @@ export function SelectField({ lens, options, label, description, placeholder, ..
         </SelectTrigger>
         <SelectContent>
           {Object.entries(options).map(([optionLabel, value]) => (
-            <SelectItem key={value} value={value}>
+            <SelectItem key={optionLabel} value={value}>
               {optionLabel}
             </SelectItem>
           ))}

--- a/packages/registry/items/react-hook-form/select-field/component.tsx
+++ b/packages/registry/items/react-hook-form/select-field/component.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Lens } from '@hookform/lenses';
 import type { SelectProps } from '@radix-ui/react-select';
 import { useController } from 'react-hook-form';

--- a/packages/registry/items/react-hook-form/textarea-field/component.tsx
+++ b/packages/registry/items/react-hook-form/textarea-field/component.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Lens } from '@hookform/lenses';
 import { InfoIcon } from 'lucide-react';
 import type * as React from 'react';

--- a/packages/registry/items/react-hook-form/textarea-field/component.tsx
+++ b/packages/registry/items/react-hook-form/textarea-field/component.tsx
@@ -1,7 +1,8 @@
 import type { Lens } from '@hookform/lenses';
 import { InfoIcon } from 'lucide-react';
 import type * as React from 'react';
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { useController } from 'react-hook-form';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupTextarea } from '@/components/ui/input-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -14,35 +15,34 @@ export interface TextareaFieldProps
 }
 
 export function TextareaField({ lens, label, description, tooltip, ...props }: TextareaFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
+
   return (
-    <FormField
-      {...lens.interop()}
-      render={({ field, fieldState }) => {
-        return (
-          <FormItem data-invalid={fieldState.invalid}>
-            {label && <FormLabel>{label}</FormLabel>}
-            <FormControl>
-              <InputGroup>
-                <InputGroupTextarea {...field} aria-invalid={fieldState.invalid} {...props} />
-                {tooltip && (
-                  <InputGroupAddon align='block-end' className='justify-end'>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InputGroupButton aria-label='Info' size='icon-xs'>
-                          <InfoIcon />
-                        </InputGroupButton>
-                      </TooltipTrigger>
-                      <TooltipContent>{tooltip}</TooltipContent>
-                    </Tooltip>
-                  </InputGroupAddon>
-                )}
-              </InputGroup>
-            </FormControl>
-            <FormMessage className='text-xs text-left' />
-            {description && <FormDescription className='text-xs'>{description}</FormDescription>}
-          </FormItem>
-        );
-      }}
-    />
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      <InputGroup>
+        <InputGroupTextarea
+          {...field}
+          id={field.name}
+          value={field.value ?? ''}
+          aria-invalid={fieldState.invalid}
+          {...props}
+        />
+        {tooltip && (
+          <InputGroupAddon align='block-end' className='justify-end'>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InputGroupButton aria-label='Info' size='icon-xs'>
+                  <InfoIcon />
+                </InputGroupButton>
+              </TooltipTrigger>
+              <TooltipContent>{tooltip}</TooltipContent>
+            </Tooltip>
+          </InputGroupAddon>
+        )}
+      </InputGroup>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
   );
 }

--- a/packages/registry/items/react-hook-form/textarea-field/component.tsx
+++ b/packages/registry/items/react-hook-form/textarea-field/component.tsx
@@ -18,18 +18,13 @@ export interface TextareaFieldProps
 
 export function TextareaField({ lens, label, description, tooltip, ...props }: TextareaFieldProps) {
   const { field, fieldState } = useController(lens.interop());
+  const id = props.id ?? field.name;
 
   return (
     <Field className='gap-2' data-invalid={fieldState.invalid}>
-      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
       <InputGroup>
-        <InputGroupTextarea
-          {...field}
-          id={field.name}
-          value={field.value ?? ''}
-          aria-invalid={fieldState.invalid}
-          {...props}
-        />
+        <InputGroupTextarea {...field} {...props} id={id} value={field.value ?? ''} aria-invalid={fieldState.invalid} />
         {tooltip && (
           <InputGroupAddon align='block-end' className='justify-end'>
             <Tooltip>


### PR DESCRIPTION
## Summary

- **Fixes a TypeScript bug** in `rhf-input-field` that broke type-check at the component definition itself.
- **Aligns rhf-fields with shadcn's 2025-10 form pattern** (`<Controller>` + `Field`/`FieldLabel`/`FieldDescription`/`FieldError`) instead of the legacy `FormField` / `FormItem` / `FormLabel` / `FormControl` / `FormMessage` / `FormDescription` stack.
- **Splits `InputField` into `InputField` (`Lens<string>`) + new `NumberField` (`Lens<number>`)**.

## The bug

`InputField` was declared as `<T extends string | number = string>`. Inside the component body, TypeScript could not reduce `PathImpl<"__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__", T, HookFormControlShim<T>>` under an unresolved `T`, so any rhf typing that requires `TName extends FieldPath<TFieldValues>` (`<Controller>`, `<FormField>`, `useController`) refused the `lens.interop()` spread:

```
items/react-hook-form/input-field/component.tsx(24,6): error TS2322:
  Type '"__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__"' is not assignable to
  type 'PathImpl<"__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__", T, HookFormControlShim<T>>'.
```

Verified with `bunx tsc --noEmit` in `packages/registry` — error reproduced in the shuip repo itself (not caught by `bun check` since Biome doesn't type-check). The root cause is the unresolved-generic constraint, not the choice between `<FormField>` / `<Controller>` / `useController` (all reproduce it).

## Fix

The only ways out are (a) cast the interop result or (b) drop the generic. This PR takes (b) because it's also a step toward the cleaner shadcn pattern and produces a more expressive API (`<NumberField>` is sharper than `<InputField type='number'>`).

## What changed

- `input-field` — drops `<T extends string | number>`, becomes `Lens<string>`-only; `useController(lens.interop())` + `Field/FieldLabel/FieldDescription/FieldError`. Numeric autodetect removed.
- **New `rhf-number-field`** — `Lens<number>`, writes back `e.target.valueAsNumber`, supports `type='range'`. Numeric example moved here.
- `checkbox-field`, `password-field`, `radio-field`, `select-field`, `textarea-field` — all migrated to `useController(lens.interop())` + `Field`/etc. Public API unchanged (still spread + `lens` prop).
- `address-field` — main render migrated (inner `useController` sub-fields already conformed).
- `index.mdx` for `input-field` updated; new `index.mdx` for `number-field`.
- `validation.example.tsx` in `input-field` switches its `age` field to `<NumberField>`.
- Auto-detected `registryDependencies` for every rhf-field migrate from `"form"` to `"field"` after `bun registry:generate`.

## Consumer-side impact

The public API of each field is **unchanged** (`<InputField lens={lens.focus('email')} label='Email' placeholder='…' />`). The only consumer breaking changes:

1. `<InputField type='number'>` on a `Lens<number>` no longer compiles — use `<NumberField>`.
2. After `shadcn add`, consumers will be prompted for `field` (shadcn primitive, `npx shadcn@latest add field`) instead of `form`.
3. The rendered DOM/CSS differs slightly (`Field` vs `FormItem` wrappers).

## Out of scope (pre-existing TS errors not touched)

`bunx tsc --noEmit` still shows 22 errors, **all pre-existing** and unrelated to this refactor:

- `blocks/responsive-dialog/{default,scrollable}.example.tsx`, `components/side-dialog/form.example.tsx` — pass `register={...}` to fields that dropped that prop in #45.
- `radio-field/{conditional-pricing,default,payment-method}.example.tsx`, `select-field/conditional.example.tsx` — pass `Lens<"a" | "b">` to fields typed as `Lens<string>` (invariance).

Worth a follow-up PR.

## Test plan

- [ ] `bun registry:generate` regenerates `registry.json`, `__index__.ts`, `stubs/`, MDX symlinks — confirm `[generate] 25 items processed`.
- [ ] `bunx tsc --noEmit --ignoreDeprecations 6.0` from `packages/registry` — no errors in any `component.tsx`.
- [ ] `bun run scripts/shadcn-build.ts` from `apps/docs` — confirm `rhf-input-field.json` and `rhf-number-field.json` emitted with `registryDependencies: ["field", "input-group", "tooltip"]`.
- [ ] `bun dev:docs` — verify rendered output of each rhf-field example page (visual smoke test).
- [ ] Install in a clean Next.js consumer via `shadcn add` and submit each field.