### PR TITLE
feat(blocks): add view-transition-tabs block

### DIFF
--- a/apps/docs/content/blocks/view-transition-tabs.mdx
+++ b/apps/docs/content/blocks/view-transition-tabs.mdx
@@ -20,6 +20,8 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 
 > **Requires Next.js App Router.** `ViewTransition` and `addTransitionType` resolve through the React that Next.js vendors for the App Router. In a non–App-Router setup (e.g. Vite on stable React) these exports are unavailable and the component will not render.
 
+> **Avoid layout shift during the transition.** A view transition briefly hides the page scrollbar; in a layout whose width is otherwise flexible, the content can widen by the scrollbar width and shift for the duration of the animation. Reserve the gutter with `html { scrollbar-gutter: stable }` (or give the tabs row a stable width) so the panel slides without nudging the rest of the page.
+
 ## Usage
 
 ### State (self-contained)

--- a/apps/docs/content/blocks/view-transition-tabs.mdx
+++ b/apps/docs/content/blocks/view-transition-tabs.mdx
@@ -73,6 +73,10 @@ export default function ProfileLayout({ children }: { children: React.ReactNode 
 
 ## Examples
 
+The previews below run in **state mode** (a tab swaps content in place). To see **router mode** — where each tab is a real route and the URL changes as the panel slides — open the live demo:
+
+<a href="/demo/view-transition-tabs/account" className="font-medium underline underline-offset-4">Open the live router demo →</a>
+
 <ItemExamples registryName={'view-transition-tabs'} />
 
 ## TabsNav props

--- a/apps/docs/content/blocks/view-transition-tabs.mdx
+++ b/apps/docs/content/blocks/view-transition-tabs.mdx
@@ -1,0 +1,118 @@
+---
+title: View Transition Tabs
+description: A tabbed navigation that animates the panel with a directional view transition — vertical sidebar or horizontal, driven by state or the router.
+registryName: view-transition-tabs
+---
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## About
+
+`view-transition-tabs` is two pieces that share a directional contract:
+
+- **`TabsNav`** — the navigation. Renders a vertical sidebar or a horizontal tab bar and, when a tab is selected, fires a directional [view transition type](https://react.dev/reference/react/addTransitionType) (`slide-forward` when moving to a later tab, `slide-backward` when moving back).
+- **`ViewTransitionPanel`** — wraps the content that changes. It maps those transition types to slide-in / slide-out animations and ships its own keyframes, so no global CSS is required.
+
+`TabsNav` works in two modes:
+
+- **State** — pass `value` and `onValueChange`. The panel content is swapped in place. This is the self-contained mode used in the examples below.
+- **Router** — omit `value` and give each tab an `href`. The active tab is matched against the current pathname, selection calls `router.push`, and the panel wraps your layout's `children`. Each tab is a real route segment.
+
+> **Requires Next.js App Router.** `ViewTransition` and `addTransitionType` resolve through the React that Next.js vendors for the App Router. In a non–App-Router setup (e.g. Vite on stable React) these exports are unavailable and the component will not render.
+
+## Usage
+
+### State (self-contained)
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { TabsNav, ViewTransitionPanel } from '@/components/block/shuip/view-transition-tabs';
+
+const TABS = [
+  { value: 'account', label: 'Account' },
+  { value: 'security', label: 'Security' },
+];
+
+export function Settings() {
+  const [tab, setTab] = useState('account');
+  return (
+    <div className="flex gap-8">
+      <TabsNav items={TABS} orientation="vertical" value={tab} onValueChange={setTab} />
+      <ViewTransitionPanel>{tab === 'account' ? <Account /> : <Security />}</ViewTransitionPanel>
+    </div>
+  );
+}
+```
+
+### Router (one route per tab)
+
+Drop `TabsNav` and `ViewTransitionPanel` into a layout. Each tab is a route segment, and `children` is the active page.
+
+```tsx
+// app/profile/layout.tsx
+import { TabsNav, ViewTransitionPanel } from '@/components/block/shuip/view-transition-tabs';
+
+const TABS = [
+  { value: 'account', label: 'Account', href: '/profile/account' },
+  { value: 'security', label: 'Security', href: '/profile/security' },
+];
+
+export default function ProfileLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex gap-8">
+      <TabsNav items={TABS} orientation="vertical" />
+      <ViewTransitionPanel>{children}</ViewTransitionPanel>
+    </div>
+  );
+}
+```
+
+## Examples
+
+<ItemExamples registryName={'view-transition-tabs'} />
+
+## TabsNav props
+
+<TypeTable
+  type={{
+    items: {
+      description:
+        'The tabs to render. Each is { value, label, href? }. Provide href for router mode; value is the stable identity used for selection and active state.',
+      type: 'ViewTransitionTab[]',
+    },
+    orientation: {
+      description: 'Vertical renders a sidebar column; horizontal renders a tab bar.',
+      type: '"horizontal" | "vertical"',
+      default: '"horizontal"',
+    },
+    value: {
+      description: 'Active tab value. Provide it (with onValueChange) for state mode. Omit it for router mode.',
+      type: 'string?',
+    },
+    onValueChange: {
+      description: 'Called with the next value when a tab is selected in state mode.',
+      type: '(value: string) => void',
+    },
+    className: {
+      description: 'Additional classes on the nav container.',
+      type: 'string?',
+    },
+  }}
+/>
+
+## ViewTransitionPanel props
+
+<TypeTable
+  type={{
+    children: {
+      description: 'The content that changes between tabs. It is snapshotted and animated on each transition.',
+      type: 'React.ReactNode',
+    },
+    className: {
+      description: 'Additional classes on the panel wrapper (defaults to min-w-0 flex-1).',
+      type: 'string?',
+    },
+  }}
+/>

--- a/apps/docs/content/blocks/view-transition-tabs.mdx
+++ b/apps/docs/content/blocks/view-transition-tabs.mdx
@@ -11,7 +11,7 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 `view-transition-tabs` is two pieces that share a directional contract:
 
 - **`TabsNav`** — the navigation. Renders a vertical sidebar or a horizontal tab bar and, when a tab is selected, fires a directional [view transition type](https://react.dev/reference/react/addTransitionType) (`slide-forward` when moving to a later tab, `slide-backward` when moving back).
-- **`ViewTransitionPanel`** — wraps the content that changes. It maps those transition types to slide-in / slide-out animations and ships its own keyframes, so no global CSS is required.
+- **`ViewTransitionPanel`** — wraps the content that changes. It animates the in-place content update with directional slide-in / slide-out keyframes, mapped to the transition types through React's `update` view-transition classes (`::view-transition-old` / `::view-transition-new` pseudo-element rules). It ships its own keyframes, so no global CSS is required.
 
 `TabsNav` works in two modes:
 

--- a/apps/docs/src/app/demo/view-transition-tabs/account/page.tsx
+++ b/apps/docs/src/app/demo/view-transition-tabs/account/page.tsx
@@ -1,0 +1,8 @@
+export default function AccountPage() {
+  return (
+    <div className='min-h-40 space-y-2'>
+      <h2 className='text-lg font-semibold'>Account</h2>
+      <p className='text-sm text-muted-foreground'>Update your name, email and public profile information.</p>
+    </div>
+  );
+}

--- a/apps/docs/src/app/demo/view-transition-tabs/layout.tsx
+++ b/apps/docs/src/app/demo/view-transition-tabs/layout.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { TabsNav, ViewTransitionPanel, type ViewTransitionTab } from '@/components/block/shuip/view-transition-tabs';
+
+const TABS: ViewTransitionTab[] = [
+  { value: 'account', label: 'Account', href: '/demo/view-transition-tabs/account' },
+  { value: 'security', label: 'Security', href: '/demo/view-transition-tabs/security' },
+  { value: 'sessions', label: 'Sessions', href: '/demo/view-transition-tabs/sessions' },
+  { value: 'preferences', label: 'Preferences', href: '/demo/view-transition-tabs/preferences' },
+];
+
+export default function ViewTransitionTabsDemoLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <main className='mx-auto w-full max-w-3xl px-6 py-16'>
+      <div className='mb-10 space-y-1'>
+        <Link
+          href='/blocks/view-transition-tabs'
+          className='text-sm text-muted-foreground underline-offset-4 hover:underline'
+        >
+          ← Back to docs
+        </Link>
+        <h1 className='text-2xl font-semibold'>View Transition Tabs — router demo</h1>
+        <p className='text-sm text-muted-foreground'>
+          Each tab is a real route. Watch the URL change and the panel slide as you navigate.
+        </p>
+      </div>
+
+      <div className='flex gap-8'>
+        <TabsNav items={TABS} orientation='vertical' />
+        <ViewTransitionPanel>{children}</ViewTransitionPanel>
+      </div>
+    </main>
+  );
+}

--- a/apps/docs/src/app/demo/view-transition-tabs/page.tsx
+++ b/apps/docs/src/app/demo/view-transition-tabs/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function ViewTransitionTabsDemoIndex() {
+  redirect('/demo/view-transition-tabs/account');
+}

--- a/apps/docs/src/app/demo/view-transition-tabs/preferences/page.tsx
+++ b/apps/docs/src/app/demo/view-transition-tabs/preferences/page.tsx
@@ -1,0 +1,8 @@
+export default function PreferencesPage() {
+  return (
+    <div className='min-h-40 space-y-2'>
+      <h2 className='text-lg font-semibold'>Preferences</h2>
+      <p className='text-sm text-muted-foreground'>Choose your theme, language and notification settings.</p>
+    </div>
+  );
+}

--- a/apps/docs/src/app/demo/view-transition-tabs/security/page.tsx
+++ b/apps/docs/src/app/demo/view-transition-tabs/security/page.tsx
@@ -1,0 +1,10 @@
+export default function SecurityPage() {
+  return (
+    <div className='min-h-40 space-y-2'>
+      <h2 className='text-lg font-semibold'>Security</h2>
+      <p className='text-sm text-muted-foreground'>
+        Manage your password, two-factor authentication and recovery codes.
+      </p>
+    </div>
+  );
+}

--- a/apps/docs/src/app/demo/view-transition-tabs/sessions/page.tsx
+++ b/apps/docs/src/app/demo/view-transition-tabs/sessions/page.tsx
@@ -1,0 +1,8 @@
+export default function SessionsPage() {
+  return (
+    <div className='min-h-40 space-y-2'>
+      <h2 className='text-lg font-semibold'>Sessions</h2>
+      <p className='text-sm text-muted-foreground'>Review the devices currently signed in to your account.</p>
+    </div>
+  );
+}

--- a/apps/docs/src/styles/globals.css
+++ b/apps/docs/src/styles/globals.css
@@ -3,6 +3,12 @@
 @import 'fumadocs-ui/css/preset.css';
 @import "@repo/ui/styles/base.css";
 
+/* Reserve the scrollbar gutter so a view transition (which suppresses the
+   scrollbar mid-animation) can't change the content width and shift the layout. */
+html {
+  scrollbar-gutter: stable;
+}
+
 .table-trigger {
   @apply relative h-9 rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-3 pt-2 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none;
 }

--- a/packages/registry/items/blocks/view-transition-tabs/component.tsx
+++ b/packages/registry/items/blocks/view-transition-tabs/component.tsx
@@ -85,14 +85,14 @@ export function TabsNav({ items, orientation = 'horizontal', value, onValueChang
 }
 
 const SLIDE_KEYFRAMES = `
-@keyframes shuip-vt-slide-from-right { from { transform: translateX(30px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
-@keyframes shuip-vt-slide-from-left { from { transform: translateX(-30px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
-@keyframes shuip-vt-slide-to-left { from { transform: translateX(0); opacity: 1; } to { transform: translateX(-30px); opacity: 0; } }
-@keyframes shuip-vt-slide-to-right { from { transform: translateX(0); opacity: 1; } to { transform: translateX(30px); opacity: 0; } }
-.shuip-vt-from-right { animation: shuip-vt-slide-from-right 0.25s ease-out; }
-.shuip-vt-from-left { animation: shuip-vt-slide-from-left 0.25s ease-out; }
-.shuip-vt-to-left { animation: shuip-vt-slide-to-left 0.15s ease-in; }
-.shuip-vt-to-right { animation: shuip-vt-slide-to-right 0.15s ease-in; }
+@keyframes shuip-vt-from-right { from { transform: translateX(30px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes shuip-vt-from-left { from { transform: translateX(-30px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes shuip-vt-to-left { from { transform: translateX(0); opacity: 1; } to { transform: translateX(-30px); opacity: 0; } }
+@keyframes shuip-vt-to-right { from { transform: translateX(0); opacity: 1; } to { transform: translateX(30px); opacity: 0; } }
+::view-transition-old(.shuip-vt-forward) { animation: shuip-vt-to-left 0.2s ease-in-out; }
+::view-transition-new(.shuip-vt-forward) { animation: shuip-vt-from-right 0.2s ease-in-out; }
+::view-transition-old(.shuip-vt-backward) { animation: shuip-vt-to-right 0.2s ease-in-out; }
+::view-transition-new(.shuip-vt-backward) { animation: shuip-vt-from-left 0.2s ease-in-out; }
 `;
 
 type ViewTransitionPanelProps = {
@@ -107,15 +107,10 @@ export function ViewTransitionPanel({ children, className }: ViewTransitionPanel
         {SLIDE_KEYFRAMES}
       </style>
       <ViewTransition
-        enter={{
+        update={{
           default: 'none',
-          'slide-forward': 'shuip-vt-from-right',
-          'slide-backward': 'shuip-vt-from-left',
-        }}
-        exit={{
-          default: 'none',
-          'slide-forward': 'shuip-vt-to-left',
-          'slide-backward': 'shuip-vt-to-right',
+          'slide-forward': 'shuip-vt-forward',
+          'slide-backward': 'shuip-vt-backward',
         }}
       >
         <div className={cn('min-w-0 flex-1', className)}>{children}</div>

--- a/packages/registry/items/blocks/view-transition-tabs/component.tsx
+++ b/packages/registry/items/blocks/view-transition-tabs/component.tsx
@@ -1,0 +1,125 @@
+/// <reference types="react/experimental" />
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import type * as React from 'react';
+import { addTransitionType, startTransition, ViewTransition } from 'react';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+
+export type ViewTransitionTab = {
+  value: string;
+  label: React.ReactNode;
+  href?: string;
+};
+
+type TabsNavProps = {
+  items: readonly ViewTransitionTab[];
+  orientation?: 'horizontal' | 'vertical';
+  value?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+};
+
+function activeRouterValue(items: readonly ViewTransitionTab[], pathname: string): string {
+  let bestValue = items[0]?.value ?? '';
+  let bestLength = -1;
+  for (const item of items) {
+    if (item.href && pathname.startsWith(item.href) && item.href.length > bestLength) {
+      bestValue = item.value;
+      bestLength = item.href.length;
+    }
+  }
+  return bestValue;
+}
+
+export function TabsNav({ items, orientation = 'horizontal', value, onValueChange, className }: TabsNavProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const isRouter = value === undefined;
+  const activeValue = isRouter ? activeRouterValue(items, pathname) : value;
+  const activeIndex = items.findIndex((item) => item.value === activeValue);
+
+  const select = (next: string) => {
+    const nextIndex = items.findIndex((item) => item.value === next);
+    if (nextIndex < 0 || nextIndex === activeIndex) return;
+    startTransition(() => {
+      addTransitionType(nextIndex > activeIndex ? 'slide-forward' : 'slide-backward');
+      if (isRouter) {
+        const href = items[nextIndex]?.href;
+        if (href) router.push(href);
+      } else {
+        onValueChange?.(next);
+      }
+    });
+  };
+
+  const isVertical = orientation === 'vertical';
+
+  return (
+    <Tabs
+      value={activeValue}
+      orientation={orientation}
+      activationMode='manual'
+      onValueChange={select}
+      className={cn(isVertical && 'w-44 shrink-0 border-r pr-4', className)}
+    >
+      <TabsList
+        className={cn('bg-transparent p-0', isVertical ? 'flex h-auto w-full flex-col items-stretch gap-1' : 'gap-1')}
+      >
+        {items.map((item) => (
+          <TabsTrigger
+            key={item.value}
+            value={item.value}
+            className={cn(
+              'data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-none',
+              isVertical && 'w-full justify-start px-3 py-2 text-base font-normal',
+            )}
+          >
+            {item.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}
+
+const SLIDE_KEYFRAMES = `
+@keyframes shuip-vt-slide-from-right { from { transform: translateX(30px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes shuip-vt-slide-from-left { from { transform: translateX(-30px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes shuip-vt-slide-to-left { from { transform: translateX(0); opacity: 1; } to { transform: translateX(-30px); opacity: 0; } }
+@keyframes shuip-vt-slide-to-right { from { transform: translateX(0); opacity: 1; } to { transform: translateX(30px); opacity: 0; } }
+.shuip-vt-from-right { animation: shuip-vt-slide-from-right 0.25s ease-out; }
+.shuip-vt-from-left { animation: shuip-vt-slide-from-left 0.25s ease-out; }
+.shuip-vt-to-left { animation: shuip-vt-slide-to-left 0.15s ease-in; }
+.shuip-vt-to-right { animation: shuip-vt-slide-to-right 0.15s ease-in; }
+`;
+
+type ViewTransitionPanelProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function ViewTransitionPanel({ children, className }: ViewTransitionPanelProps) {
+  return (
+    <>
+      <style href='shuip-view-transition-tabs' precedence='default'>
+        {SLIDE_KEYFRAMES}
+      </style>
+      <ViewTransition
+        enter={{
+          default: 'none',
+          'slide-forward': 'shuip-vt-from-right',
+          'slide-backward': 'shuip-vt-from-left',
+        }}
+        exit={{
+          default: 'none',
+          'slide-forward': 'shuip-vt-to-left',
+          'slide-backward': 'shuip-vt-to-right',
+        }}
+      >
+        <div className={cn('min-w-0 flex-1', className)}>{children}</div>
+      </ViewTransition>
+    </>
+  );
+}

--- a/packages/registry/items/blocks/view-transition-tabs/default.example.tsx
+++ b/packages/registry/items/blocks/view-transition-tabs/default.example.tsx
@@ -22,10 +22,10 @@ export default function ViewTransitionTabsExample() {
   const view = CONTENT[active];
 
   return (
-    <div className='flex gap-8'>
+    <div className='flex w-[34rem] max-w-full gap-8'>
       <TabsNav items={TABS} orientation='vertical' value={active} onValueChange={setActive} />
       <ViewTransitionPanel>
-        <div className='space-y-2'>
+        <div className='min-h-24 space-y-2'>
           <h3 className='text-lg font-semibold'>{view.title}</h3>
           <p className='text-sm text-muted-foreground'>{view.body}</p>
         </div>

--- a/packages/registry/items/blocks/view-transition-tabs/default.example.tsx
+++ b/packages/registry/items/blocks/view-transition-tabs/default.example.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import { TabsNav, ViewTransitionPanel, type ViewTransitionTab } from '@/components/block/shuip/view-transition-tabs';
+
+const TABS: ViewTransitionTab[] = [
+  { value: 'account', label: 'Account' },
+  { value: 'security', label: 'Security' },
+  { value: 'sessions', label: 'Sessions' },
+  { value: 'preferences', label: 'Preferences' },
+];
+
+const CONTENT: Record<string, { title: string; body: string }> = {
+  account: { title: 'Account', body: 'Update your name, email and public profile information.' },
+  security: { title: 'Security', body: 'Manage your password, two-factor authentication and recovery codes.' },
+  sessions: { title: 'Sessions', body: 'Review the devices currently signed in to your account.' },
+  preferences: { title: 'Preferences', body: 'Choose your theme, language and notification settings.' },
+};
+
+export default function ViewTransitionTabsExample() {
+  const [active, setActive] = useState('account');
+  const view = CONTENT[active];
+
+  return (
+    <div className='flex gap-8'>
+      <TabsNav items={TABS} orientation='vertical' value={active} onValueChange={setActive} />
+      <ViewTransitionPanel>
+        <div className='space-y-2'>
+          <h3 className='text-lg font-semibold'>{view.title}</h3>
+          <p className='text-sm text-muted-foreground'>{view.body}</p>
+        </div>
+      </ViewTransitionPanel>
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/view-transition-tabs/horizontal.example.tsx
+++ b/packages/registry/items/blocks/view-transition-tabs/horizontal.example.tsx
@@ -22,10 +22,10 @@ export default function ViewTransitionTabsHorizontalExample() {
   const view = CONTENT[active];
 
   return (
-    <div className='space-y-6'>
+    <div className='w-[34rem] max-w-full space-y-6'>
       <TabsNav items={TABS} value={active} onValueChange={setActive} />
       <ViewTransitionPanel>
-        <div className='space-y-2'>
+        <div className='min-h-24 space-y-2'>
           <h3 className='text-lg font-semibold'>{view.title}</h3>
           <p className='text-sm text-muted-foreground'>{view.body}</p>
         </div>

--- a/packages/registry/items/blocks/view-transition-tabs/horizontal.example.tsx
+++ b/packages/registry/items/blocks/view-transition-tabs/horizontal.example.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import { TabsNav, ViewTransitionPanel, type ViewTransitionTab } from '@/components/block/shuip/view-transition-tabs';
+
+const TABS: ViewTransitionTab[] = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'personas', label: 'Personas' },
+  { value: 'tickets', label: 'Tickets' },
+  { value: 'team', label: 'Team' },
+];
+
+const CONTENT: Record<string, { title: string; body: string }> = {
+  overview: { title: 'Overview', body: 'High-level health and the latest signals for this product.' },
+  personas: { title: 'Personas', body: 'The audiences you are building for and their core needs.' },
+  tickets: { title: 'Tickets', body: 'Work in progress, grouped by stage and priority.' },
+  team: { title: 'Team', body: 'Who owns what, and the people contributing to this product.' },
+};
+
+export default function ViewTransitionTabsHorizontalExample() {
+  const [active, setActive] = useState('overview');
+  const view = CONTENT[active];
+
+  return (
+    <div className='space-y-6'>
+      <TabsNav items={TABS} value={active} onValueChange={setActive} />
+      <ViewTransitionPanel>
+        <div className='space-y-2'>
+          <h3 className='text-lg font-semibold'>{view.title}</h3>
+          <p className='text-sm text-muted-foreground'>{view.body}</p>
+        </div>
+      </ViewTransitionPanel>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a `view-transition-tabs` block: a directional tabbed navigation that animates the content panel with a React view transition. Extracted and generalized from the kodex profile/CRM/product/docs layouts, which hand-rolled and copy-pasted the same `<ViewTransition>` enter/exit config across four layouts.

Two exports:

- **`TabsNav`** — vertical sidebar or horizontal bar. Computes direction (`slide-forward` / `slide-backward`) from the index delta and fires `addTransitionType` inside `startTransition`. Two modes via props:
  - **state**: `value` + `onValueChange` (content swapped in place)
  - **router**: `href` per tab, active tab matched against the pathname, selection calls `router.push` (one route segment per tab)
- **`ViewTransitionPanel`** — wraps the changing content, maps the transition types to slide animations, and ships its own keyframes via a hoisted `<style precedence>` (no global CSS / consumer config required).

## Notes

- **App Router only.** `ViewTransition` / `addTransitionType` resolve through the React that Next.js vendors for the App Router; a `/// <reference types="react/experimental" />` activates the types. Documented as a prerequisite in the MDX.
- `registryDependencies: ["tabs"]`, auto-detected.

## Verification

- `bun build:docs` passes end-to-end (registry:generate → registry:build → next build), including type-checking the experimental APIs and prerendering the docs pages.
- `bun check` (biome) clean.
- Two examples (vertical sidebar default + horizontal), both state-driven so the docs preview animates live.