### PR TITLE
feat(datetime-field): add rhf-datetime-field and tsf-datetime-field

### DIFF
--- a/apps/docs/content/docs/react-hook-form/.gitignore
+++ b/apps/docs/content/docs/react-hook-form/.gitignore
@@ -1,6 +1,7 @@
 # Auto-generated symlinks — do not commit (created by packages/registry/scripts/generate.ts)
 address-field.mdx
 checkbox-field.mdx
+datetime-field.mdx
 input-field.mdx
 number-field.mdx
 password-field.mdx

--- a/apps/docs/content/docs/tanstack-form/.gitignore
+++ b/apps/docs/content/docs/tanstack-form/.gitignore
@@ -1,5 +1,6 @@
 # Auto-generated symlinks — do not commit (created by packages/registry/scripts/generate.ts)
 checkbox-field.mdx
+datetime-field.mdx
 form-context.mdx
 input-field.mdx
 password-field.mdx

--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,6 @@
         "class-variance-authority": "catalog:",
         "clsx": "catalog:",
         "cmdk": "catalog:",
-        "date-fns": "catalog:",
         "lucide-react": "catalog:",
         "next-themes": "catalog:",
         "react": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -104,9 +104,11 @@
         "class-variance-authority": "catalog:",
         "clsx": "catalog:",
         "cmdk": "catalog:",
+        "date-fns": "catalog:",
         "lucide-react": "catalog:",
         "next-themes": "catalog:",
         "react": "catalog:",
+        "react-day-picker": "catalog:",
         "react-dom": "catalog:",
         "sonner": "catalog:",
         "tailwind-merge": "catalog:",
@@ -129,10 +131,12 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "date-fns": "^4.2.1",
     "lucide-react": "^1.16.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "^19.2.6",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.6",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
@@ -253,6 +257,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+
+    "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.51.4", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-AoziS8lRQ3ew/lY5J4JSlzYSN9Fo0oiyMBY37L3Bwq4mOQJT5GSrdZYLFPt6pH1LApDI3ZJceNyx+rHRACZSeQ=="],
 
@@ -868,6 +874,8 @@
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "date-fns": ["date-fns@4.2.1", "", {}, "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.2.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q=="],
@@ -1453,6 +1461,8 @@
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "react-day-picker": ["react-day-picker@10.0.1", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "date-fns": "^4.1.0" }, "peerDependencies": { "@types/react": ">=16.8.0", "react": ">=16.8.0" }, "optionalPeers": ["@types/react"] }, "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w=="],
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
         "@tanstack/react-form": "catalog:forms",
         "@tanstack/react-query": "catalog:forms",
         "class-variance-authority": "catalog:",
+        "date-fns": "catalog:",
         "lucide-react": "catalog:",
         "react": "catalog:",
         "react-dom": "catalog:",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
       "cmdk": "^1.1.1",
       "sonner": "^2.0.7",
       "vaul": "^1.1.2",
