### PR TITLE
feat(skills): ship shuip agent skills via the registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,6 @@ next-env.d.ts
 __index__.ts
 registry.json
 stubs/
+packages/registry/skills/.generated/
 
 *.tsbuildinfo

--- a/apps/docs/content/docs/agent-skills.mdx
+++ b/apps/docs/content/docs/agent-skills.mdx
@@ -1,0 +1,49 @@
+---
+title: Agent Skills
+description: Install shuip know-how into your AI coding agent — skills that teach it when and how to use shuip
+---
+
+shuip ships **agent skills** alongside its components. A skill is a Markdown guide your AI coding agent (Claude Code) reads to learn what shuip is, when to reach for which item, and how to build production-grade forms — so the code it writes follows shuip's conventions instead of guessing at item names and APIs.
+
+Skills install through the same registry and CLI as components. Each lands in your project at `.claude/skills/<name>/SKILL.md`, versioned alongside your code.
+
+## Available skills
+
+| Skill | Use it for |
+| ----- | ---------- |
+| `shuip-overview` | Orientation — what shuip is, how to install items, the item categories, and which skill to reach for next. |
+| `shuip-components` | Choosing and composing components — the full item catalog plus install and import conventions. |
+| `shuip-forms` | Building production-grade forms with the react-hook-form (`rhf-`) and tanstack-form (`tsf-`) field items: validation, submission, and accessible error and loading states. |
+
+## Install
+
+Add a single skill:
+
+```npm
+npx shadcn@latest add https://shuip.plvo.dev/r/shuip-forms
+```
+
+Or install all of them at once with the bundle:
+
+```npm
+npx shadcn@latest add https://shuip.plvo.dev/r/shuip-skills
+```
+
+## Where they go
+
+Skills install into your project's `.claude/` directory:
+
+```bash
+.claude/
+└── skills/
+    ├── shuip-overview/
+    │   └── SKILL.md
+    ├── shuip-components/
+    │   └── SKILL.md
+    └── shuip-forms/
+        └── SKILL.md
+```
+
+Once installed, your agent picks them up automatically — ask it to build a form or add a component and it will follow shuip's patterns.
+
+> Skills currently target Claude Code (the `SKILL.md` format). The content is format-agnostic, so support for other agents can follow.

--- a/apps/docs/content/docs/agent-skills.mdx
+++ b/apps/docs/content/docs/agent-skills.mdx
@@ -54,6 +54,7 @@ The exact Markdown each skill ships. This is what your agent reads.
 
 Routes the agent: what shuip is, how items install, and which skill to use next.
 
+{/* shuip:skill:start name="shuip-overview" */}
 ````md
 ---
 name: shuip-overview
@@ -89,11 +90,13 @@ Items install under `@/components/ui/shuip/...` (or `@/components/block/shuip/..
 
 Before building UI from scratch, check whether shuip already ships it.
 ````
+{/* shuip:skill:end */}
 
 ### shuip-components
 
 The full item catalog plus install and import conventions; the agent uses this to choose the right item before building UI from scratch.
 
+{/* shuip:skill:start name="shuip-components" */}
 ````md
 ---
 name: shuip-components
@@ -186,11 +189,13 @@ description: Use when choosing which shuip item fits a need, or composing shuip 
 | Flat path `@/components/ui/shuip/rhf-input-field` | Form categories use a sub-folder: `@/components/ui/shuip/react-hook-form/input-field`. |
 | Treating blocks as `@/components/ui/shuip/...` | Blocks import from `@/components/block/shuip/<name>`. |
 ````
+{/* shuip:skill:end */}
 
 ### shuip-forms
 
 The flagship: rhf vs tsf decision, the lens binding for react-hook-form, `createFormHook` for tanstack-form, full annotated examples, validation, submission, and accessibility.
 
+{/* shuip:skill:start name="shuip-forms" */}
 ````md
 ---
 name: shuip-forms
@@ -377,5 +382,6 @@ The field components already render `aria-invalid`, associate the error message,
 - About to write `FormField`/`FormItem`/`FormControl` by hand → a shuip field already does this.
 - Looking for an `rhf-form` install command → it doesn't exist.
 ````
+{/* shuip:skill:end */}
 
 > Skills currently target Claude Code (the `SKILL.md` format). The content is format-agnostic, so support for other agents can follow.

--- a/apps/docs/content/docs/agent-skills.mdx
+++ b/apps/docs/content/docs/agent-skills.mdx
@@ -11,9 +11,9 @@ Skills install through the same registry and CLI as components. Each lands in yo
 
 | Skill | Use it for |
 | ----- | ---------- |
-| `shuip-overview` | Orientation — what shuip is, how to install items, the item categories, and which skill to reach for next. |
-| `shuip-components` | Choosing and composing components — the full item catalog plus install and import conventions. |
-| `shuip-forms` | Building production-grade forms with the react-hook-form (`rhf-`) and tanstack-form (`tsf-`) field items: validation, submission, and accessible error and loading states. |
+| [`shuip-overview`](#shuip-overview) | Orientation — what shuip is, how to install items, the item categories, and which skill to reach for next. |
+| [`shuip-components`](#shuip-components) | Choosing and composing components — the full item catalog plus install and import conventions. |
+| [`shuip-forms`](#shuip-forms) | Building production-grade forms with the react-hook-form (`rhf-`) and tanstack-form (`tsf-`) field items: validation, submission, and accessible error and loading states. |
 
 ## Install
 
@@ -45,5 +45,337 @@ Skills install into your project's `.claude/` directory:
 ```
 
 Once installed, your agent picks them up automatically — ask it to build a form or add a component and it will follow shuip's patterns.
+
+## What each skill contains
+
+The exact Markdown each skill ships. This is what your agent reads.
+
+### shuip-overview
+
+Routes the agent: what shuip is, how items install, and which skill to use next.
+
+````md
+---
+name: shuip-overview
+description: Use when working in a project that uses shuip and you need to know what shuip provides, how to install items from its registry, or which shuip skill/category to reach for. Triggers on shuip imports (@/components/ui/shuip/...) or a shuip registry URL (shuip.plvo.dev/r/...).
+---
+
+# shuip
+
+## What it is
+
+shuip is a component library built on shadcn/ui for Next.js + React. You install individual **items** through the shadcn CLI from shuip's registry; the source is copied into the project (same model as shadcn) and you own it afterwards.
+
+## Install any item
+
+```bash
+npx shadcn@latest add "https://shuip.plvo.dev/r/<item-name>"
+```
+
+Items install under `@/components/ui/shuip/...` (or `@/components/block/shuip/...` for blocks) and pull their shadcn primitives and npm dependencies automatically. **Exported symbols are unprefixed** — the item `rhf-input-field` exports `InputField`; the `rhf-`/`tsf-`/`tsq-` prefix is only the registry name.
+
+## Categories
+
+- **components** — standalone UI: dialogs, buttons, theme toggle (e.g. `side-dialog`, `confirmation-dialog`, `copy-button`, `theme-button`).
+- **blocks** — composed multi-part UI (e.g. `kanban`, `responsive-dialog`, `title-section`).
+- **react-hook-form** (`rhf-`) — form fields wired to react-hook-form via typed lenses.
+- **tanstack-form** (`tsf-`) — form fields wired to tanstack-form via context.
+- **tanstack-query** (`tsq-`) — data-fetching helpers (e.g. `query-boundary`).
+
+## Which skill next
+
+- Building or editing a **form** → use the **shuip-forms** skill (rhf/tsf field patterns in depth).
+- Choosing or composing **components/blocks**, or you need the full item catalog → use the **shuip-components** skill.
+
+Before building UI from scratch, check whether shuip already ships it.
+````
+
+### shuip-components
+
+The full item catalog plus install and import conventions; the agent uses this to choose the right item before building UI from scratch.
+
+````md
+---
+name: shuip-components
+description: Use when choosing which shuip item fits a need, or composing shuip components and blocks — provides the full item catalog, install/import conventions, and composition notes. Use before building UI that shuip may already provide.
+---
+
+# Choosing & composing shuip components
+
+## Conventions
+
+- Install: `npx shadcn@latest add "https://shuip.plvo.dev/r/<item-name>"`.
+- Import paths by category:
+  - components → `@/components/ui/shuip/<name>`
+  - blocks → `@/components/block/shuip/<name>`
+  - react-hook-form → `@/components/ui/shuip/react-hook-form/<name>`
+  - tanstack-form → `@/components/ui/shuip/tanstack-form/<name>`
+  - tanstack-query → `@/components/ui/shuip/tanstack-query/<name>`
+- **Exports are unprefixed**: `rhf-input-field` → `InputField`, `kanban` → `Kanban`.
+- For anything form-related, use the **shuip-forms** skill — it covers the rhf/tsf field patterns in depth.
+
+## Catalog
+
+<!-- shuip:catalog:start -->
+**components**
+- `confirmation-dialog`
+- `copy-button`
+- `hover-reveal`
+- `side-dialog`
+- `submit-button`
+- `theme-button`
+
+**blocks**
+- `kanban`
+- `responsive-dialog`
+- `title-section`
+
+**react-hook-form**
+- `rhf-address-field`
+- `rhf-autocomplete-field`
+- `rhf-checkbox-field`
+- `rhf-date-field`
+- `rhf-date-range-field`
+- `rhf-datetime-field`
+- `rhf-inline-edit`
+- `rhf-input-field`
+- `rhf-month-field`
+- `rhf-number-field`
+- `rhf-password-field`
+- `rhf-radio-field`
+- `rhf-select-field`
+- `rhf-textarea-field`
+- `rhf-time-field`
+- `rhf-time-range`
+
+**tanstack-form**
+- `tsf-autocomplete-field`
+- `tsf-checkbox-field`
+- `tsf-date-field`
+- `tsf-date-range-field`
+- `tsf-datetime-field`
+- `tsf-form-context`
+- `tsf-inline-edit`
+- `tsf-input-field`
+- `tsf-month-field`
+- `tsf-password-field`
+- `tsf-radio-field`
+- `tsf-select-field`
+- `tsf-submit-button`
+- `tsf-textarea-field`
+- `tsf-time-field`
+- `tsf-time-range`
+
+**tanstack-query**
+- `tsq-query-boundary`
+<!-- shuip:catalog:end -->
+
+## Composition notes
+
+- `responsive-dialog` composes `side-dialog`; installing it resolves the dependency.
+- `confirmation-dialog` for destructive-action confirmation; `side-dialog` for sheet-style panels.
+- `query-boundary` wraps data-fetching subtrees so you don't hand-roll loading/error UI.
+- Form fields are never used alone — they compose inside a form. Use **shuip-forms**.
+
+## Common mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| Building a dialog / kanban / clipboard button from scratch | Check the catalog first — shuip likely ships it. |
+| Importing a prefixed symbol (`RhfInputField`, `TsfInputField`) | Exports are unprefixed (`InputField`). |
+| Flat path `@/components/ui/shuip/rhf-input-field` | Form categories use a sub-folder: `@/components/ui/shuip/react-hook-form/input-field`. |
+| Treating blocks as `@/components/ui/shuip/...` | Blocks import from `@/components/block/shuip/<name>`. |
+````
+
+### shuip-forms
+
+The flagship: rhf vs tsf decision, the lens binding for react-hook-form, `createFormHook` for tanstack-form, full annotated examples, validation, submission, and accessibility.
+
+````md
+---
+name: shuip-forms
+description: Use when building or editing a form in a project that uses shuip — covers shuip's react-hook-form (rhf-) and tanstack-form (tsf-) field components, their install commands, validation, submission, and accessible error/loading state. Use before hand-writing shadcn FormField boilerplate.
+---
+
+# Building forms with shuip
+
+## Overview
+
+shuip ships pre-wired form **field components** for two libraries: **react-hook-form** (registry prefix `rhf-`) and **tanstack-form** (prefix `tsf-`). Each field collapses the label / control / error-message / accessibility wiring into one component.
+
+**Core principle:** compose shuip field components — do NOT hand-write shadcn's `<FormField render={...}>` boilerplate. If you're reaching for `FormField`/`FormItem`/`FormControl`/`FormMessage`, you're rebuilding what these items already give you.
+
+There is **no composite "form" item** in the registry — you assemble a form from individual field items plus your own schema and submit handler.
+
+## Choose the library first
+
+Match whatever the project already uses. If it's greenfield:
+
+- **react-hook-form** (`rhf-*`) — mature ecosystem, uncontrolled/minimal re-renders, validates with a zod resolver. Fields bind through a typed **lens** (`@hookform/lenses`). Pick this unless you have a reason not to.
+- **tanstack-form** (`tsf-*`) — end-to-end type-safe field names, validators co-located on the field, good async validation. Natural fit if the project is already on the TanStack stack (Query/Router). Requires the `tsf-form-context` item as its foundation.
+
+Do not mix the two families in one form.
+
+## Install
+
+```bash
+# react-hook-form fields (install the ones you need)
+npx shadcn@latest add "https://shuip.plvo.dev/r/rhf-input-field"
+npx shadcn@latest add "https://shuip.plvo.dev/r/rhf-password-field"
+npx shadcn@latest add "https://shuip.plvo.dev/r/submit-button"
+
+# tanstack-form: install the form context FIRST, then fields
+npx shadcn@latest add "https://shuip.plvo.dev/r/tsf-form-context"
+npx shadcn@latest add "https://shuip.plvo.dev/r/tsf-input-field"
+npx shadcn@latest add "https://shuip.plvo.dev/r/tsf-submit-button"
+```
+
+Field naming follows the input type: `input-field`, `password-field`, `number-field`, `select-field`, `checkbox-field`, `radio-field`, `textarea-field`, `date-field`, `date-range-field`, `datetime-field`, `time-field`, `month-field`, `autocomplete-field`, plus `address-field` (rhf only). For the full catalog use the **shuip-components** skill. The shadcn CLI pulls each item's shadcn primitives and npm deps (react-hook-form / zod / @hookform/lenses, or @tanstack/react-form) automatically.
+
+**Exports are unprefixed.** The item `rhf-input-field` exports `InputField`. The `rhf-`/`tsf-` prefix is only the registry name, never the import symbol.
+
+## react-hook-form pattern
+
+Create one lens per form with `useLens({ control })`, then give each field `lens.focus('fieldName')`. Wrap everything in `<Form {...form}>`.
+
+```tsx
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { InputField } from '@/components/ui/shuip/react-hook-form/input-field';
+import { PasswordField } from '@/components/ui/shuip/react-hook-form/password-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const schema = z
+  .object({
+    email: z.string().email('Enter a valid email'),
+    password: z.string().min(8, 'At least 8 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((v) => v.password === v.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type Values = z.infer<typeof schema>;
+
+export function SignupForm() {
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '', password: '', confirmPassword: '' },
+  });
+  const lens = useLens({ control: form.control });
+
+  async function onSubmit(values: Values) {
+    const result = await signup(values); // a server action
+    if (result?.fieldErrors) {
+      for (const [name, message] of Object.entries(result.fieldErrors)) {
+        form.setError(name as keyof Values, { message });
+      }
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <InputField lens={lens.focus('email')} label="Email" type="email" placeholder="you@example.com" />
+        <PasswordField lens={lens.focus('password')} label="Password" />
+        <PasswordField lens={lens.focus('confirmPassword')} label="Confirm password" />
+        <SubmitButton loading={form.formState.isSubmitting}>Create account</SubmitButton>
+      </form>
+    </Form>
+  );
+}
+```
+
+- Field-specific props (`type`, `placeholder`, …) pass straight through to the underlying input.
+- `SubmitButton` does **not** auto-disable — bind `loading={form.formState.isSubmitting}` (it disables and shows a spinner while loading).
+- Server-side validation failures map back onto fields with `form.setError`.
+
+## tanstack-form pattern
+
+Build the typed form hook once with `createFormHook`, passing the contexts from `tsf-form-context` and your field/form components. Bind fields with `<form.AppField>`; validators live on the field.
+
+```tsx
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { InputField } from '@/components/ui/shuip/tanstack-form/input-field';
+import { PasswordField } from '@/components/ui/shuip/tanstack-form/password-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { InputField, PasswordField },
+  formComponents: { SubmitButton },
+});
+
+export function SignupForm() {
+  const form = useAppForm({
+    defaultValues: { email: '', password: '' },
+    onSubmit: async ({ value }) => {
+      await signup(value); // a server action
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="space-y-4"
+    >
+      <form.AppField
+        name="email"
+        validators={{ onChange: ({ value }) => (!value.includes('@') ? 'Invalid email' : undefined) }}
+        children={(field) => <field.InputField label="Email" props={{ type: 'email' }} />}
+      />
+      <form.AppField
+        name="password"
+        validators={{ onChange: ({ value }) => (value.length < 8 ? 'At least 8 characters' : undefined) }}
+        children={(field) => <field.PasswordField label="Password" />}
+      />
+      <form.AppForm>
+        <form.SubmitButton>Create account</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}
+```
+
+- tsf fields take split props: `props` for the native input, `fieldProps` for the field wrapper. There is no lens and no `<Form>` wrapper.
+- The tsf `SubmitButton` auto-disables via `form.Subscribe` — render it inside `<form.AppForm>`, no `loading` prop needed.
+
+## Accessibility & states (both libraries)
+
+The field components already render `aria-invalid`, associate the error message, and show validation errors — you get accessible errors for free. For a form-level server error, render a `role="alert"` region yourself. Loading/disabled on submit is handled by `SubmitButton` as shown above.
+
+## Common mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| `<InputField control={form.control} name="email" />` | Wrong API. rhf fields bind via a lens: `lens={lens.focus('email')}` after `const lens = useLens({ control: form.control })`. |
+| Importing `RhfInputField` / `TsfInputField` | Export is `InputField`. The `rhf-`/`tsf-` prefix is the registry name only. |
+| `@/components/ui/shuip/rhf-input-field` (flat) | Real path is `@/components/ui/shuip/react-hook-form/input-field` (category sub-folder). |
+| Installing a `rhf-form` / `tsf-form` item | No composite form item exists. Assemble from field items. |
+| Hand-writing `<FormField render={...}>` | That's the boilerplate shuip fields replace. Use the field component. |
+| Raw `<Button disabled={isSubmitting}>` | Use `SubmitButton`. rhf: `loading={form.formState.isSubmitting}`; tsf: auto via `form.Subscribe`. |
+| Using tsf fields without `tsf-form-context` | Every tsf field reads `useFieldContext`; install and wire `tsf-form-context` first via `createFormHook`. |
+| Mixing rhf and tsf fields in one form | Pick one family per form. |
+
+## Red flags — STOP
+
+- About to type `control={...}` or `name="..."` on an rhf shuip field → use the lens.
+- About to import a `Rhf*`/`Tsf*`-prefixed symbol → the export is unprefixed.
+- About to write `FormField`/`FormItem`/`FormControl` by hand → a shuip field already does this.
+- Looking for an `rhf-form` install command → it doesn't exist.
+````
 
 > Skills currently target Claude Code (the `SKILL.md` format). The content is format-agnostic, so support for other agents can follow.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -2,5 +2,5 @@
   "title": "Documentation",
   "description": "Documentation for the project",
   "root": true,
-  "pages": ["index", "configuration", "installation", "contribution", "changelog"]
+  "pages": ["index", "configuration", "installation", "agent-skills", "contribution", "changelog"]
 }

