### PR TITLE
fix(search): correct cmd+k result URLs missing route prefix

### DIFF
--- a/apps/docs/src/app/api/search/route.ts
+++ b/apps/docs/src/app/api/search/route.ts
@@ -1,4 +1,13 @@
-import { createFromSource } from 'fumadocs-core/search/server';
-import { combinedSource } from '@/lib/source';
+import { createSearchAPI } from 'fumadocs-core/search/server';
+import { allPages } from '@/lib/source';
 
-export const { GET } = createFromSource(combinedSource, { language: 'english' });
+export const { GET } = createSearchAPI('advanced', {
+  language: 'english',
+  indexes: allPages().map((page) => ({
+    id: page.url,
+    url: page.url,
+    title: page.data.title,
+    description: page.data.description,
+    structuredData: page.data.structuredData,
+  })),
+});

--- a/apps/docs/src/app/llms-full.txt/route.ts
+++ b/apps/docs/src/app/llms-full.txt/route.ts
@@ -1,9 +1,9 @@
-import { combinedSource, getLLMText } from '@/lib/source';
+import { allPages, getLLMText } from '@/lib/source';
 
 export const revalidate = false;
 
 export async function GET() {
-  const scan = combinedSource.getPages().map(getLLMText);
+  const scan = allPages().map(getLLMText);
   const scanned = await Promise.all(scan);
 
   return new Response(scanned.join('\n\n'));

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,5 +1,5 @@
 import { blocks, docs } from 'fumadocs-mdx:collections/server';
-import { type InferPageType, loader, multiple } from 'fumadocs-core/source';
+import { type InferPageType, loader } from 'fumadocs-core/source';
 import { icons } from 'lucide-react';
 import React from 'react';
 
@@ -22,15 +22,7 @@ export const blocksSource = loader({
   icon,
 });
 
-export const combinedSource = loader(
-  multiple({
-    docs: docs.toFumadocsSource(),
-    blocks: blocks.toFumadocsSource(),
-  }),
-  {
-    baseUrl: '/',
-  },
-);
+export const allPages = () => [...docsSource.getPages(), ...blocksSource.getPages()];
 
 export function getPageImage(
   page: InferPageType<typeof docsSource | typeof blocksSource>,
@@ -44,9 +36,7 @@ export function getPageImage(
   };
 }
 
-export async function getLLMText(
-  page: InferPageType<typeof docsSource | typeof blocksSource> | InferPageType<typeof combinedSource>,
-) {
+export async function getLLMText(page: InferPageType<typeof docsSource | typeof blocksSource>) {
   const processed = await page.data.getText('processed');
 
   return `# ${page.data.title} (${page.url})


### PR DESCRIPTION
## Problem

The cmd+K command palette opens and returns results, but **every result links to a 404**. Clicking "Copy Button" navigates to `/components/copy-button` (no `/docs` prefix) → "Not Found". Verified on shuip.plvo.dev:

- `/components/copy-button` → **404**
- `/docs/components/copy-button` → **200**

## Root cause

`apps/docs/src/lib/source.ts` built `combinedSource` by merging the `docs` and `blocks` collections into a **single** `loader` with `baseUrl: '/'`. A single loader has one base URL, so it cannot emit both `/docs/*` and `/blocks/*` — every page came out prefix-less. (`multiple()` is also deprecated in fumadocs-core 16.)

The same `combinedSource` backed `/llms-full.txt`, which had the identical corruption (`# Changelog (/changelog)` instead of `/docs/changelog`).

## Fix

Drop `combinedSource`. Add `allPages()` = `docsSource.getPages()` + `blocksSource.getPages()`; each source keeps its correct `/docs` / `/blocks` base URL. Build the search index via the canonical `createSearchAPI('advanced', { indexes })` pattern, and feed `/llms-full.txt` from the same helper.

## Verification

- `/api/search?query=button` now returns `/docs/components/...` URLs.
- `/llms-full.txt` now emits `/docs/changelog`, `/docs/configuration`.
- E2E (agent-browser): cmd+K → search → click result lands on the real page, no 404.
- `tsc --noEmit` clean (pre-existing tsconfig `baseUrl` deprecation only); Biome clean.