-      "next-themes": "^0.4.6"
+      "next-themes": "^0.4.6",
+      "react-day-picker": "^10.0.1",
+      "date-fns": "^4.2.1"
     },
     "catalogs": {
       "fumadocs": {

--- a/packages/registry/items/react-hook-form/datetime-field/component.tsx
+++ b/packages/registry/items/react-hook-form/datetime-field/component.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import type { Lens } from '@hookform/lenses';
+import type { Locale } from 'date-fns';
+import { format, setHours, setMinutes } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+import * as React from 'react';
+import { useController } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { InputGroup, InputGroupInput } from '@/components/ui/input-group';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+export interface DatetimeFieldProps {
+  lens: Lens<Date | undefined>;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  minDate?: Date;
+  maxDate?: Date;
+  locale?: Locale;
+  disabled?: boolean;
+  step?: number;
+}
+
+const pad2 = (n: number): string => n.toString().padStart(2, '0');
+
+const toTimeInputValue = (date: Date | undefined): string =>
+  date ? `${pad2(date.getHours())}:${pad2(date.getMinutes())}` : '';
+
+export function DatetimeField({
+  lens,
+  label,
+  description,
+  placeholder = 'Pick a date & time',
+  minDate,
+  maxDate,
+  locale,
+  disabled,
+  step = 60,
+}: DatetimeFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
+  const [open, setOpen] = React.useState(false);
+
+  const value = field.value as Date | undefined;
+
+  const handleDateSelect = (next: Date | undefined) => {
+    if (!next) {
+      field.onChange(undefined);
+      return;
+    }
+    const hours = value?.getHours() ?? 0;
+    const minutes = value?.getMinutes() ?? 0;
+    field.onChange(setMinutes(setHours(next, hours), minutes));
+  };
+
+  const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    if (!raw) return;
+    const [h, m] = raw.split(':').map((part) => Number.parseInt(part, 10));
+    if (Number.isNaN(h) || Number.isNaN(m)) return;
+    const base = value ?? new Date();
+    field.onChange(setMinutes(setHours(base, h), m));
+  };
+
+  const triggerLabel = value ? format(value, 'PPp', locale ? { locale } : undefined) : placeholder;
+
+  return (
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={field.name}
+            type='button'
+            variant='outline'
+            disabled={disabled}
+            aria-invalid={fieldState.invalid}
+            className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground')}
+            onBlur={field.onBlur}
+          >
+            <span className='truncate'>{triggerLabel}</span>
+            <CalendarIcon className='size-4 opacity-70' />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className='flex w-auto flex-col gap-3 p-3' align='start'>
+          <Calendar
+            mode='single'
+            selected={value}
+            onSelect={handleDateSelect}
+            disabled={[...(minDate ? [{ before: minDate }] : []), ...(maxDate ? [{ after: maxDate }] : [])]}
+            locale={locale}
+            autoFocus
+          />
+          <InputGroup>
+            <InputGroupInput
+              type='time'
+              step={step}
+              value={toTimeInputValue(value)}
+              onChange={handleTimeChange}
+              aria-label='Time'
+            />
+          </InputGroup>
+          <Button type='button' size='sm' onClick={() => setOpen(false)}>
+            OK
+          </Button>
+        </PopoverContent>
+      </Popover>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}

--- a/packages/registry/items/react-hook-form/datetime-field/component.tsx
+++ b/packages/registry/items/react-hook-form/datetime-field/component.tsx
@@ -14,7 +14,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { cn } from '@/lib/utils';
 
 export interface DatetimeFieldProps {
-  lens: Lens<Date | undefined>;
+  lens: Lens<Date>;
   label?: string;
   description?: string;
   placeholder?: string;
@@ -57,12 +57,12 @@ export function DatetimeField({
   };
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!value) return;
     const raw = event.target.value;
     if (!raw) return;
     const [h, m] = raw.split(':').map((part) => Number.parseInt(part, 10));
     if (Number.isNaN(h) || Number.isNaN(m)) return;
-    const base = value ?? new Date();
-    field.onChange(setMinutes(setHours(base, h), m));
+    field.onChange(setMinutes(setHours(value, h), m));
   };
 
   const triggerLabel = value ? format(value, 'PPp', locale ? { locale } : undefined) : placeholder;
@@ -100,6 +100,7 @@ export function DatetimeField({
               step={step}
               value={toTimeInputValue(value)}
               onChange={handleTimeChange}
+              disabled={disabled || !value}
               aria-label='Time'
             />
           </InputGroup>

--- a/packages/registry/items/react-hook-form/datetime-field/default.example.tsx
+++ b/packages/registry/items/react-hook-form/datetime-field/default.example.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { DatetimeField } from '@/components/ui/shuip/react-hook-form/datetime-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const zodSchema = z.object({
+  scheduledAt: z.date({ message: 'Pick a date & time' }),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function RhfDatetimeFieldExample() {
+  const form = useForm<Values>({
+    defaultValues: { scheduledAt: undefined },
+    resolver: zodResolver(zodSchema),
+  });
+  const lens = useLens({ control: form.control });
+
+  async function onSubmit(values: Values) {
+    alert(`Scheduled at: ${values.scheduledAt.toISOString()}`);
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <DatetimeField
+          lens={lens.focus('scheduledAt')}
+          label='Scheduled at'
+          description='Pick a date and a time of day.'
+        />
+        <SubmitButton>Schedule</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/datetime-field/index.mdx
+++ b/packages/registry/items/react-hook-form/datetime-field/index.mdx
@@ -1,0 +1,99 @@
+---
+title: Datetime Field
+description: Single date and time picker integrated with React Hook Form via typed lens binding. Stores a single Date carrying day, hours and minutes.
+registryName: rhf-datetime-field
+---
+
+`DatetimeField` is a single-value date + time picker that stores its selection as one `Date` carrying both the day and the hours/minutes. It wraps shadcn's `Calendar` and a native `<input type="time">` inside a `Popover`, and binds to the form via a typed lens from [`@hookform/lenses`](https://github.com/react-hook-form/lenses).
+
+For date-only fields, use `Calendar` directly. This component is for cases where the time of day matters as much as the date — meeting start, deadline, deliverable, etc.
+
+#### Built-in features
+
+- **Single `Date` value**: day + hours + minutes live in one field — no separate date/time pieces to reconcile
+- **Typed lens binding**: `lens.focus('scheduledAt')` autocompletes from your form's value type
+- **Locale-aware label**: trigger renders via `date-fns` `format(value, 'PPp', { locale })`
+- **Bounds**: `minDate` / `maxDate` disable out-of-range days on the calendar
+- **Time step**: native `<input type="time" step="...">` for minute or second granularity
+
+## Setup
+
+```tsx
+import { useLens } from '@hookform/lenses';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { DatetimeField } from '@/components/ui/shuip/react-hook-form/datetime-field';
+
+const schema = z.object({ scheduledAt: z.date() });
+type Values = z.infer<typeof schema>;
+
+const form = useForm<Values>({ defaultValues: { scheduledAt: undefined } });
+const lens = useLens({ control: form.control });
+
+<Form {...form}>
+  <form onSubmit={form.handleSubmit(onSubmit)}>
+    <DatetimeField lens={lens.focus('scheduledAt')} label='Scheduled at' />
+  </form>
+</Form>
+```
+
+The `<Form>` wrapper is required — it provides React Hook Form's `FormProvider` context.
+
+## Behavior
+
+- **First date pick:** when the field is empty and the user picks a day, hours and minutes default to `00:00`. When the field already has a value, the existing hours/minutes are preserved.
+- **Time change:** only the hours/minutes are updated; the date portion is preserved.
+- **Trigger label:** `format(value, 'PPp', { locale })` — e.g. `May 22, 2026, 2:30 PM`. When empty, falls back to `placeholder`.
+
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'rhf-datetime-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    lens: {
+      description: 'Typed lens from useLens (see Setup section).',
+      type: 'Lens<Date | undefined>',
+    },
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the trigger',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Trigger label shown when no date is selected',
+      type: 'string?',
+      default: "'Pick a date & time'",
+    },
+    minDate: {
+      description: 'Earliest selectable date (inclusive). Disables earlier days on the calendar.',
+      type: 'Date?',
+    },
+    maxDate: {
+      description: 'Latest selectable date (inclusive). Disables later days on the calendar.',
+      type: 'Date?',
+    },
+    locale: {
+      description: 'date-fns locale used for the trigger label and the calendar.',
+      type: 'Locale?',
+    },
+    disabled: {
+      description: 'Disables the trigger button.',
+      type: 'boolean?',
+    },
+    step: {
+      description: 'Time input step in seconds. 60 = 1 minute, 1 = 1 second.',
+      type: 'number?',
+      default: '60',
+    },
+  }}
+/>

--- a/packages/registry/items/react-hook-form/datetime-field/validation.example.tsx
+++ b/packages/registry/items/react-hook-form/datetime-field/validation.example.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { DatetimeField } from '@/components/ui/shuip/react-hook-form/datetime-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const zodSchema = z.object({
+  startsAt: z
+    .date({ message: 'Required' })
+    .refine((date) => date.getTime() > Date.now(), { message: 'Must be in the future' }),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function RhfDatetimeFieldValidationExample() {
+  const form = useForm<Values>({
+    defaultValues: { startsAt: undefined },
+    resolver: zodResolver(zodSchema),
+  });
+  const lens = useLens({ control: form.control });
+
+  async function onSubmit(values: Values) {
+    alert(`Starts at: ${values.startsAt.toISOString()}`);
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <DatetimeField
+          lens={lens.focus('startsAt')}
+          label='Starts at'
+          description='Must be a future date and time.'
+          minDate={new Date()}
+        />
+        <SubmitButton>Book</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/tanstack-form/datetime-field/component.tsx
+++ b/packages/registry/items/tanstack-form/datetime-field/component.tsx
@@ -55,12 +55,12 @@ export function DatetimeField({
   };
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!value) return;
     const raw = event.target.value;
     if (!raw) return;
     const [h, m] = raw.split(':').map((part) => Number.parseInt(part, 10));
     if (Number.isNaN(h) || Number.isNaN(m)) return;
-    const base = value ?? new Date();
-    field.handleChange(setMinutes(setHours(base, h), m));
+    field.handleChange(setMinutes(setHours(value, h), m));
   };
 
   const triggerLabel = value ? format(value, 'PPp', locale ? { locale } : undefined) : placeholder;
@@ -98,6 +98,7 @@ export function DatetimeField({
               step={step}
               value={toTimeInputValue(value)}
               onChange={handleTimeChange}
+              disabled={disabled || !value}
               aria-label='Time'
             />
           </InputGroup>

--- a/packages/registry/items/tanstack-form/datetime-field/component.tsx
+++ b/packages/registry/items/tanstack-form/datetime-field/component.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import type { Locale } from 'date-fns';
+import { format, setHours, setMinutes } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { InputGroup, InputGroupInput } from '@/components/ui/input-group';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useFieldContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { cn } from '@/lib/utils';
+
+export interface DatetimeFieldProps {
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  minDate?: Date;
+  maxDate?: Date;
+  locale?: Locale;
+  disabled?: boolean;
+  step?: number;
+}
+
+const pad2 = (n: number): string => n.toString().padStart(2, '0');
+
+const toTimeInputValue = (date: Date | undefined): string =>
+  date ? `${pad2(date.getHours())}:${pad2(date.getMinutes())}` : '';
+
+export function DatetimeField({
+  label,
+  description,
+  placeholder = 'Pick a date & time',
+  minDate,
+  maxDate,
+  locale,
+  disabled,
+  step = 60,
+}: DatetimeFieldProps) {
+  const field = useFieldContext<Date | undefined>();
+  const { isValid, errors } = field.state.meta;
+  const [open, setOpen] = React.useState(false);
+
+  const value = field.state.value;
+
+  const handleDateSelect = (next: Date | undefined) => {
+    if (!next) {
+      field.handleChange(undefined);
+      return;
+    }
+    const hours = value?.getHours() ?? 0;
+    const minutes = value?.getMinutes() ?? 0;
+    field.handleChange(setMinutes(setHours(next, hours), minutes));
+  };
+
+  const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    if (!raw) return;
+    const [h, m] = raw.split(':').map((part) => Number.parseInt(part, 10));
+    if (Number.isNaN(h) || Number.isNaN(m)) return;
+    const base = value ?? new Date();
+    field.handleChange(setMinutes(setHours(base, h), m));
+  };
+
+  const triggerLabel = value ? format(value, 'PPp', locale ? { locale } : undefined) : placeholder;
+
+  return (
+    <Field className='gap-2' data-invalid={!isValid}>
+      {label && <FieldLabel htmlFor={field.name}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={field.name}
+            type='button'
+            variant='outline'
+            disabled={disabled}
+            aria-invalid={!isValid}
+            className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground')}
+            onBlur={field.handleBlur}
+          >
+            <span className='truncate'>{triggerLabel}</span>
+            <CalendarIcon className='size-4 opacity-70' />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className='flex w-auto flex-col gap-3 p-3' align='start'>
+          <Calendar
+            mode='single'
+            selected={value}
+            onSelect={handleDateSelect}
+            disabled={[...(minDate ? [{ before: minDate }] : []), ...(maxDate ? [{ after: maxDate }] : [])]}
+            locale={locale}
+            autoFocus
+          />
+          <InputGroup>
+            <InputGroupInput
+              type='time'
+              step={step}
+              value={toTimeInputValue(value)}
+              onChange={handleTimeChange}
+              aria-label='Time'
+            />
+          </InputGroup>
+          <Button type='button' size='sm' onClick={() => setOpen(false)}>
+            OK
+          </Button>
+        </PopoverContent>
+      </Popover>
+      {!isValid && (
+        <FieldError
+          className='text-xs text-left'
+          errors={errors.map((error) => ({ message: typeof error === 'string' ? error : error?.message }))}
+        />
+      )}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}

--- a/packages/registry/items/tanstack-form/datetime-field/default.example.tsx
+++ b/packages/registry/items/tanstack-form/datetime-field/default.example.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { DatetimeField } from '@/components/ui/shuip/tanstack-form/datetime-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { DatetimeField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfDatetimeFieldExample() {
+  const form = useAppForm({
+    defaultValues: {
+      scheduledAt: undefined as Date | undefined,
+    },
+    onSubmit: async ({ value }) => {
+      alert(`Scheduled at: ${value.scheduledAt?.toISOString() ?? 'unset'}`);
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='scheduledAt'
+        children={(field) => <field.DatetimeField label='Scheduled at' description='Pick a date and a time of day.' />}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Schedule</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/datetime-field/index.mdx
+++ b/packages/registry/items/tanstack-form/datetime-field/index.mdx
@@ -1,0 +1,108 @@
+---
+title: Datetime Field
+description: Single date and time picker integrated with TanStack Form via React context. Stores a single Date carrying day, hours and minutes.
+registryName: tsf-datetime-field
+---
+
+`DatetimeField` is a single-value date + time picker that stores its selection as one `Date` carrying both the day and the hours/minutes. It wraps shadcn's `Calendar` and a native `<input type="time">` inside a `Popover`, and reads the surrounding field via `useFieldContext` from your `useAppForm` setup.
+
+For date-only fields, use `Calendar` directly. This component is for cases where the time of day matters as much as the date — meeting start, deadline, deliverable, etc.
+
+#### Built-in features
+
+- **Single `Date` value**: day + hours + minutes live in one field — no separate date/time pieces to reconcile
+- **Context-bound field state**: reads the field via `useFieldContext` — no prop drilling
+- **Locale-aware label**: trigger renders via `date-fns` `format(value, 'PPp', { locale })`
+- **Bounds**: `minDate` / `maxDate` disable out-of-range days on the calendar
+- **Time step**: native `<input type="time" step="...">` for minute or second granularity
+
+## Setup
+
+Register the field component on your `useAppForm` once, alongside the rest of your shuip TSF components:
+
+```tsx
+// lib/form.ts
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { DatetimeField } from '@/components/ui/shuip/tanstack-form/datetime-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+export const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { DatetimeField },
+  formComponents: { SubmitButton },
+});
+```
+
+See the [`form-context`](/docs/tanstack-form/form-context) item for details.
+
+Then compose it inside `<form.AppField>`:
+
+```tsx
+const form = useAppForm({
+  defaultValues: { scheduledAt: undefined as Date | undefined },
+  onSubmit: async ({ value }) => save(value),
+});
+
+<form.AppField
+  name='scheduledAt'
+  children={(field) => <field.DatetimeField label='Scheduled at' />}
+/>
+```
+
+When the field's value can be `undefined`, type the default value with an assertion as shown — TanStack Form infers `Date | undefined` from it.
+
+## Behavior
+
+- **First date pick:** when the field is empty and the user picks a day, hours and minutes default to `00:00`. When the field already has a value, the existing hours/minutes are preserved.
+- **Time change:** only the hours/minutes are updated; the date portion is preserved.
+- **Trigger label:** `format(value, 'PPp', { locale })` — e.g. `May 22, 2026, 2:30 PM`. When empty, falls back to `placeholder`.
+
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'tsf-datetime-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the trigger',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Trigger label shown when no date is selected',
+      type: 'string?',
+      default: "'Pick a date & time'",
+    },
+    minDate: {
+      description: 'Earliest selectable date (inclusive). Disables earlier days on the calendar.',
+      type: 'Date?',
+    },
+    maxDate: {
+      description: 'Latest selectable date (inclusive). Disables later days on the calendar.',
+      type: 'Date?',
+    },
+    locale: {
+      description: 'date-fns locale used for the trigger label and the calendar.',
+      type: 'Locale?',
+    },
+    disabled: {
+      description: 'Disables the trigger button.',
+      type: 'boolean?',
+    },
+    step: {
+      description: 'Time input step in seconds. 60 = 1 minute, 1 = 1 second.',
+      type: 'number?',
+      default: '60',
+    },
+  }}
+/>

--- a/packages/registry/items/tanstack-form/datetime-field/validation.example.tsx
+++ b/packages/registry/items/tanstack-form/datetime-field/validation.example.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { DatetimeField } from '@/components/ui/shuip/tanstack-form/datetime-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { DatetimeField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfDatetimeFieldValidationExample() {
+  const form = useAppForm({
+    defaultValues: {
+      startsAt: undefined as Date | undefined,
+    },
+    onSubmit: async ({ value }) => {
+      alert(`Starts at: ${value.startsAt?.toISOString() ?? 'unset'}`);
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='startsAt'
+        validators={{
+          onChange: ({ value }) => {
+            if (!value) return 'Required';
+            if (value.getTime() <= Date.now()) return 'Must be in the future';
+            return undefined;
+          },
+        }}
+        children={(field) => (
+          <field.DatetimeField label='Starts at' description='Must be a future date and time.' minDate={new Date()} />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Book</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -22,6 +22,7 @@
     "react-error-boundary": "catalog:forms",
     "zod": "catalog:",
     "lucide-react": "catalog:",
+    "date-fns": "catalog:",
     "class-variance-authority": "catalog:",
     "@radix-ui/react-icons": "catalog:radix",
     "@repo/ui": "workspace:*"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,6 @@
     "vaul": "catalog:",
     "next-themes": "catalog:",
     "react-day-picker": "catalog:",
-    "date-fns": "catalog:",
     "@radix-ui/react-dialog": "catalog:radix",
     "@radix-ui/react-popover": "catalog:radix",
     "@radix-ui/react-select": "catalog:radix",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,8 @@
     "sonner": "catalog:",
     "vaul": "catalog:",
     "next-themes": "catalog:",
+    "react-day-picker": "catalog:",
+    "date-fns": "catalog:",
     "@radix-ui/react-dialog": "catalog:radix",
     "@radix-ui/react-popover": "catalog:radix",
     "@radix-ui/react-select": "catalog:radix",

--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import * as React from "react"
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react"
+import {
+  DayPicker,
+  getDefaultClassNames,
+  type DayButton,
+} from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button, buttonVariants } from "@/components/ui/button"
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = "label",
+  buttonVariant = "ghost",
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>["variant"]
+}) {
+  const defaultClassNames = getDefaultClassNames()
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        "group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className
+      )}
+      captionLayout={captionLayout}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString("default", { month: "short" }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn(
+          "relative flex flex-col gap-4 md:flex-row",
+          defaultClassNames.months
+        ),
+        month: cn("flex w-full flex-col gap-4", defaultClassNames.month),
+        nav: cn(
+          "absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
+          defaultClassNames.nav
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) p-0 select-none aria-disabled:opacity-50",
+          defaultClassNames.button_previous
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) p-0 select-none aria-disabled:opacity-50",
+          defaultClassNames.button_next
+        ),
+        month_caption: cn(
+          "flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)",
+          defaultClassNames.month_caption
+        ),
+        dropdowns: cn(
+          "flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium",
+          defaultClassNames.dropdowns
+        ),
+        dropdown_root: cn(
+          "relative rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50",
+          defaultClassNames.dropdown_root
+        ),
+        dropdown: cn(
+          "absolute inset-0 bg-popover opacity-0",
+          defaultClassNames.dropdown
+        ),
+        caption_label: cn(
+          "font-medium select-none",
+          captionLayout === "label"
+            ? "text-sm"
+            : "flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
+          defaultClassNames.caption_label
+        ),
+        table: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn(
+          "flex-1 rounded-md text-[0.8rem] font-normal text-muted-foreground select-none",
+          defaultClassNames.weekday
+        ),
+        week: cn("mt-2 flex w-full", defaultClassNames.week),
+        week_number_header: cn(
+          "w-(--cell-size) select-none",
+          defaultClassNames.week_number_header
+        ),
+        week_number: cn(
+          "text-[0.8rem] text-muted-foreground select-none",
+          defaultClassNames.week_number
+        ),
+        day: cn(
+          "group/day relative aspect-square h-full w-full p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-md",
+          props.showWeekNumber
+            ? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-md"
+            : "[&:first-child[data-selected=true]_button]:rounded-l-md",
+          defaultClassNames.day
+        ),
+        range_start: cn(
+          "rounded-l-md bg-accent",
+          defaultClassNames.range_start
+        ),
+        range_middle: cn("rounded-none", defaultClassNames.range_middle),
+        range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+        today: cn(
+          "rounded-md bg-accent text-accent-foreground data-[selected=true]:rounded-none",
+          defaultClassNames.today
+        ),
+        outside: cn(
+          "text-muted-foreground aria-selected:text-muted-foreground",
+          defaultClassNames.outside
+        ),
+        disabled: cn(
+          "text-muted-foreground opacity-50",
+          defaultClassNames.disabled
+        ),
+        hidden: cn("invisible", defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          )
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === "left") {
+            return (
+              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
+            )
+          }
+
+          if (orientation === "right") {
+            return (
+              <ChevronRightIcon
+                className={cn("size-4", className)}
+                {...props}
+              />
+            )
+          }
+
+          return (
+            <ChevronDownIcon className={cn("size-4", className)} {...props} />
+          )
+        },
+        DayButton: CalendarDayButton,
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          )
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  )
+}
+
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  ...props
+}: React.ComponentProps<typeof DayButton>) {
+  const defaultClassNames = getDefaultClassNames()
+
+  const ref = React.useRef<HTMLButtonElement>(null)
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus()
+  }, [modifiers.focused])
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString()}
+      data-selected-single={
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        "flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:rounded-none data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground dark:hover:text-accent-foreground [&>span]:text-xs [&>span]:opacity-70",
+        defaultClassNames.day,
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Calendar, CalendarDayButton }
+


### PR DESCRIPTION
## Summary
- Adds **rhf-datetime-field** — date + time picker bound via `@hookform/lenses` to a single `Date`.
- Adds **tsf-datetime-field** — tanstack-form equivalent via `useFieldContext`.
- Popover containing a single shadcn `Calendar` + a native `<input type="time">` so the value is a single `Date` carrying date + hours + minutes.

## Depends on
Stacked on `feat/date-fields-base`.

## Test plan
- [x] `bun registry:generate` — both items processed
- [x] `bun build:docs` — green
- [ ] Pick a date and a time in both doc pages, confirm trigger label uses `'PPp'`
- [ ] Validation example flags `scheduledAt` in the past