--- a/docs/superpowers/plans/2026-05-27-shuip-agent-skills-generator-wiring.md
+++ b/docs/superpowers/plans/2026-05-27-shuip-agent-skills-generator-wiring.md
@@ -1,0 +1,762 @@
+# shuip Agent Skills — Generator Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the three already-authored skills under `packages/registry/skills/` into shuip's registry pipeline so `npx shadcn add https://shuip.plvo.dev/r/<skill>` installs each as `.claude/skills/<name>/SKILL.md`, plus a `shuip-skills` bundle.
+
+**Architecture:** Approach B — a standalone `packages/registry/scripts/skills.ts` module (pure functions + an `emitSkills` orchestrator) is called from `generate.ts`'s `main()` after the component scan. It resolves a catalog from the in-memory component list, writes catalog-resolved copies to the gitignored `skills/.generated/`, and returns `registry:item` entries that are merged into the shared `registry.json`. `apps/docs/scripts/shadcn-build.ts` already emits `public/r/*.json` generically — no build change.
+
+**Tech Stack:** Bun (runtime + `bun test`), TypeScript 6, Biome (single quotes, 2-space, 120-col, trailing commas), shadcn registry schema.
+
+**Reference:** spec at `docs/superpowers/specs/2026-05-27-shuip-agent-skills-design.md`. Skill sources already committed at `packages/registry/skills/{shuip-overview,shuip-components,shuip-forms}/SKILL.md`.
+
+**Verified facts (do not re-litigate):**
+- `apps/docs/scripts/shadcn-build.ts:45-52` — `files` is optional, loop is `for (const file of item.files ?? [])`; schema enum includes `registry:item` and `registry:file`. A files-less bundle and skill file-items both validate and build with no change.
+- That schema is non-strict and carries no `title`/`description`, and existing component items omit them too → skill items **omit `title`/`description`**.
+- `packages/registry/.gitignore` does not exist; root `.gitignore:58-61` ignores `__index__.ts`, `registry.json`, `stubs/` under a `# registry` block. `registry.json`, `__index__.ts`, `stubs/`, `public/r/` are regenerated, never committed.
+
+---
+
+## File Structure
+
+- **Create** `packages/registry/scripts/skills.ts` — frontmatter parse, catalog resolve, marker replace, name-collision guard, `emitSkills` orchestrator. One responsibility: turning `skills/` sources into registry items + `.generated/` files.
+- **Create** `packages/registry/scripts/skills.test.ts` — `bun test` unit tests for the pure functions + an `emitSkills` integration test over a temp fixture dir.
+- **Modify** `packages/registry/scripts/generate.ts` — widen `RegistryItem`, export the two registry types, call `emitSkills` from `main()`, merge + collision-check.
+- **Modify** `packages/registry/package.json` — add a `test` script.
+- **Modify** `.gitignore` — ignore `packages/registry/skills/.generated/`.
+- **Modify** `packages/registry/skills/shuip-components/SKILL.md` — replace the catalog marker region with the exact `resolveCatalog` output (source snapshot matches shipped).
+
+---
+
+## Task 1: `bun test` setup + `parseSkillFrontmatter`
+
+**Files:**
+- Create: `packages/registry/scripts/skills.ts`
+- Create: `packages/registry/scripts/skills.test.ts`
+- Modify: `packages/registry/package.json` (scripts block)
+
+- [ ] **Step 1: Add the test script**
+
+In `packages/registry/package.json`, add a `test` script next to `registry:generate`:
+
+```json
+    "registry:generate": "bun run scripts/generate.ts",
+    "test": "bun test"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/registry/scripts/skills.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import { parseSkillFrontmatter } from './skills';
+
+describe('parseSkillFrontmatter', () => {
+  test('extracts name and description', () => {
+    const src = '---\nname: shuip-forms\ndescription: Use when building a form.\n---\n\n# body\n';
+    expect(parseSkillFrontmatter(src)).toEqual({
+      name: 'shuip-forms',
+      description: 'Use when building a form.',
+    });
+  });
+
+  test('throws when frontmatter is absent', () => {
+    expect(() => parseSkillFrontmatter('# no frontmatter')).toThrow('missing YAML frontmatter');
+  });
+
+  test('throws when name is missing', () => {
+    expect(() => parseSkillFrontmatter('---\ndescription: x\n---\n')).toThrow('missing "name"');
+  });
+
+  test('throws when description is missing', () => {
+    expect(() => parseSkillFrontmatter('---\nname: x\n---\n')).toThrow('missing "description"');
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: FAIL — `Cannot find module './skills'` (or "export named 'parseSkillFrontmatter' not found").
+
+- [ ] **Step 4: Write the minimal implementation**
+
+Create `packages/registry/scripts/skills.ts`:
+
+```ts
+export function parseSkillFrontmatter(source: string): { name: string; description: string } {
+  const match = source.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error('skill SKILL.md missing YAML frontmatter');
+  const block = match[1];
+  const name = block.match(/^name:\s*(.+)$/m)?.[1]?.trim();
+  const description = block.match(/^description:\s*(.+)$/m)?.[1]?.trim();
+  if (!name) throw new Error('skill frontmatter missing "name"');
+  if (!description) throw new Error('skill frontmatter missing "description"');
+  return { name, description };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: PASS — 4 pass, 0 fail.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/registry/scripts/skills.ts packages/registry/scripts/skills.test.ts packages/registry/package.json
+git commit -m "feat(skills): add skill frontmatter parser + bun test setup"
+```
+
+---
+
+## Task 2: `resolveCatalog`
+
+**Files:**
+- Modify: `packages/registry/scripts/skills.ts`
+- Test: `packages/registry/scripts/skills.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skills.test.ts`:
+
+```ts
+import { resolveCatalog } from './skills';
+
+describe('resolveCatalog', () => {
+  test('groups published names by category in fixed order, sorted, skipping empties', () => {
+    const catalog = resolveCatalog([
+      { category: 'react-hook-form', publishedName: 'rhf-input-field' },
+      { category: 'components', publishedName: 'side-dialog' },
+      { category: 'components', publishedName: 'copy-button' },
+      { category: 'react-hook-form', publishedName: 'rhf-address-field' },
+      { category: 'lib', publishedName: 'time' },
+    ]);
+    expect(catalog).toBe(
+      '**components**\n' +
+        '- `copy-button`\n' +
+        '- `side-dialog`\n\n' +
+        '**react-hook-form**\n' +
+        '- `rhf-address-field`\n' +
+        '- `rhf-input-field`',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: FAIL — `export named 'resolveCatalog' not found`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `skills.ts`:
+
+```ts
+export interface CatalogItem {
+  category: string;
+  publishedName: string;
+}
+
+const CATALOG_ORDER = ['components', 'blocks', 'react-hook-form', 'tanstack-form', 'tanstack-query'];
+
+export function resolveCatalog(items: CatalogItem[]): string {
+  const sections: string[] = [];
+  for (const category of CATALOG_ORDER) {
+    const names = items
+      .filter((i) => i.category === category)
+      .map((i) => i.publishedName)
+      .sort((a, b) => a.localeCompare(b));
+    if (names.length === 0) continue;
+    const lines = names.map((n) => `- \`${n}\``).join('\n');
+    sections.push(`**${category}**\n${lines}`);
+  }
+  return sections.join('\n\n');
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: PASS — all tests pass (`lib` excluded, categories ordered, names sorted).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/registry/scripts/skills.ts packages/registry/scripts/skills.test.ts
+git commit -m "feat(skills): resolve item catalog markdown from registry items"
+```
+
+---
+
+## Task 3: `applyCatalog` (marker replacement)
+
+**Files:**
+- Modify: `packages/registry/scripts/skills.ts`
+- Test: `packages/registry/scripts/skills.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skills.test.ts`:
+
+```ts
+import { applyCatalog } from './skills';
+
+describe('applyCatalog', () => {
+  test('replaces content between markers, keeping the markers', () => {
+    const src = 'before\n<!-- shuip:catalog:start -->\nOLD\nLINES\n<!-- shuip:catalog:end -->\nafter\n';
+    const out = applyCatalog(src, '**components**\n- `x`');
+    expect(out).toBe(
+      'before\n<!-- shuip:catalog:start -->\n**components**\n- `x`\n<!-- shuip:catalog:end -->\nafter\n',
+    );
+  });
+
+  test('returns source unchanged when no start marker is present', () => {
+    const src = '# overview\nno markers here\n';
+    expect(applyCatalog(src, 'ANY')).toBe(src);
+  });
+
+  test('is idempotent when re-applied with the same catalog', () => {
+    const src = '<!-- shuip:catalog:start -->\nA\n<!-- shuip:catalog:end -->\n';
+    const once = applyCatalog(src, '**components**\n- `x`');
+    expect(applyCatalog(once, '**components**\n- `x`')).toBe(once);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: FAIL — `export named 'applyCatalog' not found`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `skills.ts` (the marker strings contain no regex metacharacters, so they are used directly):
+
+```ts
+const CATALOG_START = '<!-- shuip:catalog:start -->';
+const CATALOG_END = '<!-- shuip:catalog:end -->';
+
+export function applyCatalog(source: string, catalog: string): string {
+  if (!source.includes(CATALOG_START)) return source;
+  const region = new RegExp(`${CATALOG_START}\\n[\\s\\S]*?\\n${CATALOG_END}`);
+  return source.replace(region, `${CATALOG_START}\n${catalog}\n${CATALOG_END}`);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: PASS — all three `applyCatalog` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/registry/scripts/skills.ts packages/registry/scripts/skills.test.ts
+git commit -m "feat(skills): replace catalog marker region in skill source"
+```
+
+---
+
+## Task 4: `assertUniqueNames` (collision guard)
+
+**Files:**
+- Modify: `packages/registry/scripts/skills.ts`
+- Test: `packages/registry/scripts/skills.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skills.test.ts`:
+
+```ts
+import { assertUniqueNames } from './skills';
+
+describe('assertUniqueNames', () => {
+  test('passes when there is no overlap', () => {
+    expect(() => assertUniqueNames(['side-dialog', 'rhf-input-field'], ['shuip-forms'])).not.toThrow();
+  });
+
+  test('throws naming the colliding item', () => {
+    expect(() => assertUniqueNames(['shuip-forms', 'side-dialog'], ['shuip-forms'])).toThrow(
+      'collide with component items: shuip-forms',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: FAIL — `export named 'assertUniqueNames' not found`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `skills.ts`:
+
+```ts
+export function assertUniqueNames(componentNames: string[], skillNames: string[]): void {
+  const taken = new Set(componentNames);
+  const clash = skillNames.filter((n) => taken.has(n));
+  if (clash.length > 0) {
+    throw new Error(`skill name(s) collide with component items: ${clash.join(', ')}`);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/registry/scripts/skills.ts packages/registry/scripts/skills.test.ts
+git commit -m "feat(skills): guard against skill/component name collisions"
+```
+
+---
+
+## Task 5: `emitSkills` orchestrator + bundle
+
+**Files:**
+- Modify: `packages/registry/scripts/skills.ts`
+- Test: `packages/registry/scripts/skills.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skills.test.ts` (an integration test over a temp fixture dir):
+
+```ts
+import { afterAll, beforeAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { emitSkills } from './skills';
+
+describe('emitSkills', () => {
+  let root: string;
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'shuip-skills-'));
+    const skillsDir = path.join(root, 'skills');
+    fs.mkdirSync(path.join(skillsDir, 'demo'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillsDir, 'demo', 'SKILL.md'),
+      '---\nname: demo\ndescription: A demo.\n---\n<!-- shuip:catalog:start -->\nOLD\n<!-- shuip:catalog:end -->\n',
+    );
+  });
+  afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  test('writes resolved files and returns skill items + bundle', () => {
+    const skillsDir = path.join(root, 'skills');
+    const items = emitSkills({
+      skillsDir,
+      generatedDir: path.join(skillsDir, '.generated'),
+      registryRoot: root,
+      catalog: '**components**\n- `x`',
+      registryBaseUrl: 'https://shuip.plvo.dev/r',
+      bundleName: 'shuip-skills',
+    });
+
+    const written = fs.readFileSync(path.join(skillsDir, '.generated', 'demo', 'SKILL.md'), 'utf-8');
+    expect(written).toContain('**components**\n- `x`');
+    expect(written).not.toContain('OLD');
+
+    expect(items).toEqual([
+      {
+        name: 'demo',
+        type: 'registry:item',
+        files: [{ path: './skills/.generated/demo/SKILL.md', type: 'registry:file', target: '.claude/skills/demo/SKILL.md' }],
+      },
+      {
+        name: 'shuip-skills',
+        type: 'registry:item',
+        registryDependencies: ['https://shuip.plvo.dev/r/demo'],
+      },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: FAIL — `export named 'emitSkills' not found`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add the imports at the top of `skills.ts` (above the existing functions):
+
+```ts
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RegistryItem } from './generate';
+```
+
+Append to `skills.ts`:
+
+```ts
+export interface EmitSkillsOptions {
+  skillsDir: string;
+  generatedDir: string;
+  registryRoot: string;
+  catalog: string;
+  registryBaseUrl: string;
+  bundleName: string;
+}
+
+export function emitSkills(opts: EmitSkillsOptions): RegistryItem[] {
+  const { skillsDir, generatedDir, registryRoot, catalog, registryBaseUrl, bundleName } = opts;
+  fs.rmSync(generatedDir, { recursive: true, force: true });
+  if (!fs.existsSync(skillsDir)) return [];
+
+  const dirs = fs
+    .readdirSync(skillsDir)
+    .filter((d) => d !== '.generated' && fs.statSync(path.join(skillsDir, d)).isDirectory())
+    .sort();
+
+  const items: RegistryItem[] = [];
+  const skillNames: string[] = [];
+
+  for (const dir of dirs) {
+    const skillMd = path.join(skillsDir, dir, 'SKILL.md');
+    if (!fs.existsSync(skillMd)) {
+      console.warn(`[generate] skipping skill ${dir}: no SKILL.md`);
+      continue;
+    }
+    const source = fs.readFileSync(skillMd, 'utf-8');
+    const { name } = parseSkillFrontmatter(source);
+    const resolved = applyCatalog(source, catalog);
+    const outPath = path.join(generatedDir, name, 'SKILL.md');
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, resolved);
+    const relPath = path.relative(registryRoot, outPath).replace(/\\/g, '/');
+    items.push({
+      name,
+      type: 'registry:item',
+      files: [{ path: `./${relPath}`, type: 'registry:file', target: `.claude/skills/${name}/SKILL.md` }],
+    });
+    skillNames.push(name);
+  }
+
+  if (skillNames.length > 0) {
+    items.push({
+      name: bundleName,
+      type: 'registry:item',
+      registryDependencies: skillNames.map((n) => `${registryBaseUrl}/${n}`),
+    });
+  }
+
+  return items;
+}
+```
+
+Note: `import type { RegistryItem }` is erased at runtime — `skills.ts` never executes `generate.ts`, so there is no circular dependency. `RegistryItem` is widened to accept this shape in Task 6; until then `bun test` (which strips the type import) passes, but `tsc` would flag the type — that is expected and resolved in the next task.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/registry && bun test scripts/skills.test.ts`
+Expected: PASS — resolved file written with catalog substituted, two items returned (skill + bundle).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/registry/scripts/skills.ts packages/registry/scripts/skills.test.ts
+git commit -m "feat(skills): emit resolved skill files and registry items"
+```
+
+---
+
+## Task 6: Wire `emitSkills` into `generate.ts`
+
+**Files:**
+- Modify: `packages/registry/scripts/generate.ts:11-23` (export + widen types), `:341-351` (`main`)
+
+- [ ] **Step 1: Export and widen the registry types**
+
+Replace the `RegistryFile` and `RegistryItem` interface declarations (`generate.ts:11-23`) with:
+
+```ts
+export interface RegistryFile {
+  path: string;
+  type: 'registry:ui' | 'registry:block' | 'registry:lib' | 'registry:file';
+  target?: string;
+}
+
+export interface RegistryItem {
+  name: string;
+  type: 'registry:ui' | 'registry:block' | 'registry:lib' | 'registry:item';
+  dependencies?: string[];
+  registryDependencies?: string[];
+  files?: RegistryFile[];
+}
+```
+
+- [ ] **Step 2: Import the skills module**
+
+Add to the import block at the top of `generate.ts` (after the `node:path` import):
+
+```ts
+import { assertUniqueNames, emitSkills, resolveCatalog } from './skills';
+```
+
+- [ ] **Step 3: Add skills directory constants**
+
+After the existing `const COMPONENTS_CONTENT_DIR = ...` line (`generate.ts:9`), add:
+
+```ts
+const SKILLS_DIR = path.join(ROOT, 'skills');
+const SKILLS_GENERATED_DIR = path.join(SKILLS_DIR, '.generated');
+```
+
+- [ ] **Step 4: Merge skill items in `main()`**
+
+Replace the `main` function (`generate.ts:341-351`) with:
+
+```ts
+const main = () => {
+  const items = scanItems();
+  const registry = buildRegistryJson(items);
+
+  const catalogItems = items.map((i) => ({
+    category: i.category,
+    publishedName: namePrefix(i.category, i.folderName),
+  }));
+  const skillItems = emitSkills({
+    skillsDir: SKILLS_DIR,
+    generatedDir: SKILLS_GENERATED_DIR,
+    registryRoot: ROOT,
+    catalog: resolveCatalog(catalogItems),
+    registryBaseUrl: 'https://shuip.plvo.dev/r',
+    bundleName: 'shuip-skills',
+  });
+  assertUniqueNames(
+    registry.items.map((i) => i.name),
+    skillItems.map((i) => i.name),
+  );
+  registry.items.push(...skillItems);
+  registry.items.sort((a, b) => a.name.localeCompare(b.name));
+
+  fs.writeFileSync(path.join(ROOT, 'registry.json'), `${JSON.stringify(registry, null, 2)}\n`);
+  fs.writeFileSync(path.join(ROOT, '__index__.ts'), buildIndexTs(items));
+  writeStubs(items);
+  writeComponentSymlinks(items);
+  console.log(`[generate] ${items.length} items + ${skillItems.length} skill items processed`);
+};
+```
+
+- [ ] **Step 5: Typecheck the package**
+
+Run: `cd packages/registry && bunx tsc --noEmit`
+Expected: PASS — no type errors (the `RegistryItem` widening makes `skillItems` assignable; the type-only import resolves).
+
+- [ ] **Step 6: Run the generator**
+
+Run: `cd packages/registry && bun run scripts/generate.ts`
+Expected: STDOUT ends with `[generate] 46 items + 4 skill items processed` (42 component items + 4 lib/etc. as currently reported, plus 4 skill items = 3 skills + 1 bundle). Confirm the skill-item count is exactly `4` and there are no `skipping skill` warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/registry/scripts/generate.ts
+git commit -m "feat(skills): merge skill items into registry generation"
+```
+
+---
+
+## Task 7: Catalog source snapshot + gitignore
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `packages/registry/skills/shuip-components/SKILL.md` (catalog marker region)
+
+- [ ] **Step 1: Ignore the generated skills directory**
+
+In `.gitignore`, under the `# registry` block (after the `stubs/` line at `:61`), add:
+
+```
+packages/registry/skills/.generated/
+```
+
+- [ ] **Step 2: Verify the generated dir is now ignored**
+
+Run: `git check-ignore packages/registry/skills/.generated/shuip-forms/SKILL.md`
+Expected: STDOUT prints the path (it is ignored). If it prints nothing, the pattern is wrong — fix before continuing.
+
+- [ ] **Step 3: Align the source catalog snapshot with generator output**
+
+Open the generated file the generator just wrote and copy its marker region into the source so the human-readable source matches what ships. Run:
+
+```bash
+sed -n '/<!-- shuip:catalog:start -->/,/<!-- shuip:catalog:end -->/p' \
+  packages/registry/skills/.generated/shuip-components/SKILL.md
+```
+
+Replace the entire region between `<!-- shuip:catalog:start -->` and `<!-- shuip:catalog:end -->` in `packages/registry/skills/shuip-components/SKILL.md` with that output. It must read exactly:
+
+```
+<!-- shuip:catalog:start -->
+**components**
+- `confirmation-dialog`
+- `copy-button`
+- `hover-reveal`
+- `side-dialog`
+- `submit-button`
+- `theme-button`
+
+**blocks**
+- `kanban`
+- `responsive-dialog`
+- `title-section`
+
+**react-hook-form**
+- `rhf-address-field`
+- `rhf-autocomplete-field`
+- `rhf-checkbox-field`
+- `rhf-date-field`
+- `rhf-date-range-field`
+- `rhf-datetime-field`
+- `rhf-inline-edit`
+- `rhf-input-field`
+- `rhf-month-field`
+- `rhf-number-field`
+- `rhf-password-field`
+- `rhf-radio-field`
+- `rhf-select-field`
+- `rhf-textarea-field`
+- `rhf-time-field`
+- `rhf-time-range`
+
+**tanstack-form**
+- `tsf-autocomplete-field`
+- `tsf-checkbox-field`
+- `tsf-date-field`
+- `tsf-date-range-field`
+- `tsf-datetime-field`
+- `tsf-form-context`
+- `tsf-inline-edit`
+- `tsf-input-field`
+- `tsf-month-field`
+- `tsf-password-field`
+- `tsf-radio-field`
+- `tsf-select-field`
+- `tsf-submit-button`
+- `tsf-textarea-field`
+- `tsf-time-field`
+- `tsf-time-range`
+
+**tanstack-query**
+- `tsq-query-boundary`
+<!-- shuip:catalog:end -->
+```
+
+(If the generated output differs from the above — e.g. an item was added since this plan — trust the generated output; it is the source of truth.)
+
+- [ ] **Step 4: Re-run the generator and confirm the source region is stable**
+
+Run: `cd packages/registry && bun run scripts/generate.ts && diff <(sed -n '/<!-- shuip:catalog:start -->/,/<!-- shuip:catalog:end -->/p' skills/shuip-components/SKILL.md) <(sed -n '/<!-- shuip:catalog:start -->/,/<!-- shuip:catalog:end -->/p' skills/.generated/shuip-components/SKILL.md)`
+Expected: no diff output (source snapshot equals shipped catalog).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .gitignore packages/registry/skills/shuip-components/SKILL.md
+git commit -m "feat(skills): ignore generated skills dir and snapshot catalog"
+```
+
+---
+
+## Task 8: Build the registry and prove the install payload
+
+**Files:** none modified (verification only; outputs under `apps/docs/public/r/` are gitignored).
+
+- [ ] **Step 1: Build the public registry JSON**
+
+Run: `bun registry:build`
+Expected: STDOUT `[shadcn-build] N items written ...` with N = component items + 4. No Zod validation error (proves the files-less bundle and `registry:file` skill items pass the schema — Flag 1 + Flag 2).
+
+- [ ] **Step 2: Verify a skill item inlines its content and targets `.claude/`**
+
+Run:
+```bash
+cat apps/docs/public/r/shuip-forms.json | bun -e 'const j=JSON.parse(require("fs").readFileSync(0));console.log(j.type, j.files[0].type, j.files[0].target, j.files[0].content.includes("Building forms with shuip"))'
+```
+Expected: `registry:item registry:file .claude/skills/shuip-forms/SKILL.md true`
+
+- [ ] **Step 3: Verify the bundle aggregates the three skills with full URLs**
+
+Run:
+```bash
+cat apps/docs/public/r/shuip-skills.json | bun -e 'const j=JSON.parse(require("fs").readFileSync(0));console.log(j.type, j.files??"no-files", JSON.stringify(j.registryDependencies))'
+```
+Expected: `registry:item no-files ["https://shuip.plvo.dev/r/shuip-components","https://shuip.plvo.dev/r/shuip-forms","https://shuip.plvo.dev/r/shuip-overview"]`
+
+- [ ] **Step 4: Verify shuip-components ships the generated catalog**
+
+Run:
+```bash
+cat apps/docs/public/r/shuip-components.json | bun -e 'const j=JSON.parse(require("fs").readFileSync(0));const c=j.files[0].content;console.log(c.includes("- `rhf-input-field`") && c.includes("- `tsf-form-context`") && !c.includes("shuip:catalog:start") === false)'
+```
+Expected: `true` (catalog names present; markers still wrap them).
+
+- [ ] **Step 5 (optional, real end-to-end install):** Serve and install into a throwaway app.
+
+```bash
+# terminal A: serve the built registry
+bunx serve apps/docs/public -p 8741
+# terminal B:
+cd "$(mktemp -d)" && npm create next-app@latest app --yes >/dev/null 2>&1 && cd app
+npx shadcn@latest init --yes >/dev/null 2>&1
+npx shadcn@latest add "http://localhost:8741/r/shuip-forms.json"
+test -f .claude/skills/shuip-forms/SKILL.md && echo "INSTALLED OK"
+```
+Expected: `INSTALLED OK` and the file contains the forms skill. (Skip if no network for `create next-app`; Steps 1-4 already prove the payload deterministically.)
+
+- [ ] **Step 6: No commit** — all outputs here are gitignored. Proceed to Task 9.
+
+---
+
+## Task 9: Full build gate + final verification
+
+**Files:** none modified (verification only).
+
+- [ ] **Step 1: Run the unit tests once more**
+
+Run: `cd packages/registry && bun test`
+Expected: PASS — all `skills.test.ts` tests green.
+
+- [ ] **Step 2: Run the authoritative type/build gate**
+
+Run: `NODE_OPTIONS=--max-old-space-size=6144 bun build:docs`
+Expected: success (chains `registry:generate` → `registry:build` → `next build`). The heap flag avoids the known WSL2 OOM (exit 137).
+
+- [ ] **Step 3: Confirm the working tree has only source changes**
+
+Run: `git status --short`
+Expected: clean (everything committed; no stray `registry.json`, `.generated/`, `stubs/`, or `public/r/` changes — all gitignored).
+
+- [ ] **Step 4: Confirm the skills are absent from the live-preview index**
+
+Run: `grep -c 'shuip-forms' packages/registry/__index__.ts || echo 0`
+Expected: `0` — skills are docs, not React components, so they must not appear in `REGISTRY_INDEX`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Source layout / `.generated/` (spec §1) → Tasks 5, 7.
+- Registry item shape, project-relative target, files-less bundle with full URLs (spec §2) → Tasks 5, 8.
+- Generation flow: scan, resolveCatalog from in-memory items, marker replace, merge, collision assert (spec §3) → Tasks 2-6.
+- Skill content (spec §4) → already authored/committed; not in this plan.
+- Docs page (spec §5) → deferred, intentionally out of scope.
+- Silent-failure guards: missing SKILL.md warn, missing frontmatter throw, `.generated/` gitignored, collision throw (spec §6) → Tasks 1 (frontmatter), 4 (collision), 5 (missing-file warn), 7 (gitignore).
+- Validation: generator assertions, build, smoke test (spec §7) → Tasks 6, 8, 9.
+- Open flags (files-less bundle, generic build) → resolved in plan preamble; proven in Task 8.
+- New finding: skill items omit `title`/`description` → reflected in Task 5 item shape.
+
+**Placeholder scan:** none — every code/command step has concrete content.
+
+**Type consistency:** `RegistryItem`/`RegistryFile` widened in Task 6 match the objects `emitSkills` returns in Task 5; `CatalogItem` (Task 2) matches the `catalogItems` shape passed in Task 6; `emitSkills` option names are identical between Task 5 implementation, its test, and the Task 6 call site; `parseSkillFrontmatter`/`applyCatalog`/`resolveCatalog`/`assertUniqueNames` signatures are stable across tasks.

--- a/docs/superpowers/plans/2026-05-27-shuip-agent-skills-generator-wiring.md
+++ b/docs/superpowers/plans/2026-05-27-shuip-agent-skills-generator-wiring.md
@@ -555,7 +555,7 @@ Expected: PASS — no type errors (the `RegistryItem` widening makes `skillItems
 - [ ] **Step 6: Run the generator**
 
 Run: `cd packages/registry && bun run scripts/generate.ts`
-Expected: STDOUT ends with `[generate] 46 items + 4 skill items processed` (42 component items + 4 lib/etc. as currently reported, plus 4 skill items = 3 skills + 1 bundle). Confirm the skill-item count is exactly `4` and there are no `skipping skill` warnings.
+Expected: STDOUT ends with `[generate] 43 items + 4 skill items processed` (43 scanned item dirs, plus 4 skill items = 3 skills + 1 bundle). The leading count must equal the pre-change run; the suffix `+ 4 skill items` is the key assertion. There must be no `skipping skill` warnings.
 
 - [ ] **Step 7: Commit**
 
@@ -675,7 +675,7 @@ git commit -m "feat(skills): ignore generated skills dir and snapshot catalog"
 - [ ] **Step 1: Build the public registry JSON**
 
 Run: `bun registry:build`
-Expected: STDOUT `[shadcn-build] N items written ...` with N = component items + 4. No Zod validation error (proves the files-less bundle and `registry:file` skill items pass the schema — Flag 1 + Flag 2).
+Expected: STDOUT `[shadcn-build] 47 items written ...` (43 component items + 4 skill items). No Zod validation error (proves the files-less bundle and `registry:file` skill items pass the schema — Flag 1 + Flag 2).
 
 - [ ] **Step 2: Verify a skill item inlines its content and targets `.claude/`**
 

--- a/docs/superpowers/specs/2026-05-27-shuip-agent-skills-design.md
+++ b/docs/superpowers/specs/2026-05-27-shuip-agent-skills-design.md
@@ -1,0 +1,128 @@
+# shuip Agent Skills — Design
+
+Date: 2026-05-27
+Status: Approved (brainstorming) — pending implementation
+Branch: `feat/agent-skills`
+
+## Goal
+
+Ship agent skills alongside shuip's components so a downstream developer's coding
+agent learns to: present shuip and its purpose, contextualize components (when/how
+to use them), and build a prod-grade form with react-hook-form and tanstack-form.
+
+## Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Audience | Portable vision (any coding agent); **MVP ships Claude Code `SKILL.md` only**. Authoring layer stays format-agnostic so Cursor `.mdc` / AGENTS emission is additive later. |
+| Granularity | **3 skills, layered by purpose**: `shuip-overview`, `shuip-components`, `shuip-forms`. |
+| Packaging | Each skill is a standalone registry item, **plus a `shuip-skills` bundle** that pulls all three. |
+| Forms scope | Guidance over **existing** `rhf-*`/`tsf-*` items (both libs + when to choose). **No new components.** |
+| Generator integration | **Approach B**: parallel `skills/` source tree + a focused emit pass that merges into the shared `registry.json`. Component pipeline untouched. |
+| Catalog sync | **Auto-embed** a catalog generated from the in-memory component list, so overview/components skills never drift. |
+| Docs site page | **Deferred** — out of MVP scope. |
+
+## 1. Source layout
+
+A tree sibling to `items/`, because skills are a different kind of artifact (agent
+docs, not React components):
+
+```
+packages/registry/skills/
+  shuip-overview/SKILL.md
+  shuip-components/SKILL.md
+  shuip-forms/SKILL.md
+  .generated/<name>/SKILL.md      catalog-resolved output, gitignored
+```
+
+`SKILL.md` is the source of truth: Claude Code frontmatter (`name`, `description`)
+plus body. The body may contain a catalog token (see §3). Folder name == published
+registry name; the `shuip-` prefix namespaces skills away from component item names,
+so no collision.
+
+## 2. Registry item shape
+
+Each skill emits one `registry:item` with a single `registry:file`, target
+**project-relative** so it lands in the consumer's repo and versions with their code:
+
+```json
+{
+  "name": "shuip-forms",
+  "type": "registry:item",
+  "title": "shuip Forms",
+  "description": "Build prod-grade forms with shuip's rhf/tsf field items.",
+  "files": [{
+    "path": "./skills/.generated/shuip-forms/SKILL.md",
+    "type": "registry:file",
+    "target": ".claude/skills/shuip-forms/SKILL.md"
+  }]
+}
+```
+
+The **bundle** `shuip-skills` is a files-less aggregator using `registryDependencies`
+(full URLs, matching the existing install-command style) to pull all three skills.
+
+> **Open flag (verify in plan):** confirm shadcn accepts a files-less `registry:item`.
+> If not, the bundle carries a tiny README file as its single `registry:file`.
+
+## 3. Generation flow (Approach B)
+
+A focused skills pass added to `generate.ts`, running **after** `scanItems()` so it
+reuses the in-memory component list — the catalog is generated from the exact same
+source that builds `registry.json`, in one run:
+
+1. `scanSkills()` — read each `SKILL.md`, parse frontmatter, validate `name` + `description` present.
+2. `resolveCatalog(items)` — build a "current items by category" markdown block from the scanned components.
+3. Replace `<!-- shuip:catalog [category="..."] -->` token → write the resolved file to `skills/.generated/<name>/SKILL.md`.
+4. `buildSkillRegistryItems()` — produce the items, merge into the same `registry.json` array, re-sort, assert name-uniqueness against component items.
+
+`registry:build` (`scripts/shadcn-build.ts`) then emits `public/r/shuip-*.json`
+automatically — skills are standard registry items.
+
+> **Open flag (verify in plan):** confirm `shadcn-build.ts` iterates items generically
+> and inlines `registry:file` content.
+
+## 4. The three skills — content outline
+
+- **`shuip-overview`** — *trigger:* working in a shuip project. What shuip is, the
+  `npx shadcn add https://shuip.plvo.dev/r/<name>` model, the categories, full
+  `<!-- shuip:catalog -->`, and routing ("for forms → shuip-forms; for picking →
+  shuip-components").
+- **`shuip-components`** — *trigger:* choosing/composing components. Decision guidance
+  per category, composition patterns, `<!-- shuip:catalog category="components,blocks" -->`,
+  doc links.
+- **`shuip-forms`** (flagship) — *trigger:* building a form. Choosing rhf vs tsf; zod
+  schema; wiring the `rhf-*`/`tsf-*` field items (the `register` prop pattern from
+  `input-field`); server-action submission; error/loading/disabled states; a11y; one
+  complete annotated example assembled from existing items. **No new components.**
+
+## 5. Docs site
+
+Deferred. A short guide page under the existing `docs` collection presenting the skills
+and their `shadcn add` commands may be added later; not in MVP.
+
+## 6. Silent-failure guards
+
+Per shuip's `debugging-shuip-silent-failures` ethos:
+
+- Missing `SKILL.md` → `[generate] skipping skill <name>` warning (mirrors the component scanner).
+- Missing/empty `name` or `description` frontmatter → **fail loudly** (skill won't trigger otherwise).
+- Catalog token with unknown category → warn.
+- `.generated/` added to `.gitignore` (honors "generated artifacts never committed").
+- Skill/component name collision → throw on merge.
+
+## 7. Validation
+
+No test runner is configured (per CLAUDE.md). MVP validation:
+
+- Generator assertions: item counts, resolved tokens, no unexpected warnings.
+- `bun build:docs` end-to-end.
+- Manual `shadcn add` smoke test into a scratch dir → confirm
+  `.claude/skills/shuip-forms/SKILL.md` lands with inlined content.
+
+A formal automated test setup will be **proposed before** any tests are written, per CLAUDE.md.
+
+## Open flags to resolve during planning
+
+1. Files-less bundle `registry:item` accepted by shadcn? (else bundle ships a README file)
+2. `shadcn-build.ts` handles `registry:item` + `registry:file` generically?

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -9,7 +9,8 @@
     "./stubs/*": "./stubs/*"
   },
   "scripts": {
-    "registry:generate": "bun run scripts/generate.ts"
+    "registry:generate": "bun run scripts/generate.ts",
+    "test": "bun test"
   },
   "dependencies": {
     "react": "catalog:",

--- a/packages/registry/scripts/generate.ts
+++ b/packages/registry/scripts/generate.ts
@@ -2,24 +2,27 @@
 /** biome-ignore-all lint/suspicious/noAssignInExpressions: script */
 import fs from 'node:fs';
 import path from 'node:path';
+import { assertUniqueNames, emitSkills, resolveCatalog } from './skills';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const ITEMS_DIR = path.join(ROOT, 'items');
 const STUBS_DIR = path.join(ROOT, 'stubs');
 const COMPONENTS_CONTENT_DIR = path.resolve(ROOT, '../../apps/docs/content/components');
+const SKILLS_DIR = path.join(ROOT, 'skills');
+const SKILLS_GENERATED_DIR = path.join(SKILLS_DIR, '.generated');
 
-interface RegistryFile {
+export interface RegistryFile {
   path: string;
   type: 'registry:ui' | 'registry:block' | 'registry:lib' | 'registry:file';
   target?: string;
 }
 
-interface RegistryItem {
+export interface RegistryItem {
   name: string;
-  type: 'registry:ui' | 'registry:block' | 'registry:lib';
+  type: 'registry:ui' | 'registry:block' | 'registry:lib' | 'registry:item';
   dependencies?: string[];
   registryDependencies?: string[];
-  files: RegistryFile[];
+  files?: RegistryFile[];
 }
 
 interface ItemMeta {
@@ -341,11 +344,31 @@ const writeComponentSymlinks = (items: ScannedItem[]): void => {
 const main = () => {
   const items = scanItems();
   const registry = buildRegistryJson(items);
+
+  const catalogItems = items.map((i) => ({
+    category: i.category,
+    publishedName: namePrefix(i.category, i.folderName),
+  }));
+  const skillItems = emitSkills({
+    skillsDir: SKILLS_DIR,
+    generatedDir: SKILLS_GENERATED_DIR,
+    registryRoot: ROOT,
+    catalog: resolveCatalog(catalogItems),
+    registryBaseUrl: 'https://shuip.plvo.dev/r',
+    bundleName: 'shuip-skills',
+  });
+  assertUniqueNames(
+    registry.items.map((i) => i.name),
+    skillItems.map((i) => i.name),
+  );
+  registry.items.push(...skillItems);
+  registry.items.sort((a, b) => a.name.localeCompare(b.name));
+
   fs.writeFileSync(path.join(ROOT, 'registry.json'), `${JSON.stringify(registry, null, 2)}\n`);
   fs.writeFileSync(path.join(ROOT, '__index__.ts'), buildIndexTs(items));
   writeStubs(items);
   writeComponentSymlinks(items);
-  console.log(`[generate] ${items.length} items processed`);
+  console.log(`[generate] ${items.length} items + ${skillItems.length} skill items processed`);
 };
 
 main();

--- a/packages/registry/scripts/generate.ts
+++ b/packages/registry/scripts/generate.ts
@@ -2,7 +2,7 @@
 /** biome-ignore-all lint/suspicious/noAssignInExpressions: script */
 import fs from 'node:fs';
 import path from 'node:path';
-import { assertUniqueNames, emitSkills, resolveCatalog } from './skills';
+import { applySkillSourcesToDocs, assertUniqueNames, emitSkills, resolveCatalog } from './skills';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const ITEMS_DIR = path.join(ROOT, 'items');
@@ -10,6 +10,7 @@ const STUBS_DIR = path.join(ROOT, 'stubs');
 const COMPONENTS_CONTENT_DIR = path.resolve(ROOT, '../../apps/docs/content/components');
 const SKILLS_DIR = path.join(ROOT, 'skills');
 const SKILLS_GENERATED_DIR = path.join(SKILLS_DIR, '.generated');
+const AGENT_SKILLS_DOC = path.resolve(ROOT, '../../apps/docs/content/docs/agent-skills.mdx');
 
 export interface RegistryFile {
   path: string;
@@ -349,7 +350,7 @@ const main = () => {
     category: i.category,
     publishedName: namePrefix(i.category, i.folderName),
   }));
-  const skillItems = emitSkills({
+  const { items: skillItems, sources: skillSources } = emitSkills({
     skillsDir: SKILLS_DIR,
     generatedDir: SKILLS_GENERATED_DIR,
     registryRoot: ROOT,
@@ -368,6 +369,13 @@ const main = () => {
   fs.writeFileSync(path.join(ROOT, '__index__.ts'), buildIndexTs(items));
   writeStubs(items);
   writeComponentSymlinks(items);
+
+  if (fs.existsSync(AGENT_SKILLS_DOC)) {
+    const docs = fs.readFileSync(AGENT_SKILLS_DOC, 'utf-8');
+    const rewritten = applySkillSourcesToDocs(docs, skillSources);
+    if (rewritten !== docs) fs.writeFileSync(AGENT_SKILLS_DOC, rewritten);
+  }
+
   console.log(`[generate] ${items.length} items + ${skillItems.length} skill items processed`);
 };
 

--- a/packages/registry/scripts/skills.test.ts
+++ b/packages/registry/scripts/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { applyCatalog, parseSkillFrontmatter, resolveCatalog } from './skills';
+import { applyCatalog, assertUniqueNames, parseSkillFrontmatter, resolveCatalog } from './skills';
 
 describe('parseSkillFrontmatter', () => {
   test('extracts name and description', () => {
@@ -61,5 +61,17 @@ describe('applyCatalog', () => {
     const src = '<!-- shuip:catalog:start -->\nA\n<!-- shuip:catalog:end -->\n';
     const once = applyCatalog(src, '**components**\n- `x`');
     expect(applyCatalog(once, '**components**\n- `x`')).toBe(once);
+  });
+});
+
+describe('assertUniqueNames', () => {
+  test('passes when there is no overlap', () => {
+    expect(() => assertUniqueNames(['side-dialog', 'rhf-input-field'], ['shuip-forms'])).not.toThrow();
+  });
+
+  test('throws naming the colliding item', () => {
+    expect(() => assertUniqueNames(['shuip-forms', 'side-dialog'], ['shuip-forms'])).toThrow(
+      'collide with component items: shuip-forms',
+    );
   });
 });

--- a/packages/registry/scripts/skills.test.ts
+++ b/packages/registry/scripts/skills.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { parseSkillFrontmatter } from './skills';
+
+describe('parseSkillFrontmatter', () => {
+  test('extracts name and description', () => {
+    const src = '---\nname: shuip-forms\ndescription: Use when building a form.\n---\n\n# body\n';
+    expect(parseSkillFrontmatter(src)).toEqual({
+      name: 'shuip-forms',
+      description: 'Use when building a form.',
+    });
+  });
+
+  test('throws when frontmatter is absent', () => {
+    expect(() => parseSkillFrontmatter('# no frontmatter')).toThrow('missing YAML frontmatter');
+  });
+
+  test('throws when name is missing', () => {
+    expect(() => parseSkillFrontmatter('---\ndescription: x\n---\n')).toThrow('missing "name"');
+  });
+
+  test('throws when description is missing', () => {
+    expect(() => parseSkillFrontmatter('---\nname: x\n---\n')).toThrow('missing "description"');
+  });
+});

--- a/packages/registry/scripts/skills.test.ts
+++ b/packages/registry/scripts/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseSkillFrontmatter, resolveCatalog } from './skills';
+import { applyCatalog, parseSkillFrontmatter, resolveCatalog } from './skills';
 
 describe('parseSkillFrontmatter', () => {
   test('extracts name and description', () => {
@@ -40,5 +40,26 @@ describe('resolveCatalog', () => {
         '- `rhf-address-field`\n' +
         '- `rhf-input-field`',
     );
+  });
+});
+
+describe('applyCatalog', () => {
+  test('replaces content between markers, keeping the markers', () => {
+    const src = 'before\n<!-- shuip:catalog:start -->\nOLD\nLINES\n<!-- shuip:catalog:end -->\nafter\n';
+    const out = applyCatalog(src, '**components**\n- `x`');
+    expect(out).toBe(
+      'before\n<!-- shuip:catalog:start -->\n**components**\n- `x`\n<!-- shuip:catalog:end -->\nafter\n',
+    );
+  });
+
+  test('returns source unchanged when no start marker is present', () => {
+    const src = '# overview\nno markers here\n';
+    expect(applyCatalog(src, 'ANY')).toBe(src);
+  });
+
+  test('is idempotent when re-applied with the same catalog', () => {
+    const src = '<!-- shuip:catalog:start -->\nA\n<!-- shuip:catalog:end -->\n';
+    const once = applyCatalog(src, '**components**\n- `x`');
+    expect(applyCatalog(once, '**components**\n- `x`')).toBe(once);
   });
 });

--- a/packages/registry/scripts/skills.test.ts
+++ b/packages/registry/scripts/skills.test.ts
@@ -2,7 +2,14 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { applyCatalog, assertUniqueNames, emitSkills, parseSkillFrontmatter, resolveCatalog } from './skills';
+import {
+  applyCatalog,
+  applySkillSourcesToDocs,
+  assertUniqueNames,
+  emitSkills,
+  parseSkillFrontmatter,
+  resolveCatalog,
+} from './skills';
 
 describe('parseSkillFrontmatter', () => {
   test('extracts name and description', () => {
@@ -79,6 +86,60 @@ describe('assertUniqueNames', () => {
   });
 });
 
+describe('applySkillSourcesToDocs', () => {
+  test('replaces a single marked region with a 4-backtick md fence containing the source', () => {
+    const docs = 'before\n{/* shuip:skill:start name="a" */}\nOLD\n{/* shuip:skill:end */}\nafter\n';
+    const out = applySkillSourcesToDocs(docs, new Map([['a', '---\nname: a\n---\nbody\n']]));
+    expect(out).toBe(
+      'before\n{/* shuip:skill:start name="a" */}\n````md\n---\nname: a\n---\nbody\n````\n{/* shuip:skill:end */}\nafter\n',
+    );
+  });
+
+  test('replaces multiple marked regions independently', () => {
+    const docs =
+      '{/* shuip:skill:start name="a" */}\nOLD-A\n{/* shuip:skill:end */}\n' +
+      'middle\n' +
+      '{/* shuip:skill:start name="b" */}\nOLD-B\n{/* shuip:skill:end */}\n';
+    const out = applySkillSourcesToDocs(
+      docs,
+      new Map([
+        ['a', 'A\n'],
+        ['b', 'B\n'],
+      ]),
+    );
+    expect(out).toBe(
+      '{/* shuip:skill:start name="a" */}\n````md\nA\n````\n{/* shuip:skill:end */}\n' +
+        'middle\n' +
+        '{/* shuip:skill:start name="b" */}\n````md\nB\n````\n{/* shuip:skill:end */}\n',
+    );
+  });
+
+  test('is idempotent when re-applied with the same sources', () => {
+    const docs = '{/* shuip:skill:start name="a" */}\nOLD\n{/* shuip:skill:end */}\n';
+    const sources = new Map([['a', '---\nname: a\n---\n']]);
+    const once = applySkillSourcesToDocs(docs, sources);
+    expect(applySkillSourcesToDocs(once, sources)).toBe(once);
+  });
+
+  test('returns docs unchanged when no skill markers are present', () => {
+    const docs = '# agent skills\nno markers here\n';
+    expect(applySkillSourcesToDocs(docs, new Map([['a', 'A\n']]))).toBe(docs);
+  });
+
+  test('throws when a marker references an unknown skill', () => {
+    const docs = '{/* shuip:skill:start name="missing" */}\nX\n{/* shuip:skill:end */}\n';
+    expect(() => applySkillSourcesToDocs(docs, new Map([['a', 'A\n']]))).toThrow(
+      'unknown skill "missing" referenced in docs page',
+    );
+  });
+
+  test('normalizes a source without trailing newline', () => {
+    const docs = '{/* shuip:skill:start name="a" */}\nX\n{/* shuip:skill:end */}\n';
+    const out = applySkillSourcesToDocs(docs, new Map([['a', 'no-trailing-nl']]));
+    expect(out).toBe('{/* shuip:skill:start name="a" */}\n````md\nno-trailing-nl\n````\n{/* shuip:skill:end */}\n');
+  });
+});
+
 describe('emitSkills', () => {
   let root: string;
   beforeAll(() => {
@@ -92,9 +153,9 @@ describe('emitSkills', () => {
   });
   afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
 
-  test('writes resolved files and returns skill items + bundle', () => {
+  test('writes resolved files, returns skill items + bundle, and exposes raw sources', () => {
     const skillsDir = path.join(root, 'skills');
-    const items = emitSkills({
+    const result = emitSkills({
       skillsDir,
       generatedDir: path.join(skillsDir, '.generated'),
       registryRoot: root,
@@ -107,7 +168,7 @@ describe('emitSkills', () => {
     expect(written).toContain('**components**\n- `x`');
     expect(written).not.toContain('OLD');
 
-    expect(items).toEqual([
+    expect(result.items).toEqual([
       {
         name: 'demo',
         type: 'registry:item',
@@ -121,5 +182,9 @@ describe('emitSkills', () => {
         registryDependencies: ['https://shuip.plvo.dev/r/demo'],
       },
     ]);
+
+    expect(result.sources.get('demo')).toBe(
+      '---\nname: demo\ndescription: A demo.\n---\n<!-- shuip:catalog:start -->\nOLD\n<!-- shuip:catalog:end -->\n',
+    );
   });
 });

--- a/packages/registry/scripts/skills.test.ts
+++ b/packages/registry/scripts/skills.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from 'bun:test';
-import { applyCatalog, assertUniqueNames, parseSkillFrontmatter, resolveCatalog } from './skills';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { applyCatalog, assertUniqueNames, emitSkills, parseSkillFrontmatter, resolveCatalog } from './skills';
 
 describe('parseSkillFrontmatter', () => {
   test('extracts name and description', () => {
@@ -73,5 +76,50 @@ describe('assertUniqueNames', () => {
     expect(() => assertUniqueNames(['shuip-forms', 'side-dialog'], ['shuip-forms'])).toThrow(
       'collide with component items: shuip-forms',
     );
+  });
+});
+
+describe('emitSkills', () => {
+  let root: string;
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'shuip-skills-'));
+    const skillsDir = path.join(root, 'skills');
+    fs.mkdirSync(path.join(skillsDir, 'demo'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillsDir, 'demo', 'SKILL.md'),
+      '---\nname: demo\ndescription: A demo.\n---\n<!-- shuip:catalog:start -->\nOLD\n<!-- shuip:catalog:end -->\n',
+    );
+  });
+  afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  test('writes resolved files and returns skill items + bundle', () => {
+    const skillsDir = path.join(root, 'skills');
+    const items = emitSkills({
+      skillsDir,
+      generatedDir: path.join(skillsDir, '.generated'),
+      registryRoot: root,
+      catalog: '**components**\n- `x`',
+      registryBaseUrl: 'https://shuip.plvo.dev/r',
+      bundleName: 'shuip-skills',
+    });
+
+    const written = fs.readFileSync(path.join(skillsDir, '.generated', 'demo', 'SKILL.md'), 'utf-8');
+    expect(written).toContain('**components**\n- `x`');
+    expect(written).not.toContain('OLD');
+
+    expect(items).toEqual([
+      {
+        name: 'demo',
+        type: 'registry:item',
+        files: [
+          { path: './skills/.generated/demo/SKILL.md', type: 'registry:file', target: '.claude/skills/demo/SKILL.md' },
+        ],
+      },
+      {
+        name: 'shuip-skills',
+        type: 'registry:item',
+        registryDependencies: ['https://shuip.plvo.dev/r/demo'],
+      },
+    ]);
   });
 });

--- a/packages/registry/scripts/skills.test.ts
+++ b/packages/registry/scripts/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseSkillFrontmatter } from './skills';
+import { parseSkillFrontmatter, resolveCatalog } from './skills';
 
 describe('parseSkillFrontmatter', () => {
   test('extracts name and description', () => {
@@ -20,5 +20,25 @@ describe('parseSkillFrontmatter', () => {
 
   test('throws when description is missing', () => {
     expect(() => parseSkillFrontmatter('---\nname: x\n---\n')).toThrow('missing "description"');
+  });
+});
+
+describe('resolveCatalog', () => {
+  test('groups published names by category in fixed order, sorted, skipping empties', () => {
+    const catalog = resolveCatalog([
+      { category: 'react-hook-form', publishedName: 'rhf-input-field' },
+      { category: 'components', publishedName: 'side-dialog' },
+      { category: 'components', publishedName: 'copy-button' },
+      { category: 'react-hook-form', publishedName: 'rhf-address-field' },
+      { category: 'lib', publishedName: 'time' },
+    ]);
+    expect(catalog).toBe(
+      '**components**\n' +
+        '- `copy-button`\n' +
+        '- `side-dialog`\n\n' +
+        '**react-hook-form**\n' +
+        '- `rhf-address-field`\n' +
+        '- `rhf-input-field`',
+    );
   });
 });

--- a/packages/registry/scripts/skills.ts
+++ b/packages/registry/scripts/skills.ts
@@ -38,3 +38,11 @@ export function applyCatalog(source: string, catalog: string): string {
   const region = new RegExp(`${CATALOG_START}\\n[\\s\\S]*?\\n${CATALOG_END}`);
   return source.replace(region, `${CATALOG_START}\n${catalog}\n${CATALOG_END}`);
 }
+
+export function assertUniqueNames(componentNames: string[], skillNames: string[]): void {
+  const taken = new Set(componentNames);
+  const clash = skillNames.filter((n) => taken.has(n));
+  if (clash.length > 0) {
+    throw new Error(`skill name(s) collide with component items: ${clash.join(', ')}`);
+  }
+}

--- a/packages/registry/scripts/skills.ts
+++ b/packages/registry/scripts/skills.ts
@@ -51,6 +51,19 @@ export function assertUniqueNames(componentNames: string[], skillNames: string[]
   }
 }
 
+const SKILL_REGION_RE = /\{\/\* shuip:skill:start name="([^"]+)" \*\/\}\n([\s\S]*?)\n\{\/\* shuip:skill:end \*\/\}/g;
+
+export function applySkillSourcesToDocs(docs: string, sources: Map<string, string>): string {
+  return docs.replace(SKILL_REGION_RE, (_match, name: string) => {
+    const source = sources.get(name);
+    if (source === undefined) {
+      throw new Error(`unknown skill "${name}" referenced in docs page`);
+    }
+    const normalized = source.endsWith('\n') ? source : `${source}\n`;
+    return `{/* shuip:skill:start name="${name}" */}\n\`\`\`\`md\n${normalized}\`\`\`\`\n{/* shuip:skill:end */}`;
+  });
+}
+
 export interface EmitSkillsOptions {
   skillsDir: string;
   generatedDir: string;
@@ -60,10 +73,15 @@ export interface EmitSkillsOptions {
   bundleName: string;
 }
 
-export function emitSkills(opts: EmitSkillsOptions): RegistryItem[] {
+export interface EmitSkillsResult {
+  items: RegistryItem[];
+  sources: Map<string, string>;
+}
+
+export function emitSkills(opts: EmitSkillsOptions): EmitSkillsResult {
   const { skillsDir, generatedDir, registryRoot, catalog, registryBaseUrl, bundleName } = opts;
   fs.rmSync(generatedDir, { recursive: true, force: true });
-  if (!fs.existsSync(skillsDir)) return [];
+  if (!fs.existsSync(skillsDir)) return { items: [], sources: new Map() };
 
   const dirs = fs
     .readdirSync(skillsDir)
@@ -71,6 +89,7 @@ export function emitSkills(opts: EmitSkillsOptions): RegistryItem[] {
     .sort();
 
   const items: RegistryItem[] = [];
+  const sources = new Map<string, string>();
   const skillNames: string[] = [];
 
   for (const dir of dirs) {
@@ -91,6 +110,7 @@ export function emitSkills(opts: EmitSkillsOptions): RegistryItem[] {
       type: 'registry:item',
       files: [{ path: `./${relPath}`, type: 'registry:file', target: `.claude/skills/${name}/SKILL.md` }],
     });
+    sources.set(name, source);
     skillNames.push(name);
   }
 
@@ -102,5 +122,5 @@ export function emitSkills(opts: EmitSkillsOptions): RegistryItem[] {
     });
   }
 
-  return items;
+  return { items, sources };
 }

--- a/packages/registry/scripts/skills.ts
+++ b/packages/registry/scripts/skills.ts
@@ -8,3 +8,24 @@ export function parseSkillFrontmatter(source: string): { name: string; descripti
   if (!description) throw new Error('skill frontmatter missing "description"');
   return { name, description };
 }
+
+export interface CatalogItem {
+  category: string;
+  publishedName: string;
+}
+
+const CATALOG_ORDER = ['components', 'blocks', 'react-hook-form', 'tanstack-form', 'tanstack-query'];
+
+export function resolveCatalog(items: CatalogItem[]): string {
+  const sections: string[] = [];
+  for (const category of CATALOG_ORDER) {
+    const names = items
+      .filter((i) => i.category === category)
+      .map((i) => i.publishedName)
+      .sort((a, b) => a.localeCompare(b));
+    if (names.length === 0) continue;
+    const lines = names.map((n) => `- \`${n}\``).join('\n');
+    sections.push(`**${category}**\n${lines}`);
+  }
+  return sections.join('\n\n');
+}

--- a/packages/registry/scripts/skills.ts
+++ b/packages/registry/scripts/skills.ts
@@ -29,3 +29,12 @@ export function resolveCatalog(items: CatalogItem[]): string {
   }
   return sections.join('\n\n');
 }
+
+const CATALOG_START = '<!-- shuip:catalog:start -->';
+const CATALOG_END = '<!-- shuip:catalog:end -->';
+
+export function applyCatalog(source: string, catalog: string): string {
+  if (!source.includes(CATALOG_START)) return source;
+  const region = new RegExp(`${CATALOG_START}\\n[\\s\\S]*?\\n${CATALOG_END}`);
+  return source.replace(region, `${CATALOG_START}\n${catalog}\n${CATALOG_END}`);
+}

--- a/packages/registry/scripts/skills.ts
+++ b/packages/registry/scripts/skills.ts
@@ -1,0 +1,10 @@
+export function parseSkillFrontmatter(source: string): { name: string; description: string } {
+  const match = source.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error('skill SKILL.md missing YAML frontmatter');
+  const block = match[1];
+  const name = block.match(/^name:\s*(.+)$/m)?.[1]?.trim();
+  const description = block.match(/^description:\s*(.+)$/m)?.[1]?.trim();
+  if (!name) throw new Error('skill frontmatter missing "name"');
+  if (!description) throw new Error('skill frontmatter missing "description"');
+  return { name, description };
+}

--- a/packages/registry/scripts/skills.ts
+++ b/packages/registry/scripts/skills.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RegistryItem } from './generate';
+
 export function parseSkillFrontmatter(source: string): { name: string; description: string } {
   const match = source.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error('skill SKILL.md missing YAML frontmatter');
@@ -45,4 +49,58 @@ export function assertUniqueNames(componentNames: string[], skillNames: string[]
   if (clash.length > 0) {
     throw new Error(`skill name(s) collide with component items: ${clash.join(', ')}`);
   }
+}
+
+export interface EmitSkillsOptions {
+  skillsDir: string;
+  generatedDir: string;
+  registryRoot: string;
+  catalog: string;
+  registryBaseUrl: string;
+  bundleName: string;
+}
+
+export function emitSkills(opts: EmitSkillsOptions): RegistryItem[] {
+  const { skillsDir, generatedDir, registryRoot, catalog, registryBaseUrl, bundleName } = opts;
+  fs.rmSync(generatedDir, { recursive: true, force: true });
+  if (!fs.existsSync(skillsDir)) return [];
+
+  const dirs = fs
+    .readdirSync(skillsDir)
+    .filter((d) => d !== '.generated' && fs.statSync(path.join(skillsDir, d)).isDirectory())
+    .sort();
+
+  const items: RegistryItem[] = [];
+  const skillNames: string[] = [];
+
+  for (const dir of dirs) {
+    const skillMd = path.join(skillsDir, dir, 'SKILL.md');
+    if (!fs.existsSync(skillMd)) {
+      console.warn(`[generate] skipping skill ${dir}: no SKILL.md`);
+      continue;
+    }
+    const source = fs.readFileSync(skillMd, 'utf-8');
+    const { name } = parseSkillFrontmatter(source);
+    const resolved = applyCatalog(source, catalog);
+    const outPath = path.join(generatedDir, name, 'SKILL.md');
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, resolved);
+    const relPath = path.relative(registryRoot, outPath).replace(/\\/g, '/');
+    items.push({
+      name,
+      type: 'registry:item',
+      files: [{ path: `./${relPath}`, type: 'registry:file', target: `.claude/skills/${name}/SKILL.md` }],
+    });
+    skillNames.push(name);
+  }
+
+  if (skillNames.length > 0) {
+    items.push({
+      name: bundleName,
+      type: 'registry:item',
+      registryDependencies: skillNames.map((n) => `${registryBaseUrl}/${n}`),
+    });
+  }
+
+  return items;
 }

--- a/packages/registry/skills/shuip-components/SKILL.md
+++ b/packages/registry/skills/shuip-components/SKILL.md
@@ -20,27 +20,57 @@ description: Use when choosing which shuip item fits a need, or composing shuip 
 ## Catalog
 
 <!-- shuip:catalog:start -->
-**components** (import `@/components/ui/shuip/<name>`)
-- `confirmation-dialog` — modal to confirm a destructive action
-- `copy-button` — button that copies text to the clipboard with feedback
-- `hover-reveal` — reveal content on hover
-- `side-dialog` — sheet/drawer-style dialog anchored to a screen edge
-- `submit-button` — submit button with explicit `loading` state (used by react-hook-form forms)
-- `theme-button` — light/dark theme toggle
+**components**
+- `confirmation-dialog`
+- `copy-button`
+- `hover-reveal`
+- `side-dialog`
+- `submit-button`
+- `theme-button`
 
-**blocks** (import `@/components/block/shuip/<name>`)
-- `kanban` — drag-and-drop kanban board
-- `responsive-dialog` — dialog on desktop, drawer on mobile (composes `side-dialog`)
-- `title-section` — page/section heading layout
+**blocks**
+- `kanban`
+- `responsive-dialog`
+- `title-section`
 
-**react-hook-form** — `rhf-` items, lens-bound fields (see shuip-forms)
-- `input-field`, `password-field`, `number-field`, `textarea-field`, `select-field`, `checkbox-field`, `radio-field`, `autocomplete-field`, `date-field`, `date-range-field`, `datetime-field`, `month-field`, `time-field`, `time-range`, `inline-edit`, `address-field` (with Places autocomplete)
+**react-hook-form**
+- `rhf-address-field`
+- `rhf-autocomplete-field`
+- `rhf-checkbox-field`
+- `rhf-date-field`
+- `rhf-date-range-field`
+- `rhf-datetime-field`
+- `rhf-inline-edit`
+- `rhf-input-field`
+- `rhf-month-field`
+- `rhf-number-field`
+- `rhf-password-field`
+- `rhf-radio-field`
+- `rhf-select-field`
+- `rhf-textarea-field`
+- `rhf-time-field`
+- `rhf-time-range`
 
-**tanstack-form** — `tsf-` items, context-bound fields (see shuip-forms)
-- `form-context` (required foundation), `input-field`, `password-field`, `number-field`, `textarea-field`, `select-field`, `checkbox-field`, `radio-field`, `autocomplete-field`, `date-field`, `date-range-field`, `datetime-field`, `month-field`, `time-field`, `time-range`, `inline-edit`, `submit-button` (auto-disables via `form.Subscribe`)
+**tanstack-form**
+- `tsf-autocomplete-field`
+- `tsf-checkbox-field`
+- `tsf-date-field`
+- `tsf-date-range-field`
+- `tsf-datetime-field`
+- `tsf-form-context`
+- `tsf-inline-edit`
+- `tsf-input-field`
+- `tsf-month-field`
+- `tsf-password-field`
+- `tsf-radio-field`
+- `tsf-select-field`
+- `tsf-submit-button`
+- `tsf-textarea-field`
+- `tsf-time-field`
+- `tsf-time-range`
 
-**tanstack-query** (import `@/components/ui/shuip/tanstack-query/<name>`)
-- `query-boundary` — wrap a subtree to handle TanStack Query loading/error states
+**tanstack-query**
+- `tsq-query-boundary`
 <!-- shuip:catalog:end -->
 
 ## Composition notes

--- a/packages/registry/skills/shuip-components/SKILL.md
+++ b/packages/registry/skills/shuip-components/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: shuip-components
+description: Use when choosing which shuip item fits a need, or composing shuip components and blocks — provides the full item catalog, install/import conventions, and composition notes. Use before building UI that shuip may already provide.
+---
+
+# Choosing & composing shuip components
+
+## Conventions
+
+- Install: `npx shadcn@latest add "https://shuip.plvo.dev/r/<item-name>"`.
+- Import paths by category:
+  - components → `@/components/ui/shuip/<name>`
+  - blocks → `@/components/block/shuip/<name>`
+  - react-hook-form → `@/components/ui/shuip/react-hook-form/<name>`
+  - tanstack-form → `@/components/ui/shuip/tanstack-form/<name>`
+  - tanstack-query → `@/components/ui/shuip/tanstack-query/<name>`
+- **Exports are unprefixed**: `rhf-input-field` → `InputField`, `kanban` → `Kanban`.
+- For anything form-related, use the **shuip-forms** skill — it covers the rhf/tsf field patterns in depth.
+
+## Catalog
+
+<!-- shuip:catalog:start -->
+**components** (import `@/components/ui/shuip/<name>`)
+- `confirmation-dialog` — modal to confirm a destructive action
+- `copy-button` — button that copies text to the clipboard with feedback
+- `hover-reveal` — reveal content on hover
+- `side-dialog` — sheet/drawer-style dialog anchored to a screen edge
+- `submit-button` — submit button with explicit `loading` state (used by react-hook-form forms)
+- `theme-button` — light/dark theme toggle
+
+**blocks** (import `@/components/block/shuip/<name>`)
+- `kanban` — drag-and-drop kanban board
+- `responsive-dialog` — dialog on desktop, drawer on mobile (composes `side-dialog`)
+- `title-section` — page/section heading layout
+
+**react-hook-form** — `rhf-` items, lens-bound fields (see shuip-forms)
+- `input-field`, `password-field`, `number-field`, `textarea-field`, `select-field`, `checkbox-field`, `radio-field`, `autocomplete-field`, `date-field`, `date-range-field`, `datetime-field`, `month-field`, `time-field`, `time-range`, `inline-edit`, `address-field` (with Places autocomplete)
+
+**tanstack-form** — `tsf-` items, context-bound fields (see shuip-forms)
+- `form-context` (required foundation), `input-field`, `password-field`, `number-field`, `textarea-field`, `select-field`, `checkbox-field`, `radio-field`, `autocomplete-field`, `date-field`, `date-range-field`, `datetime-field`, `month-field`, `time-field`, `time-range`, `inline-edit`, `submit-button` (auto-disables via `form.Subscribe`)
+
+**tanstack-query** (import `@/components/ui/shuip/tanstack-query/<name>`)
+- `query-boundary` — wrap a subtree to handle TanStack Query loading/error states
+<!-- shuip:catalog:end -->
+
+## Composition notes
+
+- `responsive-dialog` composes `side-dialog`; installing it resolves the dependency.
+- `confirmation-dialog` for destructive-action confirmation; `side-dialog` for sheet-style panels.
+- `query-boundary` wraps data-fetching subtrees so you don't hand-roll loading/error UI.
+- Form fields are never used alone — they compose inside a form. Use **shuip-forms**.
+
+## Common mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| Building a dialog / kanban / clipboard button from scratch | Check the catalog first — shuip likely ships it. |
+| Importing a prefixed symbol (`RhfInputField`, `TsfInputField`) | Exports are unprefixed (`InputField`). |
+| Flat path `@/components/ui/shuip/rhf-input-field` | Form categories use a sub-folder: `@/components/ui/shuip/react-hook-form/input-field`. |
+| Treating blocks as `@/components/ui/shuip/...` | Blocks import from `@/components/block/shuip/<name>`. |

--- a/packages/registry/skills/shuip-forms/SKILL.md
+++ b/packages/registry/skills/shuip-forms/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: shuip-forms
+description: Use when building or editing a form in a project that uses shuip — covers shuip's react-hook-form (rhf-) and tanstack-form (tsf-) field components, their install commands, validation, submission, and accessible error/loading state. Use before hand-writing shadcn FormField boilerplate.
+---
+
+# Building forms with shuip
+
+## Overview
+
+shuip ships pre-wired form **field components** for two libraries: **react-hook-form** (registry prefix `rhf-`) and **tanstack-form** (prefix `tsf-`). Each field collapses the label / control / error-message / accessibility wiring into one component.
+
+**Core principle:** compose shuip field components — do NOT hand-write shadcn's `<FormField render={...}>` boilerplate. If you're reaching for `FormField`/`FormItem`/`FormControl`/`FormMessage`, you're rebuilding what these items already give you.
+
+There is **no composite "form" item** in the registry — you assemble a form from individual field items plus your own schema and submit handler.
+
+## Choose the library first
+
+Match whatever the project already uses. If it's greenfield:
+
+- **react-hook-form** (`rhf-*`) — mature ecosystem, uncontrolled/minimal re-renders, validates with a zod resolver. Fields bind through a typed **lens** (`@hookform/lenses`). Pick this unless you have a reason not to.
+- **tanstack-form** (`tsf-*`) — end-to-end type-safe field names, validators co-located on the field, good async validation. Natural fit if the project is already on the TanStack stack (Query/Router). Requires the `tsf-form-context` item as its foundation.
+
+Do not mix the two families in one form.
+
+## Install
+
+```bash
+# react-hook-form fields (install the ones you need)
+npx shadcn@latest add "https://shuip.plvo.dev/r/rhf-input-field"
+npx shadcn@latest add "https://shuip.plvo.dev/r/rhf-password-field"
+npx shadcn@latest add "https://shuip.plvo.dev/r/submit-button"
+
+# tanstack-form: install the form context FIRST, then fields
+npx shadcn@latest add "https://shuip.plvo.dev/r/tsf-form-context"
+npx shadcn@latest add "https://shuip.plvo.dev/r/tsf-input-field"
+npx shadcn@latest add "https://shuip.plvo.dev/r/tsf-submit-button"
+```
+
+Field naming follows the input type: `input-field`, `password-field`, `number-field`, `select-field`, `checkbox-field`, `radio-field`, `textarea-field`, `date-field`, `date-range-field`, `datetime-field`, `time-field`, `month-field`, `autocomplete-field`, plus `address-field` (rhf only). For the full catalog use the **shuip-components** skill. The shadcn CLI pulls each item's shadcn primitives and npm deps (react-hook-form / zod / @hookform/lenses, or @tanstack/react-form) automatically.
+
+**Exports are unprefixed.** The item `rhf-input-field` exports `InputField`. The `rhf-`/`tsf-` prefix is only the registry name, never the import symbol.
+
+## react-hook-form pattern
+
+Create one lens per form with `useLens({ control })`, then give each field `lens.focus('fieldName')`. Wrap everything in `<Form {...form}>`.
+
+```tsx
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { InputField } from '@/components/ui/shuip/react-hook-form/input-field';
+import { PasswordField } from '@/components/ui/shuip/react-hook-form/password-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const schema = z
+  .object({
+    email: z.string().email('Enter a valid email'),
+    password: z.string().min(8, 'At least 8 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((v) => v.password === v.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type Values = z.infer<typeof schema>;
+
+export function SignupForm() {
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '', password: '', confirmPassword: '' },
+  });
+  const lens = useLens({ control: form.control });
+
+  async function onSubmit(values: Values) {
+    const result = await signup(values); // a server action
+    if (result?.fieldErrors) {
+      for (const [name, message] of Object.entries(result.fieldErrors)) {
+        form.setError(name as keyof Values, { message });
+      }
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <InputField lens={lens.focus('email')} label="Email" type="email" placeholder="you@example.com" />
+        <PasswordField lens={lens.focus('password')} label="Password" />
+        <PasswordField lens={lens.focus('confirmPassword')} label="Confirm password" />
+        <SubmitButton loading={form.formState.isSubmitting}>Create account</SubmitButton>
+      </form>
+    </Form>
+  );
+}
+```
+
+- Field-specific props (`type`, `placeholder`, …) pass straight through to the underlying input.
+- `SubmitButton` does **not** auto-disable — bind `loading={form.formState.isSubmitting}` (it disables and shows a spinner while loading).
+- Server-side validation failures map back onto fields with `form.setError`.
+
+## tanstack-form pattern
+
+Build the typed form hook once with `createFormHook`, passing the contexts from `tsf-form-context` and your field/form components. Bind fields with `<form.AppField>`; validators live on the field.
+
+```tsx
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { InputField } from '@/components/ui/shuip/tanstack-form/input-field';
+import { PasswordField } from '@/components/ui/shuip/tanstack-form/password-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { InputField, PasswordField },
+  formComponents: { SubmitButton },
+});
+
+export function SignupForm() {
+  const form = useAppForm({
+    defaultValues: { email: '', password: '' },
+    onSubmit: async ({ value }) => {
+      await signup(value); // a server action
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="space-y-4"
+    >
+      <form.AppField
+        name="email"
+        validators={{ onChange: ({ value }) => (!value.includes('@') ? 'Invalid email' : undefined) }}
+        children={(field) => <field.InputField label="Email" props={{ type: 'email' }} />}
+      />
+      <form.AppField
+        name="password"
+        validators={{ onChange: ({ value }) => (value.length < 8 ? 'At least 8 characters' : undefined) }}
+        children={(field) => <field.PasswordField label="Password" />}
+      />
+      <form.AppForm>
+        <form.SubmitButton>Create account</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}
+```
+
+- tsf fields take split props: `props` for the native input, `fieldProps` for the field wrapper. There is no lens and no `<Form>` wrapper.
+- The tsf `SubmitButton` auto-disables via `form.Subscribe` — render it inside `<form.AppForm>`, no `loading` prop needed.
+
+## Accessibility & states (both libraries)
+
+The field components already render `aria-invalid`, associate the error message, and show validation errors — you get accessible errors for free. For a form-level server error, render a `role="alert"` region yourself. Loading/disabled on submit is handled by `SubmitButton` as shown above.
+
+## Common mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| `<InputField control={form.control} name="email" />` | Wrong API. rhf fields bind via a lens: `lens={lens.focus('email')}` after `const lens = useLens({ control: form.control })`. |
+| Importing `RhfInputField` / `TsfInputField` | Export is `InputField`. The `rhf-`/`tsf-` prefix is the registry name only. |
+| `@/components/ui/shuip/rhf-input-field` (flat) | Real path is `@/components/ui/shuip/react-hook-form/input-field` (category sub-folder). |
+| Installing a `rhf-form` / `tsf-form` item | No composite form item exists. Assemble from field items. |
+| Hand-writing `<FormField render={...}>` | That's the boilerplate shuip fields replace. Use the field component. |
+| Raw `<Button disabled={isSubmitting}>` | Use `SubmitButton`. rhf: `loading={form.formState.isSubmitting}`; tsf: auto via `form.Subscribe`. |
+| Using tsf fields without `tsf-form-context` | Every tsf field reads `useFieldContext`; install and wire `tsf-form-context` first via `createFormHook`. |
+| Mixing rhf and tsf fields in one form | Pick one family per form. |
+
+## Red flags — STOP
+
+- About to type `control={...}` or `name="..."` on an rhf shuip field → use the lens.
+- About to import a `Rhf*`/`Tsf*`-prefixed symbol → the export is unprefixed.
+- About to write `FormField`/`FormItem`/`FormControl` by hand → a shuip field already does this.
+- Looking for an `rhf-form` install command → it doesn't exist.

--- a/packages/registry/skills/shuip-overview/SKILL.md
+++ b/packages/registry/skills/shuip-overview/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: shuip-overview
+description: Use when working in a project that uses shuip and you need to know what shuip provides, how to install items from its registry, or which shuip skill/category to reach for. Triggers on shuip imports (@/components/ui/shuip/...) or a shuip registry URL (shuip.plvo.dev/r/...).
+---
+
+# shuip
+
+## What it is
+
+shuip is a component library built on shadcn/ui for Next.js + React. You install individual **items** through the shadcn CLI from shuip's registry; the source is copied into the project (same model as shadcn) and you own it afterwards.
+
+## Install any item
+
+```bash
+npx shadcn@latest add "https://shuip.plvo.dev/r/<item-name>"
+```
+
+Items install under `@/components/ui/shuip/...` (or `@/components/block/shuip/...` for blocks) and pull their shadcn primitives and npm dependencies automatically. **Exported symbols are unprefixed** — the item `rhf-input-field` exports `InputField`; the `rhf-`/`tsf-`/`tsq-` prefix is only the registry name.
+
+## Categories
+
+- **components** — standalone UI: dialogs, buttons, theme toggle (e.g. `side-dialog`, `confirmation-dialog`, `copy-button`, `theme-button`).
+- **blocks** — composed multi-part UI (e.g. `kanban`, `responsive-dialog`, `title-section`).
+- **react-hook-form** (`rhf-`) — form fields wired to react-hook-form via typed lenses.
+- **tanstack-form** (`tsf-`) — form fields wired to tanstack-form via context.
+- **tanstack-query** (`tsq-`) — data-fetching helpers (e.g. `query-boundary`).
+
+## Which skill next
+
+- Building or editing a **form** → use the **shuip-forms** skill (rhf/tsf field patterns in depth).
+- Choosing or composing **components/blocks**, or you need the full item catalog → use the **shuip-components** skill.
+
+Before building UI from scratch, check whether shuip already ships it.


### PR DESCRIPTION
## What

Ships three **agent skills** through the shuip registry so a downstream developer's coding agent learns to use shuip. Installable like any item:

```bash
npx shadcn@latest add "https://shuip.plvo.dev/r/shuip-forms"     # flagship
npx shadcn@latest add "https://shuip.plvo.dev/r/shuip-skills"    # bundle: all three
```

Each installs as `.claude/skills/<name>/SKILL.md` in the consumer's project.

### The three skills
- **`shuip-overview`** — what shuip is, the install model, categories, routing to the other skills.
- **`shuip-components`** — full item catalog (auto-generated from `registry.json`), install/import conventions, composition notes.
- **`shuip-forms`** — prod-grade forms over the existing `rhf-*`/`tsf-*` field items: rhf-vs-tsf choice, the `@hookform/lenses` binding, `createFormHook` pattern, zod, server-action submission, accessible error/loading states.
- **`shuip-skills`** — a files-less bundle that pulls all three via `registryDependencies`.

## How (Approach B)

A standalone `packages/registry/scripts/skills.ts` (pure functions + `emitSkills`) is called from `generate.ts`'s `main()`. It resolves a catalog from the in-memory component list, writes catalog-resolved copies to the gitignored `skills/.generated/`, and merges `registry:item` entries into the shared `registry.json`. `shadcn-build.ts` emits `public/r/*.json` generically — **no build change**. Skills are decoupled from `generate.ts` via a type-only import (no circular dependency).

Skill items omit `title`/`description` to match existing component items (the build schema is non-strict and would silently drop them).

## Verification
- `bun test` — 11/11 unit tests (frontmatter parse, catalog resolve, marker replace, collision guard, emit).
- `bun registry:build` — 47 items, no schema errors (proves the files-less bundle + `registry:file` skill items validate).
- Emitted `public/r/shuip-forms.json` carries the SKILL.md content inline with target `.claude/skills/shuip-forms/SKILL.md`; `shuip-skills.json` aggregates the three by full URL.
- `bun build:docs` — full chain succeeds (TypeScript passed, 162 pages), clean tree, skills absent from the live-preview index.
- The skill content was authored TDD-style: a baseline agent without the skills invented item names and the prop API; with the skills it produced correct lens binding, item names, imports, and `SubmitButton`.

## Notes
- Generated artifacts (`registry.json`, `skills/.generated/`, `public/r/`) stay gitignored — commits are source-only.
- Portable-agent formats (Cursor `.mdc`, AGENTS) are deliberately deferred; the authoring layer is format-agnostic for an additive follow-up.

Spec: `docs/superpowers/specs/2026-05-27-shuip-agent-skills-design.md`
Plan: `docs/superpowers/plans/2026-05-27-shuip-agent-skills-generator-wiring.md`