### PR TITLE
feat(autocomplete-field): add rhf- and tsf-autocomplete-field

### DIFF
--- a/apps/docs/content/docs/react-hook-form/.gitignore
+++ b/apps/docs/content/docs/react-hook-form/.gitignore
@@ -1,5 +1,6 @@
 # Auto-generated symlinks — do not commit (created by packages/registry/scripts/generate.ts)
 address-field.mdx
+autocomplete-field.mdx
 checkbox-field.mdx
 date-field.mdx
 date-range-field.mdx

--- a/apps/docs/content/docs/tanstack-form/.gitignore
+++ b/apps/docs/content/docs/tanstack-form/.gitignore
@@ -1,4 +1,5 @@
 # Auto-generated symlinks — do not commit (created by packages/registry/scripts/generate.ts)
+autocomplete-field.mdx
 checkbox-field.mdx
 date-field.mdx
 date-range-field.mdx

--- a/docs/superpowers/plans/2026-05-25-autocomplete-field.md
+++ b/docs/superpowers/plans/2026-05-25-autocomplete-field.md
@@ -1,0 +1,981 @@
+# Autocomplete Field Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a free-text string autocomplete field (`rhf-autocomplete-field` + `tsf-autocomplete-field`) to the shuip registry.
+
+**Architecture:** Each item is a self-contained `component.tsx` modelled on `address-field`'s proven interaction (Input as typing surface + `Popover`/`Command` dropdown, manual keyboard nav, debounce + stale-response guard). Two suggestion modes — static `suggestions: string[]` (client substring filter) and async `onSearch` (debounced fetch). The rhf/tsf pair duplicates the ~100-line core and differs only in form binding (Approach A, accepted deliberately for registry self-containment).
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, `@hookform/lenses` + `react-hook-form` (rhf), `@tanstack/react-form` (tsf), shadcn `command`/`popover`/`input`/`field` primitives, `lucide-react`.
+
+**Testing note:** shuip has no test runner (per `.claude/CLAUDE.md`). Do NOT add one. Each task is verified by the generator + build pipeline and `tsc --noEmit`, plus visual previews on the docs site. This replaces the unit-test loop.
+
+---
+
+## File Structure
+
+- `packages/registry/items/react-hook-form/autocomplete-field/component.tsx` — RHF item source.
+- `packages/registry/items/react-hook-form/autocomplete-field/default.example.tsx` — static-mode preview.
+- `packages/registry/items/react-hook-form/autocomplete-field/async.example.tsx` — async-mode preview.
+- `packages/registry/items/react-hook-form/autocomplete-field/index.mdx` — doc page.
+- `packages/registry/items/tanstack-form/autocomplete-field/component.tsx` — TSF item source.
+- `packages/registry/items/tanstack-form/autocomplete-field/default.example.tsx` — static-mode preview.
+- `packages/registry/items/tanstack-form/autocomplete-field/async.example.tsx` — async-mode preview.
+- `packages/registry/items/tanstack-form/autocomplete-field/index.mdx` — doc page.
+
+Generated artifacts (registry.json, __index__.ts, stubs, MDX symlinks, public/r) are produced by `bun registry:generate` / `bun registry:build` — never hand-edited.
+
+---
+
+## Task 1: RHF component.tsx
+
+**Files:**
+- Create: `packages/registry/items/react-hook-form/autocomplete-field/component.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+'use client';
+
+import type { Lens } from '@hookform/lenses';
+import { Loader2 } from 'lucide-react';
+import * as React from 'react';
+import { useController } from 'react-hook-form';
+import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+const DEBOUNCE_TIME = 300;
+
+function defaultFilter(suggestion: string, query: string) {
+  return suggestion.toLowerCase().includes(query.toLowerCase());
+}
+
+export interface AutocompleteFieldProps extends Omit<React.ComponentProps<typeof Input>, 'value' | 'onChange'> {
+  lens: Lens<string>;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  suggestions?: string[];
+  onSearch?: (query: string) => Promise<string[]>;
+  emptyText?: string;
+  debounceMs?: number;
+  filter?: (suggestion: string, query: string) => boolean;
+}
+
+export function AutocompleteField({
+  lens,
+  label,
+  description,
+  placeholder,
+  suggestions,
+  onSearch,
+  emptyText = 'No results',
+  debounceMs = DEBOUNCE_TIME,
+  filter = defaultFilter,
+  ...props
+}: AutocompleteFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
+
+  const [open, setOpen] = React.useState(false);
+  const [selectedIndex, setSelectedIndex] = React.useState(-1);
+  const [results, setResults] = React.useState<string[]>([]);
+  const [isPending, setIsPending] = React.useState(false);
+  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  const requestIdRef = React.useRef(0);
+  const popoverRef = React.useRef<HTMLDivElement>(null);
+
+  const query = field.value ?? '';
+
+  const items = React.useMemo(() => {
+    if (onSearch) return results;
+    if (!suggestions) return [];
+    if (!query) return suggestions;
+    return suggestions.filter((suggestion) => filter(suggestion, query));
+  }, [onSearch, results, suggestions, query, filter]);
+
+  React.useEffect(() => {
+    if (!onSearch || !open) return;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    if (!query) {
+      setResults([]);
+      return;
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      const requestId = ++requestIdRef.current;
+      setIsPending(true);
+      onSearch(query)
+        .then((res) => {
+          if (requestId !== requestIdRef.current) return;
+          setResults(res);
+        })
+        .catch(() => {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+        })
+        .finally(() => {
+          if (requestId !== requestIdRef.current) return;
+          setIsPending(false);
+        });
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [query, onSearch, open, debounceMs]);
+
+  const handleSelect = (value: string) => {
+    field.onChange(value);
+    setOpen(false);
+    setSelectedIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || items.length === 0) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
+        break;
+      case 'Enter':
+        if (selectedIndex >= 0 && selectedIndex < items.length) {
+          e.preventDefault();
+          handleSelect(items[selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        setSelectedIndex(-1);
+        break;
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent) => {
+    const relatedTarget = e.relatedTarget as HTMLElement;
+    if (popoverRef.current?.contains(relatedTarget)) {
+      return;
+    }
+    field.onBlur();
+    setTimeout(() => {
+      setOpen(false);
+      setSelectedIndex(-1);
+    }, 150);
+  };
+
+  const id = props.id ?? field.name;
+
+  return (
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <div className='relative'>
+            <Input
+              name={field.name}
+              value={query}
+              placeholder={placeholder}
+              autoComplete='off'
+              {...props}
+              id={id}
+              onChange={(e) => {
+                field.onChange(e.target.value);
+                setOpen(true);
+                setSelectedIndex(-1);
+              }}
+              onFocus={() => setOpen(true)}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              aria-invalid={fieldState.invalid}
+            />
+            {isPending && (
+              <div className='absolute inset-y-0 right-0 flex items-center pr-3'>
+                <Loader2 className='size-4 animate-spin text-muted-foreground' />
+              </div>
+            )}
+          </div>
+        </PopoverTrigger>
+        <PopoverContent
+          ref={popoverRef}
+          className='p-0'
+          align='start'
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          style={{ width: 'var(--radix-popover-trigger-width)' }}
+        >
+          <Command shouldFilter={false} className='w-full'>
+            <CommandList className='max-h-60'>
+              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
+              <CommandGroup>
+                {items.map((item, index) => (
+                  <CommandItem
+                    key={item}
+                    value={item}
+                    onSelect={() => handleSelect(item)}
+                    className={cn('cursor-pointer', selectedIndex === index && 'bg-accent')}
+                  >
+                    {item}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck the registry workspace**
+
+Run: `cd packages/registry && bun tsc --noEmit`
+Expected: no errors referencing `autocomplete-field` (note: the stub alias resolves only after Task 7 generate; an unresolved `@/components/ui/shuip/...` import does NOT exist yet in this file, so this should be clean).
+
+---
+
+## Task 2: RHF examples
+
+**Files:**
+- Create: `packages/registry/items/react-hook-form/autocomplete-field/default.example.tsx`
+- Create: `packages/registry/items/react-hook-form/autocomplete-field/async.example.tsx`
+
+- [ ] **Step 1: Write the static-mode example**
+
+`default.example.tsx`:
+
+```tsx
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { AutocompleteField } from '@/components/ui/shuip/react-hook-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const SOURCES = ['LinkedIn', 'IRL', 'Prospection', 'Referral', 'Website', 'Cold call'];
+
+const zodSchema = z.object({
+  source: z.string().nonempty({ message: 'Source is required' }),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function AutocompleteFieldExample() {
+  const form = useForm<Values>({
+    defaultValues: { source: '' },
+    resolver: zodResolver(zodSchema),
+  });
+  const lens = useLens({ control: form.control });
+
+  function onSubmit(values: Values) {
+    alert(`Source: ${values.source}`);
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <AutocompleteField
+          lens={lens.focus('source')}
+          label='Source'
+          description='Pick a known source or type your own'
+          placeholder='e.g. LinkedIn'
+          suggestions={SOURCES}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </form>
+    </Form>
+  );
+}
+```
+
+- [ ] **Step 2: Write the async-mode example**
+
+`async.example.tsx`:
+
+```tsx
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { AutocompleteField } from '@/components/ui/shuip/react-hook-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const FRUITS = [
+  'Apple',
+  'Apricot',
+  'Banana',
+  'Blackberry',
+  'Blueberry',
+  'Cherry',
+  'Mango',
+  'Melon',
+  'Orange',
+  'Peach',
+];
+
+async function searchFruits(query: string): Promise<string[]> {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  return FRUITS.filter((fruit) => fruit.toLowerCase().includes(query.toLowerCase()));
+}
+
+const zodSchema = z.object({
+  fruit: z.string(),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function AutocompleteFieldAsyncExample() {
+  const form = useForm<Values>({ defaultValues: { fruit: '' } });
+  const lens = useLens({ control: form.control });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit((values) => alert(values.fruit))} className='space-y-4'>
+        <AutocompleteField
+          lens={lens.focus('fruit')}
+          label='Fruit'
+          description='Async search with simulated latency'
+          placeholder='Search a fruit…'
+          onSearch={searchFruits}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </form>
+    </Form>
+  );
+}
+```
+
+---
+
+## Task 3: RHF index.mdx
+
+**Files:**
+- Create: `packages/registry/items/react-hook-form/autocomplete-field/index.mdx`
+
+- [ ] **Step 1: Write the doc page**
+
+```mdx
+---
+title: Autocomplete Field
+description: Free-text input that suggests matching values from a static list or an async search. The committed value is a plain string — suggestions only propose, they never restrict.
+registryName: rhf-autocomplete-field
+---
+
+`AutocompleteField` is a text input that proposes matching strings as the user types, while still allowing any free-text value. It binds to React Hook Form through `@hookform/lenses` (`lens` prop) and stores a plain `string`.
+
+Use it when a field has a set of common values worth suggesting (sources, tags, cities…) but you don't want to force the user to pick from the list.
+
+#### Built-in features
+
+- **Two suggestion modes**: a static `suggestions` array (filtered client-side) or an async `onSearch` function (debounced fetch).
+- **Free text**: the typed value is always kept — closing the dropdown without selecting commits what was typed.
+- **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close.
+- **Custom matching**: override the default case-insensitive substring match via `filter` (static mode).
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'rhf-autocomplete-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    lens: {
+      description: 'React Hook Form lens focused on a string field (@hookform/lenses)',
+      type: 'Lens<string>',
+    },
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the input',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Input placeholder',
+      type: 'string?',
+    },
+    suggestions: {
+      description: 'Static list of suggestions, filtered client-side. Ignored when onSearch is provided.',
+      type: 'string[]?',
+    },
+    onSearch: {
+      description: 'Async resolver called with the current query; its result is shown as-is. Takes precedence over suggestions.',
+      type: '((query: string) => Promise<string[]>)?',
+    },
+    emptyText: {
+      description: 'Message shown when there are no matches',
+      type: 'string?',
+      default: "'No results'",
+    },
+    debounceMs: {
+      description: 'Debounce delay before calling onSearch (async mode only)',
+      type: 'number?',
+      default: '300',
+    },
+    filter: {
+      description: 'Custom matcher for static mode; defaults to case-insensitive substring',
+      type: '((suggestion: string, query: string) => boolean)?',
+    },
+  }}
+/>
+```
+
+---
+
+## Task 4: TSF component.tsx
+
+**Files:**
+- Create: `packages/registry/items/tanstack-form/autocomplete-field/component.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import * as React from 'react';
+import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useFieldContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { cn } from '@/lib/utils';
+
+const DEBOUNCE_TIME = 300;
+
+function defaultFilter(suggestion: string, query: string) {
+  return suggestion.toLowerCase().includes(query.toLowerCase());
+}
+
+export interface AutocompleteFieldProps {
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  suggestions?: string[];
+  onSearch?: (query: string) => Promise<string[]>;
+  emptyText?: string;
+  debounceMs?: number;
+  filter?: (suggestion: string, query: string) => boolean;
+  fieldProps?: React.ComponentProps<typeof Field>;
+  props?: Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>;
+}
+
+export function AutocompleteField({
+  label,
+  description,
+  placeholder,
+  suggestions,
+  onSearch,
+  emptyText = 'No results',
+  debounceMs = DEBOUNCE_TIME,
+  filter = defaultFilter,
+  fieldProps,
+  props,
+}: AutocompleteFieldProps) {
+  const field = useFieldContext<string>();
+  const { isValid, errors } = field.state.meta;
+
+  const [open, setOpen] = React.useState(false);
+  const [selectedIndex, setSelectedIndex] = React.useState(-1);
+  const [results, setResults] = React.useState<string[]>([]);
+  const [isPending, setIsPending] = React.useState(false);
+  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  const requestIdRef = React.useRef(0);
+  const popoverRef = React.useRef<HTMLDivElement>(null);
+
+  const query = field.state.value ?? '';
+
+  const items = React.useMemo(() => {
+    if (onSearch) return results;
+    if (!suggestions) return [];
+    if (!query) return suggestions;
+    return suggestions.filter((suggestion) => filter(suggestion, query));
+  }, [onSearch, results, suggestions, query, filter]);
+
+  React.useEffect(() => {
+    if (!onSearch || !open) return;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    if (!query) {
+      setResults([]);
+      return;
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      const requestId = ++requestIdRef.current;
+      setIsPending(true);
+      onSearch(query)
+        .then((res) => {
+          if (requestId !== requestIdRef.current) return;
+          setResults(res);
+        })
+        .catch(() => {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+        })
+        .finally(() => {
+          if (requestId !== requestIdRef.current) return;
+          setIsPending(false);
+        });
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [query, onSearch, open, debounceMs]);
+
+  const handleSelect = (value: string) => {
+    field.handleChange(value);
+    setOpen(false);
+    setSelectedIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || items.length === 0) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
+        break;
+      case 'Enter':
+        if (selectedIndex >= 0 && selectedIndex < items.length) {
+          e.preventDefault();
+          handleSelect(items[selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        setSelectedIndex(-1);
+        break;
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent) => {
+    const relatedTarget = e.relatedTarget as HTMLElement;
+    if (popoverRef.current?.contains(relatedTarget)) {
+      return;
+    }
+    field.handleBlur();
+    setTimeout(() => {
+      setOpen(false);
+      setSelectedIndex(-1);
+    }, 150);
+  };
+
+  const id = props?.id ?? field.name;
+
+  return (
+    <Field className='gap-2' data-invalid={!isValid} {...fieldProps}>
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <div className='relative'>
+            <Input
+              name={field.name}
+              value={query}
+              placeholder={placeholder}
+              autoComplete='off'
+              {...props}
+              id={id}
+              onChange={(e) => {
+                field.handleChange(e.target.value);
+                setOpen(true);
+                setSelectedIndex(-1);
+              }}
+              onFocus={() => setOpen(true)}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              aria-invalid={!isValid}
+            />
+            {isPending && (
+              <div className='absolute inset-y-0 right-0 flex items-center pr-3'>
+                <Loader2 className='size-4 animate-spin text-muted-foreground' />
+              </div>
+            )}
+          </div>
+        </PopoverTrigger>
+        <PopoverContent
+          ref={popoverRef}
+          className='p-0'
+          align='start'
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          style={{ width: 'var(--radix-popover-trigger-width)' }}
+        >
+          <Command shouldFilter={false} className='w-full'>
+            <CommandList className='max-h-60'>
+              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
+              <CommandGroup>
+                {items.map((item, index) => (
+                  <CommandItem
+                    key={item}
+                    value={item}
+                    onSelect={() => handleSelect(item)}
+                    className={cn('cursor-pointer', selectedIndex === index && 'bg-accent')}
+                  >
+                    {item}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {!isValid && (
+        <FieldError
+          className='text-xs text-left'
+          errors={errors.map((error) => ({ message: typeof error === 'string' ? error : error?.message }))}
+        />
+      )}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}
+```
+
+---
+
+## Task 5: TSF examples
+
+**Files:**
+- Create: `packages/registry/items/tanstack-form/autocomplete-field/default.example.tsx`
+- Create: `packages/registry/items/tanstack-form/autocomplete-field/async.example.tsx`
+
+- [ ] **Step 1: Write the static-mode example**
+
+`default.example.tsx`:
+
+```tsx
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { AutocompleteField } from '@/components/ui/shuip/tanstack-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const SOURCES = ['LinkedIn', 'IRL', 'Prospection', 'Referral', 'Website', 'Cold call'];
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { AutocompleteField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfAutocompleteFieldExample() {
+  const form = useAppForm({
+    defaultValues: {
+      source: '',
+    },
+    onSubmit: async ({ value }) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='source'
+        validators={{
+          onChange: ({ value }) => (value.length === 0 ? 'Source is required' : undefined),
+        }}
+        children={(field) => (
+          <field.AutocompleteField
+            label='Source'
+            description='Pick a known source or type your own'
+            placeholder='e.g. LinkedIn'
+            suggestions={SOURCES}
+          />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 2: Write the async-mode example**
+
+`async.example.tsx`:
+
+```tsx
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { AutocompleteField } from '@/components/ui/shuip/tanstack-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const FRUITS = [
+  'Apple',
+  'Apricot',
+  'Banana',
+  'Blackberry',
+  'Blueberry',
+  'Cherry',
+  'Mango',
+  'Melon',
+  'Orange',
+  'Peach',
+];
+
+async function searchFruits(query: string): Promise<string[]> {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  return FRUITS.filter((fruit) => fruit.toLowerCase().includes(query.toLowerCase()));
+}
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { AutocompleteField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfAutocompleteFieldAsyncExample() {
+  const form = useAppForm({
+    defaultValues: {
+      fruit: '',
+    },
+    onSubmit: async ({ value }) => {
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='fruit'
+        children={(field) => (
+          <field.AutocompleteField
+            label='Fruit'
+            description='Async search with simulated latency'
+            placeholder='Search a fruit…'
+            onSearch={searchFruits}
+          />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}
+```
+
+---
+
+## Task 6: TSF index.mdx
+
+**Files:**
+- Create: `packages/registry/items/tanstack-form/autocomplete-field/index.mdx`
+
+- [ ] **Step 1: Write the doc page**
+
+```mdx
+---
+title: Autocomplete Field
+description: Free-text input that suggests matching values from a static list or an async search, integrated with TanStack Form via React context. The committed value is a plain string.
+registryName: tsf-autocomplete-field
+---
+
+`AutocompleteField` is a text input that proposes matching strings as the user types, while still allowing any free-text value. It reads the surrounding field via `useFieldContext`, so you compose it inside a `<form.AppField>` rather than passing a `form` instance by prop. It stores a plain `string`.
+
+#### Built-in features
+
+- **Two suggestion modes**: a static `suggestions` array (filtered client-side) or an async `onSearch` function (debounced fetch).
+- **Free text**: the typed value is always kept — closing the dropdown without selecting commits what was typed.
+- **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close.
+- **Custom matching**: override the default case-insensitive substring match via `filter` (static mode).
+
+## Setup
+
+Field components are bound via React context. In your project, create `lib/form.ts` once:
+
+```tsx
+// lib/form.ts
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { AutocompleteField } from '@/components/ui/shuip/tanstack-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+export const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { AutocompleteField },
+  formComponents: { SubmitButton },
+});
+```
+
+See the [`form-context`](/docs/tanstack-form/form-context) item for details.
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'tsf-autocomplete-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the input',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Input placeholder',
+      type: 'string?',
+    },
+    suggestions: {
+      description: 'Static list of suggestions, filtered client-side. Ignored when onSearch is provided.',
+      type: 'string[]?',
+    },
+    onSearch: {
+      description: 'Async resolver called with the current query; its result is shown as-is. Takes precedence over suggestions.',
+      type: '((query: string) => Promise<string[]>)?',
+    },
+    emptyText: {
+      description: 'Message shown when there are no matches',
+      type: 'string?',
+      default: "'No results'",
+    },
+    debounceMs: {
+      description: 'Debounce delay before calling onSearch (async mode only)',
+      type: 'number?',
+      default: '300',
+    },
+    filter: {
+      description: 'Custom matcher for static mode; defaults to case-insensitive substring',
+      type: '((suggestion: string, query: string) => boolean)?',
+    },
+    fieldProps: {
+      description: 'Props passed to the Field wrapper component',
+      type: 'React.ComponentProps<typeof Field>?',
+    },
+    props: {
+      description: 'Native HTML input props (placeholder, disabled, etc.)',
+      type: "Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>?",
+    },
+  }}
+/>
+```
+
+---
+
+## Task 7: Generate registry artifacts
+
+**Files:**
+- Auto-generated: `registry.json`, `__index__.ts`, `stubs/**`, MDX symlinks.
+
+- [ ] **Step 1: Run the generator**
+
+Run: `bun registry:generate`
+Expected: `[generate] N items processed` with N increased by 2 vs the prior count. NO `[generate] skipping react-hook-form/autocomplete-field: no component.tsx` and NO `skipping tanstack-form/autocomplete-field` warnings.
+
+- [ ] **Step 2: Verify artifacts**
+
+Run: `git status --short packages/registry apps/docs/content`
+Expected to see (untracked/modified): `registry.json`, `__index__.ts`, `stubs/react-hook-form/autocomplete-field.tsx`, `stubs/tanstack-form/autocomplete-field.tsx`, and symlinks `apps/docs/content/docs/react-hook-form/autocomplete-field.mdx`, `apps/docs/content/docs/tanstack-form/autocomplete-field.mdx`.
+
+Run: `grep -c "autocomplete-field" packages/registry/registry.json`
+Expected: at least 2 (one per item; more counting examples keys).
+
+Inspect the new entries: confirm `registryDependencies` includes `command`, `popover`, `input`, `field`, and `dependencies` includes `lucide-react`.
+
+---
+
+## Task 8: End-to-end build and commit
+
+- [ ] **Step 1: Build docs end-to-end**
+
+Run: `bun build:docs`
+Expected: chains generate → registry:build → next build, exits 0. Confirm `apps/docs/public/r/rhf-autocomplete-field.json` and `apps/docs/public/r/tsf-autocomplete-field.json` exist.
+
+- [ ] **Step 2: Biome check**
+
+Run: `bun check`
+Expected: no errors on the new files (formatting auto-applied).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/registry apps/docs docs/superpowers
+git commit -m "feat(autocomplete-field): add rhf-autocomplete-field and tsf-autocomplete-field"
+```
+
+---
+
+## Task 9: Open the PR
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push -u origin feat/input-autocomplete
+gh pr create --title "feat(autocomplete-field): add rhf- and tsf-autocomplete-field" \
+  --body "Adds a free-text string autocomplete field to the registry (RHF + TSF). Static \`suggestions\` list (client substring filter) or async \`onSearch\` (debounced). Modelled on the address-field interaction pattern. Spec: docs/superpowers/specs/2026-05-25-autocomplete-field-design.md"
+```
+
+Expected: PR URL returned.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** both items (rhf/tsf) ✓; static + async modes ✓ (Tasks 1/4 logic, 2/5 examples); free text via field value ✓; Famille-A behaviour ✓; props `lens`/`suggestions`/`onSearch`/`emptyText`/`debounceMs`/`filter` ✓; `filter` static-only (async branch returns `results` before filter) ✓; address-field interaction model ✓; deps auto-detected ✓; verification via generate+build ✓.
+- **Placeholder scan:** no TBD/TODO; all code blocks complete.
+- **Type consistency:** `AutocompleteFieldProps`, `AutocompleteField`, `defaultFilter`, `handleSelect`, `handleKeyDown`, `handleBlur` names consistent across rhf/tsf; `registryName` values (`rhf-autocomplete-field`/`tsf-autocomplete-field`) match folder + prefix; example default exports unique per file.

--- a/docs/superpowers/specs/2026-05-25-autocomplete-field-design.md
+++ b/docs/superpowers/specs/2026-05-25-autocomplete-field-design.md
@@ -1,0 +1,147 @@
+# Autocomplete Field — Design
+
+**Date:** 2026-05-25
+**Branch:** `feat/input-autocomplete`
+**Status:** Approved
+
+## Goal
+
+Add a string autocomplete field to the shuip registry: a free-text input that
+suggests matching values from a list as the user types. The committed form value
+is a plain `string` — the suggestion list only proposes, it never restricts. This
+matches the "Famille A" pattern already used across the user's projects
+(`StringAutocompleteField` in agence-nuisibles-crm and kodex).
+
+It is distinct from:
+- `address-field` — autocomplete specialised for Google Places (server action).
+- entity comboboxes — restrict the value to a list and store IDs ("Famille B").
+- `select-field` — static dropdown, no free text entry.
+
+## Items
+
+Two published items (one per form integration), following the existing `rhf-`/`tsf-`
+pair convention:
+
+- `packages/registry/items/react-hook-form/autocomplete-field/`
+- `packages/registry/items/tanstack-form/autocomplete-field/`
+
+### Structure decision: full duplication (Approach A)
+
+The presentational + interaction core (filtering, debounce, keyboard nav, popover)
+is ~100 lines and is duplicated between the rhf and tsf `component.tsx`; only the
+form binding (~10 lines) differs. This is heavier duplication than the existing
+field pairs (~15 lines each), but it is accepted deliberately:
+
+- It honours the registry's self-containment guarantee — `shadcn add
+  rhf-autocomplete-field` installs one complete, working file.
+- The alternative (a base `components/autocomplete` headless item wrapped by the
+  pair via `meta.shuip.json` `dependsOn`) would add a third item and force
+  consumers to install two items. Rejected for now (YAGNI); revisit only if a
+  third consumer of the core appears.
+
+## Behaviour (Famille A)
+
+- Text input is the primary typing surface and holds the field value (free text).
+- While typing, a dropdown below the input lists matching suggestions.
+- Selection: click, or `ArrowDown`/`ArrowUp` + `Enter`. `Escape` closes the dropdown.
+- Text outside the list is preserved — closing without selecting keeps what was typed.
+- Committed value is always a `string` (what the user typed or the suggestion chosen).
+
+### Two suggestion modes (mutually exclusive)
+
+- **Static** — `suggestions: string[]`. Client-side substring filter, case-insensitive:
+  `s.toLowerCase().includes(query.toLowerCase())`.
+- **Async** — `onSearch: (query) => Promise<string[]>`. Debounced (default 300ms)
+  fetch; results displayed as-is (server already filtered). A stale-response guard
+  (`requestIdRef`) drops out-of-order responses. A `Loader2` spinner shows while
+  the promise is pending.
+- If both props are passed, `onSearch` takes precedence.
+
+## Interaction implementation
+
+Model on the established `address-field` pattern (the existing shuip autocomplete
+precedent):
+
+- The `Input` is the `PopoverTrigger`; `onOpenAutoFocus` is prevented so focus
+  stays in the input while the popover is open.
+- `Popover` width pinned to the trigger via `var(--radix-popover-trigger-width)`.
+- `Command` with `shouldFilter={false}` (filtering is done by us, not cmdk),
+  `CommandList`, `CommandEmpty`, `CommandGroup`, `CommandItem`.
+- Manual keyboard navigation: `selectedIndex` state + `handleKeyDown`
+  (ArrowDown/ArrowUp/Enter/Escape), because focus is in the outer input, not a
+  `CommandInput`.
+- `CommandEmpty` shows `emptyText` (default `"No results"`), or a "Searching…"
+  state while async is pending.
+
+## Props
+
+### RHF — `AutocompleteFieldProps`
+
+```ts
+interface AutocompleteFieldProps
+  extends Omit<React.ComponentProps<typeof Input>, 'value' | 'onChange'> {
+  lens: Lens<string>;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  suggestions?: string[];
+  onSearch?: (query: string) => Promise<string[]>;
+  emptyText?: string;        // default "No results"
+  debounceMs?: number;       // default 300, async mode only
+  filter?: (suggestion: string, query: string) => boolean; // override default substring match (static mode only)
+}
+```
+
+Binding: `const { field, fieldState } = useController(lens.interop());`, value
+sourced from `field.value ?? ''`, `aria-invalid={fieldState.invalid}`, errors via
+`<FieldError errors={[fieldState.error]} />`.
+
+### TSF — `AutocompleteFieldProps`
+
+Same logic and feature set. Differences follow the tsf field convention:
+
+- No `lens`; binding via `const field = useFieldContext<string>();`.
+- UI props nested under `props?: React.ComponentProps<'input'>` and
+  `fieldProps?: React.ComponentProps<typeof Field>` rather than spread at the top level.
+- `suggestions`, `onSearch`, `emptyText`, `debounceMs`, `filter`, `label`,
+  `description`, `placeholder` remain top-level on the props object.
+- Value/handlers: `field.state.value`, `field.handleChange`, `field.handleBlur`,
+  validity/errors from `field.state.meta`.
+
+## Files per item
+
+- `component.tsx` (REQUIRED, exact name).
+- `default.example.tsx` — static mode, e.g. `suggestions={['linkedin','irl','prospection']}`.
+- `async.example.tsx` — `onSearch` mode with a simulated async fetch.
+- `index.mdx` — frontmatter (`title`, `description`, `registryName`),
+  `<ItemExamples registryName={...} />`, and a `<TypeTable>` for props
+  (import `TypeTable` inline).
+
+Examples import the component via the stub alias
+(`@/components/ui/shuip/react-hook-form/autocomplete-field` /
+`@/components/ui/shuip/tanstack-form/autocomplete-field`), never relative.
+
+## Dependencies (auto-detected by generate.ts)
+
+- `registryDependencies`: `command`, `popover`, `input`, `field` (via
+  `@/components/ui/<name>` imports).
+- `dependencies`: `lucide-react` (`Loader2` spinner).
+- RHF additionally pulls `@hookform/lenses` + `react-hook-form`; TSF pulls
+  `@tanstack/react-form` and uses the `form-context` stub.
+
+## Verification
+
+1. `bun registry:generate` — item count +2, no `skipping … no component.tsx` warning.
+2. New entries in `registry.json` with expected `registryDependencies`/`dependencies`.
+3. Stubs at `stubs/react-hook-form/autocomplete-field.tsx` and
+   `stubs/tanstack-form/autocomplete-field.tsx`; MDX symlinks under
+   `content/docs/react-hook-form/` and `content/docs/tanstack-form/`.
+4. `bun build:docs` succeeds end-to-end.
+
+## Out of scope (YAGNI)
+
+- Ghost-text inline completion (considered, dropped: conflicts with substring
+  matching and degrades under async).
+- Multi-value / tag entry (the `SkillsTagInput` pattern).
+- A shared headless base component (Approach B).
+- Restricting the value to the list (Famille B / entity combobox).

--- a/packages/registry/items/react-hook-form/autocomplete-field/async.example.tsx
+++ b/packages/registry/items/react-hook-form/autocomplete-field/async.example.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { AutocompleteField } from '@/components/ui/shuip/react-hook-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const FRUITS = ['Apple', 'Apricot', 'Banana', 'Blackberry', 'Blueberry', 'Cherry', 'Mango', 'Melon', 'Orange', 'Peach'];
+
+async function searchFruits(query: string): Promise<string[]> {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  return FRUITS.filter((fruit) => fruit.toLowerCase().includes(query.toLowerCase()));
+}
+
+const zodSchema = z.object({
+  fruit: z.string(),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function AutocompleteFieldAsyncExample() {
+  const form = useForm<Values>({ defaultValues: { fruit: '' } });
+  const lens = useLens({ control: form.control });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit((values) => alert(values.fruit))} className='space-y-4'>
+        <AutocompleteField
+          lens={lens.focus('fruit')}
+          label='Fruit'
+          description='Async search with simulated latency'
+          placeholder='Search a fruit…'
+          onSearch={searchFruits}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/autocomplete-field/component.tsx
+++ b/packages/registry/items/react-hook-form/autocomplete-field/component.tsx
@@ -7,7 +7,7 @@ import { useController } from 'react-hook-form';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
 const DEBOUNCE_TIME = 300;
@@ -146,7 +146,7 @@ export function AutocompleteField({
     <Field className='gap-2' data-invalid={fieldState.invalid}>
       {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
+        <PopoverAnchor asChild>
           <div className='relative'>
             <Input
               name={field.name}
@@ -171,7 +171,7 @@ export function AutocompleteField({
               </div>
             )}
           </div>
-        </PopoverTrigger>
+        </PopoverAnchor>
         <PopoverContent
           ref={popoverRef}
           className='p-0'

--- a/packages/registry/items/react-hook-form/autocomplete-field/component.tsx
+++ b/packages/registry/items/react-hook-form/autocomplete-field/component.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import type { Lens } from '@hookform/lenses';
+import { Loader2 } from 'lucide-react';
+import * as React from 'react';
+import { useController } from 'react-hook-form';
+import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+const DEBOUNCE_TIME = 300;
+
+function defaultFilter(suggestion: string, query: string) {
+  return suggestion.toLowerCase().includes(query.toLowerCase());
+}
+
+export interface AutocompleteFieldProps extends Omit<React.ComponentProps<typeof Input>, 'value' | 'onChange'> {
+  lens: Lens<string>;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  suggestions?: string[];
+  onSearch?: (query: string) => Promise<string[]>;
+  emptyText?: string;
+  debounceMs?: number;
+  filter?: (suggestion: string, query: string) => boolean;
+}
+
+export function AutocompleteField({
+  lens,
+  label,
+  description,
+  placeholder,
+  suggestions,
+  onSearch,
+  emptyText = 'No results',
+  debounceMs = DEBOUNCE_TIME,
+  filter = defaultFilter,
+  ...props
+}: AutocompleteFieldProps) {
+  const { field, fieldState } = useController(lens.interop());
+
+  const [open, setOpen] = React.useState(false);
+  const [selectedIndex, setSelectedIndex] = React.useState(-1);
+  const [results, setResults] = React.useState<string[]>([]);
+  const [isPending, setIsPending] = React.useState(false);
+  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  const requestIdRef = React.useRef(0);
+  const popoverRef = React.useRef<HTMLDivElement>(null);
+
+  const query = field.value ?? '';
+
+  const items = React.useMemo(() => {
+    if (onSearch) return results;
+    if (!suggestions) return [];
+    if (!query) return suggestions;
+    return suggestions.filter((suggestion) => filter(suggestion, query));
+  }, [onSearch, results, suggestions, query, filter]);
+
+  React.useEffect(() => {
+    if (!onSearch || !open) return;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    if (!query) {
+      setResults([]);
+      return;
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      const requestId = ++requestIdRef.current;
+      setIsPending(true);
+      onSearch(query)
+        .then((res) => {
+          if (requestId !== requestIdRef.current) return;
+          setResults(res);
+        })
+        .catch(() => {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+        })
+        .finally(() => {
+          if (requestId !== requestIdRef.current) return;
+          setIsPending(false);
+        });
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [query, onSearch, open, debounceMs]);
+
+  const handleSelect = (value: string) => {
+    field.onChange(value);
+    setOpen(false);
+    setSelectedIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || items.length === 0) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
+        break;
+      case 'Enter':
+        if (selectedIndex >= 0 && selectedIndex < items.length) {
+          e.preventDefault();
+          handleSelect(items[selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        setSelectedIndex(-1);
+        break;
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent) => {
+    const relatedTarget = e.relatedTarget as HTMLElement;
+    if (popoverRef.current?.contains(relatedTarget)) {
+      return;
+    }
+    field.onBlur();
+    setTimeout(() => {
+      setOpen(false);
+      setSelectedIndex(-1);
+    }, 150);
+  };
+
+  const id = props.id ?? field.name;
+
+  return (
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <div className='relative'>
+            <Input
+              name={field.name}
+              value={query}
+              placeholder={placeholder}
+              autoComplete='off'
+              {...props}
+              id={id}
+              onChange={(e) => {
+                field.onChange(e.target.value);
+                setOpen(true);
+                setSelectedIndex(-1);
+              }}
+              onFocus={() => setOpen(true)}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              aria-invalid={fieldState.invalid}
+            />
+            {isPending && (
+              <div className='absolute inset-y-0 right-0 flex items-center pr-3'>
+                <Loader2 className='size-4 animate-spin text-muted-foreground' />
+              </div>
+            )}
+          </div>
+        </PopoverTrigger>
+        <PopoverContent
+          ref={popoverRef}
+          className='p-0'
+          align='start'
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          style={{ width: 'var(--radix-popover-trigger-width)' }}
+        >
+          <Command shouldFilter={false} className='w-full'>
+            <CommandList className='max-h-60'>
+              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
+              <CommandGroup>
+                {items.map((item, index) => (
+                  <CommandItem
+                    key={item}
+                    value={item}
+                    onSelect={() => handleSelect(item)}
+                    className={cn('cursor-pointer', selectedIndex === index && 'bg-accent')}
+                  >
+                    {item}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}

--- a/packages/registry/items/react-hook-form/autocomplete-field/component.tsx
+++ b/packages/registry/items/react-hook-form/autocomplete-field/component.tsx
@@ -45,7 +45,7 @@ export function AutocompleteField({
   const [open, setOpen] = React.useState(false);
   const [selectedIndex, setSelectedIndex] = React.useState(-1);
   const [results, setResults] = React.useState<string[]>([]);
-  const [isPending, setIsPending] = React.useState(false);
+  const [isPending, startTransition] = React.useTransition();
   const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
   const requestIdRef = React.useRef(0);
   const popoverRef = React.useRef<HTMLDivElement>(null);
@@ -67,32 +67,30 @@ export function AutocompleteField({
     }
 
     if (!query) {
+      requestIdRef.current++;
       setResults([]);
       return;
     }
 
     debounceTimerRef.current = setTimeout(() => {
       const requestId = ++requestIdRef.current;
-      setIsPending(true);
-      onSearch(query)
-        .then((res) => {
+      startTransition(async () => {
+        try {
+          const res = await onSearch(query);
           if (requestId !== requestIdRef.current) return;
           setResults(res);
-        })
-        .catch(() => {
+        } catch {
           if (requestId !== requestIdRef.current) return;
           setResults([]);
-        })
-        .finally(() => {
-          if (requestId !== requestIdRef.current) return;
-          setIsPending(false);
-        });
+        }
+      });
     }, debounceMs);
 
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
+      requestIdRef.current++;
     };
   }, [query, onSearch, open, debounceMs]);
 
@@ -103,7 +101,16 @@ export function AutocompleteField({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!open || items.length === 0) return;
+    if (!open) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+      setSelectedIndex(-1);
+      return;
+    }
+
+    if (items.length === 0) return;
 
     switch (e.key) {
       case 'ArrowDown':
@@ -119,11 +126,6 @@ export function AutocompleteField({
           e.preventDefault();
           handleSelect(items[selectedIndex]);
         }
-        break;
-      case 'Escape':
-        e.preventDefault();
-        setOpen(false);
-        setSelectedIndex(-1);
         break;
     }
   };
@@ -185,7 +187,7 @@ export function AutocompleteField({
               <CommandGroup>
                 {items.map((item, index) => (
                   <CommandItem
-                    key={item}
+                    key={`${item}-${index}`}
                     value={item}
                     onSelect={() => handleSelect(item)}
                     className={cn('cursor-pointer', selectedIndex === index && 'bg-accent')}

--- a/packages/registry/items/react-hook-form/autocomplete-field/default.example.tsx
+++ b/packages/registry/items/react-hook-form/autocomplete-field/default.example.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { AutocompleteField } from '@/components/ui/shuip/react-hook-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const SOURCES = ['LinkedIn', 'IRL', 'Prospection', 'Referral', 'Website', 'Cold call'];
+
+const zodSchema = z.object({
+  source: z.string().nonempty({ message: 'Source is required' }),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function AutocompleteFieldExample() {
+  const form = useForm<Values>({
+    defaultValues: { source: '' },
+    resolver: zodResolver(zodSchema),
+  });
+  const lens = useLens({ control: form.control });
+
+  function onSubmit(values: Values) {
+    alert(`Source: ${values.source}`);
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <AutocompleteField
+          lens={lens.focus('source')}
+          label='Source'
+          description='Pick a known source or type your own'
+          placeholder='e.g. LinkedIn'
+          suggestions={SOURCES}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/autocomplete-field/index.mdx
+++ b/packages/registry/items/react-hook-form/autocomplete-field/index.mdx
@@ -1,0 +1,67 @@
+---
+title: Autocomplete Field
+description: Free-text input that suggests matching values from a static list or an async search. The committed value is a plain string — suggestions only propose, they never restrict.
+registryName: rhf-autocomplete-field
+---
+
+`AutocompleteField` is a text input that proposes matching strings as the user types, while still allowing any free-text value. It binds to React Hook Form through `@hookform/lenses` (`lens` prop) and stores a plain `string`.
+
+Use it when a field has a set of common values worth suggesting (sources, tags, cities…) but you don't want to force the user to pick from the list.
+
+#### Built-in features
+
+- **Two suggestion modes**: a static `suggestions` array (filtered client-side) or an async `onSearch` function (debounced fetch).
+- **Free text**: the typed value is always kept — closing the dropdown without selecting commits what was typed.
+- **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close.
+- **Custom matching**: override the default case-insensitive substring match via `filter` (static mode).
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'rhf-autocomplete-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    lens: {
+      description: 'React Hook Form lens focused on a string field (@hookform/lenses)',
+      type: 'Lens<string>',
+    },
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the input',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Input placeholder',
+      type: 'string?',
+    },
+    suggestions: {
+      description: 'Static list of suggestions, filtered client-side. Ignored when onSearch is provided.',
+      type: 'string[]?',
+    },
+    onSearch: {
+      description: 'Async resolver called with the current query; its result is shown as-is. Takes precedence over suggestions.',
+      type: '((query: string) => Promise<string[]>)?',
+    },
+    emptyText: {
+      description: 'Message shown when there are no matches',
+      type: 'string?',
+      default: "'No results'",
+    },
+    debounceMs: {
+      description: 'Debounce delay before calling onSearch (async mode only)',
+      type: 'number?',
+      default: '300',
+    },
+    filter: {
+      description: 'Custom matcher for static mode; defaults to case-insensitive substring',
+      type: '((suggestion: string, query: string) => boolean)?',
+    },
+  }}
+/>

--- a/packages/registry/items/tanstack-form/autocomplete-field/async.example.tsx
+++ b/packages/registry/items/tanstack-form/autocomplete-field/async.example.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { AutocompleteField } from '@/components/ui/shuip/tanstack-form/autocomplete-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const FRUITS = ['Apple', 'Apricot', 'Banana', 'Blackberry', 'Blueberry', 'Cherry', 'Mango', 'Melon', 'Orange', 'Peach'];
+
+async function searchFruits(query: string): Promise<string[]> {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  return FRUITS.filter((fruit) => fruit.toLowerCase().includes(query.toLowerCase()));
+}
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { AutocompleteField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfAutocompleteFieldAsyncExample() {
+  const form = useAppForm({
+    defaultValues: {
+      fruit: '',
+    },
+    onSubmit: async ({ value }) => {
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='fruit'
+        children={(field) => (
+          <field.AutocompleteField
+            label='Fruit'
+            description='Async search with simulated latency'
+            placeholder='Search a fruit…'
+            onSearch={searchFruits}
+          />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/autocomplete-field/component.tsx
+++ b/packages/registry/items/tanstack-form/autocomplete-field/component.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import * as React from 'react';
+import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useFieldContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { cn } from '@/lib/utils';
+
+const DEBOUNCE_TIME = 300;
+
+function defaultFilter(suggestion: string, query: string) {
+  return suggestion.toLowerCase().includes(query.toLowerCase());
+}
+
+export interface AutocompleteFieldProps {
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  suggestions?: string[];
+  onSearch?: (query: string) => Promise<string[]>;
+  emptyText?: string;
+  debounceMs?: number;
+  filter?: (suggestion: string, query: string) => boolean;
+  fieldProps?: React.ComponentProps<typeof Field>;
+  props?: Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>;
+}
+
+export function AutocompleteField({
+  label,
+  description,
+  placeholder,
+  suggestions,
+  onSearch,
+  emptyText = 'No results',
+  debounceMs = DEBOUNCE_TIME,
+  filter = defaultFilter,
+  fieldProps,
+  props,
+}: AutocompleteFieldProps) {
+  const field = useFieldContext<string>();
+  const { isValid, errors } = field.state.meta;
+
+  const [open, setOpen] = React.useState(false);
+  const [selectedIndex, setSelectedIndex] = React.useState(-1);
+  const [results, setResults] = React.useState<string[]>([]);
+  const [isPending, setIsPending] = React.useState(false);
+  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  const requestIdRef = React.useRef(0);
+  const popoverRef = React.useRef<HTMLDivElement>(null);
+
+  const query = field.state.value ?? '';
+
+  const items = React.useMemo(() => {
+    if (onSearch) return results;
+    if (!suggestions) return [];
+    if (!query) return suggestions;
+    return suggestions.filter((suggestion) => filter(suggestion, query));
+  }, [onSearch, results, suggestions, query, filter]);
+
+  React.useEffect(() => {
+    if (!onSearch || !open) return;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    if (!query) {
+      setResults([]);
+      return;
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      const requestId = ++requestIdRef.current;
+      setIsPending(true);
+      onSearch(query)
+        .then((res) => {
+          if (requestId !== requestIdRef.current) return;
+          setResults(res);
+        })
+        .catch(() => {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+        })
+        .finally(() => {
+          if (requestId !== requestIdRef.current) return;
+          setIsPending(false);
+        });
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [query, onSearch, open, debounceMs]);
+
+  const handleSelect = (value: string) => {
+    field.handleChange(value);
+    setOpen(false);
+    setSelectedIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || items.length === 0) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
+        break;
+      case 'Enter':
+        if (selectedIndex >= 0 && selectedIndex < items.length) {
+          e.preventDefault();
+          handleSelect(items[selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        setSelectedIndex(-1);
+        break;
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent) => {
+    const relatedTarget = e.relatedTarget as HTMLElement;
+    if (popoverRef.current?.contains(relatedTarget)) {
+      return;
+    }
+    field.handleBlur();
+    setTimeout(() => {
+      setOpen(false);
+      setSelectedIndex(-1);
+    }, 150);
+  };
+
+  const id = props?.id ?? field.name;
+
+  return (
+    <Field className='gap-2' data-invalid={!isValid} {...fieldProps}>
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <div className='relative'>
+            <Input
+              name={field.name}
+              value={query}
+              placeholder={placeholder}
+              autoComplete='off'
+              {...props}
+              id={id}
+              onChange={(e) => {
+                field.handleChange(e.target.value);
+                setOpen(true);
+                setSelectedIndex(-1);
+              }}
+              onFocus={() => setOpen(true)}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              aria-invalid={!isValid}
+            />
+            {isPending && (
+              <div className='absolute inset-y-0 right-0 flex items-center pr-3'>
+                <Loader2 className='size-4 animate-spin text-muted-foreground' />
+              </div>
+            )}
+          </div>
+        </PopoverTrigger>
+        <PopoverContent
+          ref={popoverRef}
+          className='p-0'
+          align='start'
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          style={{ width: 'var(--radix-popover-trigger-width)' }}
+        >
+          <Command shouldFilter={false} className='w-full'>
+            <CommandList className='max-h-60'>
+              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
+              <CommandGroup>
+                {items.map((item, index) => (
+                  <CommandItem
+                    key={item}
+                    value={item}
+                    onSelect={() => handleSelect(item)}
+                    className={cn('cursor-pointer', selectedIndex === index && 'bg-accent')}
+                  >
+                    {item}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {!isValid && (
+        <FieldError
+          className='text-xs text-left'
+          errors={errors.map((error) => ({ message: typeof error === 'string' ? error : error?.message }))}
+        />
+      )}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}

--- a/packages/registry/items/tanstack-form/autocomplete-field/component.tsx
+++ b/packages/registry/items/tanstack-form/autocomplete-field/component.tsx
@@ -46,7 +46,7 @@ export function AutocompleteField({
   const [open, setOpen] = React.useState(false);
   const [selectedIndex, setSelectedIndex] = React.useState(-1);
   const [results, setResults] = React.useState<string[]>([]);
-  const [isPending, setIsPending] = React.useState(false);
+  const [isPending, startTransition] = React.useTransition();
   const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
   const requestIdRef = React.useRef(0);
   const popoverRef = React.useRef<HTMLDivElement>(null);
@@ -68,32 +68,30 @@ export function AutocompleteField({
     }
 
     if (!query) {
+      requestIdRef.current++;
       setResults([]);
       return;
     }
 
     debounceTimerRef.current = setTimeout(() => {
       const requestId = ++requestIdRef.current;
-      setIsPending(true);
-      onSearch(query)
-        .then((res) => {
+      startTransition(async () => {
+        try {
+          const res = await onSearch(query);
           if (requestId !== requestIdRef.current) return;
           setResults(res);
-        })
-        .catch(() => {
+        } catch {
           if (requestId !== requestIdRef.current) return;
           setResults([]);
-        })
-        .finally(() => {
-          if (requestId !== requestIdRef.current) return;
-          setIsPending(false);
-        });
+        }
+      });
     }, debounceMs);
 
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
+      requestIdRef.current++;
     };
   }, [query, onSearch, open, debounceMs]);
 
@@ -104,7 +102,16 @@ export function AutocompleteField({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!open || items.length === 0) return;
+    if (!open) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+      setSelectedIndex(-1);
+      return;
+    }
+
+    if (items.length === 0) return;
 
     switch (e.key) {
       case 'ArrowDown':
@@ -120,11 +127,6 @@ export function AutocompleteField({
           e.preventDefault();
           handleSelect(items[selectedIndex]);
         }
-        break;
-      case 'Escape':
-        e.preventDefault();
-        setOpen(false);
-        setSelectedIndex(-1);
         break;
     }
   };
@@ -186,7 +188,7 @@ export function AutocompleteField({
               <CommandGroup>
                 {items.map((item, index) => (
                   <CommandItem
-                    key={item}
+                    key={`${item}-${index}`}
                     value={item}
                     onSelect={() => handleSelect(item)}
                     className={cn('cursor-pointer', selectedIndex === index && 'bg-accent')}

--- a/packages/registry/items/tanstack-form/autocomplete-field/component.tsx
+++ b/packages/registry/items/tanstack-form/autocomplete-field/component.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { useFieldContext } from '@/components/ui/shuip/tanstack-form/form-context';
 import { cn } from '@/lib/utils';
 
@@ -147,7 +147,7 @@ export function AutocompleteField({
     <Field className='gap-2' data-invalid={!isValid} {...fieldProps}>
       {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
+        <PopoverAnchor asChild>
           <div className='relative'>
             <Input
               name={field.name}
@@ -172,7 +172,7 @@ export function AutocompleteField({
               </div>
             )}
           </div>
-        </PopoverTrigger>
+        </PopoverAnchor>
         <PopoverContent
           ref={popoverRef}
           className='p-0'

--- a/packages/registry/items/tanstack-form/autocomplete-field/default.example.tsx
+++ b/packages/registry/items/tanstack-form/autocomplete-field/default.example.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { AutocompleteField } from '@/components/ui/shuip/tanstack-form/autocomplete-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const SOURCES = ['LinkedIn', 'IRL', 'Prospection', 'Referral', 'Website', 'Cold call'];
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { AutocompleteField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfAutocompleteFieldExample() {
+  const form = useAppForm({
+    defaultValues: {
+      source: '',
+    },
+    onSubmit: async ({ value }) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='source'
+        validators={{
+          onChange: ({ value }) => (value.length === 0 ? 'Source is required' : undefined),
+        }}
+        children={(field) => (
+          <field.AutocompleteField
+            label='Source'
+            description='Pick a known source or type your own'
+            placeholder='e.g. LinkedIn'
+            suggestions={SOURCES}
+          />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/autocomplete-field/index.mdx
+++ b/packages/registry/items/tanstack-form/autocomplete-field/index.mdx
@@ -1,0 +1,90 @@
+---
+title: Autocomplete Field
+description: Free-text input that suggests matching values from a static list or an async search, integrated with TanStack Form via React context. The committed value is a plain string.
+registryName: tsf-autocomplete-field
+---
+
+`AutocompleteField` is a text input that proposes matching strings as the user types, while still allowing any free-text value. It reads the surrounding field via `useFieldContext`, so you compose it inside a `<form.AppField>` rather than passing a `form` instance by prop. It stores a plain `string`.
+
+#### Built-in features
+
+- **Two suggestion modes**: a static `suggestions` array (filtered client-side) or an async `onSearch` function (debounced fetch).
+- **Free text**: the typed value is always kept — closing the dropdown without selecting commits what was typed.
+- **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close.
+- **Custom matching**: override the default case-insensitive substring match via `filter` (static mode).
+
+## Setup
+
+Field components are bound via React context. In your project, create `lib/form.ts` once:
+
+```tsx
+// lib/form.ts
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { AutocompleteField } from '@/components/ui/shuip/tanstack-form/autocomplete-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+export const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { AutocompleteField },
+  formComponents: { SubmitButton },
+});
+```
+
+See the [`form-context`](/docs/tanstack-form/form-context) item for details.
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'tsf-autocomplete-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the input',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Input placeholder',
+      type: 'string?',
+    },
+    suggestions: {
+      description: 'Static list of suggestions, filtered client-side. Ignored when onSearch is provided.',
+      type: 'string[]?',
+    },
+    onSearch: {
+      description: 'Async resolver called with the current query; its result is shown as-is. Takes precedence over suggestions.',
+      type: '((query: string) => Promise<string[]>)?',
+    },
+    emptyText: {
+      description: 'Message shown when there are no matches',
+      type: 'string?',
+      default: "'No results'",
+    },
+    debounceMs: {
+      description: 'Debounce delay before calling onSearch (async mode only)',
+      type: 'number?',
+      default: '300',
+    },
+    filter: {
+      description: 'Custom matcher for static mode; defaults to case-insensitive substring',
+      type: '((suggestion: string, query: string) => boolean)?',
+    },
+    fieldProps: {
+      description: 'Props passed to the Field wrapper component',
+      type: 'React.ComponentProps<typeof Field>?',
+    },
+    props: {
+      description: 'Native HTML input props (placeholder, disabled, etc.)',
+      type: "Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>?",
+    },
+  }}
+/>


### PR DESCRIPTION
## What

Adds a free-text **string autocomplete** field to the registry, published as a pair:

- `rhf-autocomplete-field` (React Hook Form, `lens` + `useController`)
- `tsf-autocomplete-field` (TanStack Form, `useFieldContext` + `createFormHook`)

A text input that suggests matching values as you type, while keeping any free-text value (the committed value is a plain `string` — suggestions only propose, never restrict). This is the "string autocomplete" pattern from our CRM/edik/kodex projects, made generic.

## Behaviour

- **Two suggestion modes** (mutually exclusive): static `suggestions: string[]` (client-side case-insensitive substring filter) or async `onSearch: (q) => Promise<string[]>` (debounced 300ms, stale-response guard, loading spinner). `onSearch` takes precedence.
- **Free text** preserved; closing without selecting commits what was typed.
- **Keyboard nav**: ArrowUp/Down, Enter to select, Escape to close.
- **Custom matching** via `filter` (static mode).

Modelled on the existing `address-field` interaction (Input as typing surface + `Popover`/`Command` dropdown, manual keyboard handling, `onOpenAutoFocus` prevented).

## Notes

- Each item is fully self-contained (~100 lines duplicated across rhf/tsf, deliberate — registry self-containment over DRY).
- Auto-detected deps: `registryDependencies` = command, popover, input, field (+ tsf-form-context for the tsf variant); `dependencies` = lucide-react.
- `bun build:docs` passes end-to-end.

Design spec & plan: `docs/superpowers/specs/2026-05-25-autocomplete-field-design.md`, `docs/superpowers/plans/2026-05-25-autocomplete-field.md`.