### PR TITLE
feat(data-table): add entity-agnostic dual-mode data-table block

### DIFF
--- a/apps/docs/content/blocks/data-table.mdx
+++ b/apps/docs/content/blocks/data-table.mdx
@@ -1,0 +1,165 @@
+---
+title: Data Table
+description: An entity-agnostic, dual-mode data table built on TanStack Table. Define your columns and drop in your data — client-side out of the box, or server-side with pagination, sorting, and filtering.
+registryName: data-table
+---
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+`DataTable` is a generic table system (`useDataTable<TData>` + composable sub-components) that renders any array of typed rows. All per-entity configuration lives in your TanStack `ColumnDef[]` and a typed `meta` extension; the components only ever read the table instance, so nothing is hardcoded to a domain.
+
+### Built-in features
+
+- **Generic data model**: `useDataTable<T>` works with any row type via `ColumnDef<T>[]`.
+- **Dual mode**: client-side out of the box (sorting, filtering, pagination computed in memory) or server-side by passing `pageCount` + controlled state and `on*Change` handlers.
+- **Auto-generated toolbar**: faceted filters are derived from each column's `meta.variant` / `meta.options` — no per-table wiring.
+- **Composable**: drop `DataTableToolbar`, `DataTable`, and `DataTablePagination` where you want them; swap any piece.
+- **Row selection, column visibility, column pinning** (sticky columns), sortable headers, global search.
+- **States**: loading skeleton, empty, and no-results-after-filter.
+
+## Examples
+
+<ItemExamples registryName={'data-table'} />
+
+## The `meta` convention
+
+Per-entity configuration rides on TanStack's `ColumnMeta`, augmented by this block:
+
+```ts
+interface ColumnMeta {
+  label?: string;
+  placeholder?: string;
+  variant?: 'text' | 'number' | 'date' | 'select' | 'multiSelect';
+  options?: { label: string; value: string; icon?: React.ComponentType; count?: number }[];
+  icon?: React.ComponentType;
+}
+```
+
+A column with `meta.variant: 'multiSelect'` and `meta.options` automatically gets a faceted filter in the toolbar. For client-side multi-select filtering, set `filterFn: 'arrIncludesSome'` on that column.
+
+## Client vs server mode
+
+Client mode is the default — pass `data` and `columns` and the table computes everything:
+
+```tsx
+const { table } = useDataTable({ data, columns, getRowId: (row) => row.id });
+```
+
+Server mode activates when you pass `pageCount`. Control the state yourself and react to changes by refetching:
+
+```tsx
+const { table } = useDataTable({
+  data: result.rows,
+  columns,
+  pageCount: Math.ceil(result.total / pagination.pageSize),
+  state: { pagination, sorting, columnFilters, globalFilter },
+  onPaginationChange: setPagination,
+  onSortingChange: setSorting,
+  onColumnFiltersChange: setColumnFilters,
+  onGlobalFilterChange: setGlobalFilter,
+});
+```
+
+## Recipe: sync state to the URL with nuqs
+
+Server mode pairs naturally with shareable, bookmarkable URLs. This is opt-in and not bundled with the block (it would force a router dependency on every consumer). Install nuqs and wrap your app once:
+
+```bash
+bun add nuqs
+```
+
+```tsx
+// app/layout.tsx
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang='en'>
+      <body>
+        <NuqsAdapter>{children}</NuqsAdapter>
+      </body>
+    </html>
+  );
+}
+```
+
+Then drop in this hook and feed its output straight into `useDataTable`:
+
+```tsx
+// hooks/use-data-table-url-state.ts
+'use client';
+
+import type { ColumnFiltersState, PaginationState, SortingState } from '@tanstack/react-table';
+import { parseAsInteger, parseAsJson, parseAsString, useQueryStates } from 'nuqs';
+
+export function useDataTableUrlState() {
+  const [state, setState] = useQueryStates(
+    {
+      pageIndex: parseAsInteger.withDefault(0),
+      pageSize: parseAsInteger.withDefault(10),
+      sorting: parseAsJson<SortingState>((value) => value as SortingState).withDefault([]),
+      columnFilters: parseAsJson<ColumnFiltersState>((value) => value as ColumnFiltersState).withDefault([]),
+      globalFilter: parseAsString.withDefault(''),
+    },
+    { history: 'push', shallow: false, throttleMs: 50, clearOnDefault: true },
+  );
+
+  const pagination: PaginationState = { pageIndex: state.pageIndex, pageSize: state.pageSize };
+
+  return {
+    pagination,
+    sorting: state.sorting,
+    columnFilters: state.columnFilters,
+    globalFilter: state.globalFilter,
+    onPaginationChange: (updater: PaginationState | ((old: PaginationState) => PaginationState)) => {
+      const next = typeof updater === 'function' ? updater(pagination) : updater;
+      void setState({ pageIndex: next.pageIndex, pageSize: next.pageSize });
+    },
+    onSortingChange: (updater: SortingState | ((old: SortingState) => SortingState)) => {
+      const next = typeof updater === 'function' ? updater(state.sorting) : updater;
+      void setState({ sorting: next, pageIndex: 0 });
+    },
+    onColumnFiltersChange: (updater: ColumnFiltersState | ((old: ColumnFiltersState) => ColumnFiltersState)) => {
+      const next = typeof updater === 'function' ? updater(state.columnFilters) : updater;
+      void setState({ columnFilters: next, pageIndex: 0 });
+    },
+    onGlobalFilterChange: (updater: string | ((old: string) => string)) => {
+      const next = typeof updater === 'function' ? updater(state.globalFilter) : updater;
+      void setState({ globalFilter: next, pageIndex: 0 });
+    },
+  };
+}
+```
+
+```tsx
+const url = useDataTableUrlState();
+const { table } = useDataTable({
+  data: result.rows,
+  columns,
+  pageCount: Math.ceil(result.total / url.pagination.pageSize),
+  state: url,
+  onPaginationChange: url.onPaginationChange,
+  onSortingChange: url.onSortingChange,
+  onColumnFiltersChange: url.onColumnFiltersChange,
+  onGlobalFilterChange: url.onGlobalFilterChange,
+});
+```
+
+## Props
+
+<TypeTable
+  type={{
+    data: { description: 'The rows to render.', type: 'TData[]' },
+    columns: { description: 'TanStack column definitions. Carry per-entity config in meta.', type: 'ColumnDef<TData>[]' },
+    pageCount: { description: 'Total page count. Passing it switches the table to server-side (manual) mode.', type: 'number?' },
+    getRowId: { description: 'Stable row id, so selection survives pagination/sorting/refetch.', type: '(row: TData, index: number) => string' },
+    enableRowSelection: { description: 'Enable row selection.', type: 'boolean', default: 'false' },
+    enableColumnPinning: { description: 'Enable sticky pinned columns.', type: 'boolean', default: 'false' },
+    initialState: { description: 'Initial pagination / sorting / columnVisibility / columnPinning.', type: 'object?' },
+    state: { description: 'Controlled state for server mode (pagination, sorting, columnFilters, globalFilter).', type: 'object?' },
+    onPaginationChange: { description: 'Pagination change handler (server mode).', type: 'OnChangeFn<PaginationState>?' },
+    onSortingChange: { description: 'Sorting change handler (server mode).', type: 'OnChangeFn<SortingState>?' },
+    onColumnFiltersChange: { description: 'Column filters change handler (server mode).', type: 'OnChangeFn<ColumnFiltersState>?' },
+    onGlobalFilterChange: { description: 'Global filter change handler (server mode).', type: 'OnChangeFn<string>?' },
+  }}
+/>

--- a/apps/docs/content/blocks/data-table.mdx
+++ b/apps/docs/content/blocks/data-table.mdx
@@ -14,12 +14,46 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 - **Dual mode**: client-side out of the box (sorting, filtering, pagination computed in memory) or server-side by passing `pageCount` + controlled state and `on*Change` handlers.
 - **Auto-generated toolbar**: faceted filters are derived from each column's `meta.variant` / `meta.options` — no per-table wiring.
 - **Composable**: drop `DataTableToolbar`, `DataTable`, and `DataTablePagination` where you want them; swap any piece.
+- **Per-zone variants**: pagination (`simple` / `numbered`), progressive `DataTableLoadMore` (`button` / `infinite`), toolbar (`default` / `inline-chips` / `minimal`), empty state (`text` / `illustrated` / `with-action`), and loading (`skeleton` / `overlay` / `shimmer`).
 - **Row selection, column visibility, column pinning** (sticky columns), sortable headers, global search.
 - **States**: loading skeleton, empty, and no-results-after-filter.
 
 ## Examples
 
 <ItemExamples registryName={'data-table'} />
+
+## Variants
+
+Each zone of the table is a separate sub-component with its own `variant`, so you compose the look you want by swapping the relevant piece — nothing else changes.
+
+```tsx
+// Pagination — page-based presentation of the same table state
+<DataTablePagination table={table} variant='simple' />   // arrows + "Page X of Y" (default)
+<DataTablePagination table={table} variant='numbered' />  // numbered pages with truncation
+
+// Progressive loading — accumulate rows instead of paging (server- or client-driven)
+<DataTableLoadMore mode='button' onLoadMore={loadMore} hasMore={hasMore} isLoading={isLoading} loaded={rows.length} total={total} />
+<DataTableLoadMore mode='infinite' onLoadMore={loadMore} hasMore={hasMore} isLoading={isLoading} />
+
+// Toolbar
+<DataTableToolbar table={table} variant='default' />       // search + faceted filters + view (default)
+<DataTableToolbar table={table} variant='inline-chips' />  // active filters as removable chips on a second row
+<DataTableToolbar table={table} variant='minimal' />       // search + view only
+
+// Empty state — pass a ready-made brick to `emptyState`, or any node of your own
+<DataTable
+  table={table}
+  emptyState={
+    <DataTableEmpty variant='illustrated' icon={Inbox} title='No results' description='Try adjusting your filters.' />
+  }
+/>
+<DataTableEmpty variant='with-action' title='No users yet' action={<Button size='sm'>Invite user</Button>} />
+
+// Loading
+<DataTable table={table} isLoading={isLoading} loadingVariant='skeleton' />  // skeleton rows (default)
+<DataTable table={table} isLoading={isLoading} loadingVariant='overlay' />   // keep rows, dim + spinner (best for refetch)
+<DataTable table={table} isLoading={isLoading} loadingVariant='shimmer' />   // animated sweep (reduced-motion aware)
+```
 
 ## The `meta` convention
 

--- a/apps/docs/content/blocks/data-table.mdx
+++ b/apps/docs/content/blocks/data-table.mdx
@@ -68,8 +68,8 @@ Three composable controls — drop them in any row, no toolbar assumed. Each is 
 </div>
 ```
 
-- **`DataTableFilterMenu`** — a condition builder (`Where [field] [operator] [value]`). Operators are inferred from `meta.variant`: `text` → contains / is / is empty…, `number` → `= ≠ > < ≥ ≤`, `date` → before / after / on or before…, `select` / `multiSelect` → is / is any of / is none of. The `variant` prop renders the same builder in a popover or a dialog.
-- **`DataTableSortMenu`** — multi-column sort; order is priority (first row = primary). Secondary columns show a priority badge in their header.
+- **`DataTableFilterMenu`** — a condition builder (`Where [field] [operator] [value]`); rows reorder by dragging the handle. Operators are inferred from `meta.variant`: `text` → contains / is / is empty…, `number` → `= ≠ > < ≥ ≤`, `date` → before / after / on or before…, `select` / `multiSelect` → is / is any of / is none of. The `variant` prop renders the same builder in a popover or a dialog.
+- **`DataTableSortMenu`** — multi-column sort; order is priority (first row = primary), and rows reorder by dragging the handle. Secondary columns show a priority badge in their header.
 - **`DataTableViews`** — save the current `{ filters, sorting }` as a named view in `localStorage` (`shuip:dt-views:<storageKey>`), then apply or delete it.
 
 Conditions live in TanStack's `columnFilters` as `{ id, value: { operator, value } }`. In client mode `useDataTable` registers an operator-aware `filterFn` (`dataTableFilterFn`), so filtering works with no per-column wiring; in server mode, read `table.getState().columnFilters` and translate it to your query. One condition per column (the `columnFilters` model); conditions combine with AND.

--- a/apps/docs/content/blocks/data-table.mdx
+++ b/apps/docs/content/blocks/data-table.mdx
@@ -15,6 +15,7 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 - **Auto-generated toolbar**: faceted filters are derived from each column's `meta.variant` / `meta.options` — no per-table wiring.
 - **Composable**: drop `DataTableToolbar`, `DataTable`, and `DataTablePagination` where you want them; swap any piece.
 - **Per-zone variants**: pagination (`simple` / `numbered`), progressive `DataTableLoadMore` (`button` / `infinite`), toolbar (`default` / `inline-chips` / `minimal`), empty state (`text` / `illustrated` / `with-action`), and loading (`skeleton` / `overlay` / `shimmer`).
+- **Advanced filtering & sorting**: a Notion-style condition builder (`DataTableFilterMenu`, popover or dialog), multi-sort (`DataTableSortMenu`), and saved views in localStorage (`DataTableViews`) — all derived from the same `meta` convention.
 - **Row selection, column visibility, column pinning** (sticky columns), sortable headers, global search.
 - **States**: loading skeleton, empty, and no-results-after-filter.
 
@@ -54,6 +55,24 @@ Each zone of the table is a separate sub-component with its own `variant`, so yo
 <DataTable table={table} isLoading={isLoading} loadingVariant='overlay' />   // keep rows, dim + spinner (best for refetch)
 <DataTable table={table} isLoading={isLoading} loadingVariant='shimmer' />   // animated sweep (reduced-motion aware)
 ```
+
+## Advanced filtering, sorting & saved views
+
+Three composable controls — drop them in any row, no toolbar assumed. Each is driven by the `table` instance alone; the filterable fields and their operators are derived from each column's existing `meta`, so there is no separate filter config to keep in sync.
+
+```tsx
+<div className='flex items-center gap-2'>
+  <DataTableFilterMenu table={table} variant='popover' />  {/* or 'dialog' */}
+  <DataTableSortMenu table={table} />
+  <DataTableViews table={table} storageKey='deals' />
+</div>
+```
+
+- **`DataTableFilterMenu`** — a condition builder (`Where [field] [operator] [value]`). Operators are inferred from `meta.variant`: `text` → contains / is / is empty…, `number` → `= ≠ > < ≥ ≤`, `date` → before / after / on or before…, `select` / `multiSelect` → is / is any of / is none of. The `variant` prop renders the same builder in a popover or a dialog.
+- **`DataTableSortMenu`** — multi-column sort; order is priority (first row = primary). Secondary columns show a priority badge in their header.
+- **`DataTableViews`** — save the current `{ filters, sorting }` as a named view in `localStorage` (`shuip:dt-views:<storageKey>`), then apply or delete it.
+
+Conditions live in TanStack's `columnFilters` as `{ id, value: { operator, value } }`. In client mode `useDataTable` registers an operator-aware `filterFn` (`dataTableFilterFn`), so filtering works with no per-column wiring; in server mode, read `table.getState().columnFilters` and translate it to your query. One condition per column (the `columnFilters` model); conditions combine with AND.
 
 ## The `meta` convention
 

--- a/apps/docs/src/components/item-preview.tsx
+++ b/apps/docs/src/components/item-preview.tsx
@@ -46,7 +46,7 @@ export function Preview({ registryName }: { registryName: string }) {
   }, [registryName]);
 
   return (
-    <div className='w-full min-h-[150px] flex items-center justify-center p-8 bg-background border border-border rounded-md'>
+    <div className='not-prose w-full min-h-[150px] flex items-center justify-center p-8 bg-background border border-border rounded-md'>
       <React.Suspense
         fallback={
           <div className='flex w-full items-center justify-center text-sm text-muted-foreground'>

--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,7 @@
     "ignoreUnknown": true,
     "includes": [
       "**",
+      "!**/.claude/**/*",
       "!**/node_modules/**/*",
       "!**/.next/**/*",
       "!**/.turbo/**/*",

--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,7 @@
         "@repo/ui": "workspace:*",
         "@tanstack/react-form": "catalog:forms",
         "@tanstack/react-query": "catalog:forms",
+        "@tanstack/react-table": "catalog:",
         "class-variance-authority": "catalog:",
         "date-fns": "catalog:",
         "lucide-react": "catalog:",
@@ -136,6 +137,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/postcss": "^4.3.0",
+    "@tanstack/react-table": "^8.21.3",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
@@ -723,7 +725,11 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 

--- a/docs/superpowers/plans/2026-06-14-data-table-block.md
+++ b/docs/superpowers/plans/2026-06-14-data-table-block.md
@@ -1,0 +1,1424 @@
+# DataTable Block Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship one entity-agnostic, dual-mode `data-table` block to the shuip registry, built on TanStack Table v8 + shadcn/ui primitives.
+
+**Architecture:** A single `component.tsx` exports a generic `useDataTable<TData>` hook (auto-selects client vs server mode) plus composable sub-components (`DataTable`, `DataTableToolbar`, `DataTableColumnHeader`, `DataTableFacetedFilter`, `DataTableViewOptions`, `DataTablePagination`). All entity knowledge lives in `ColumnDef[]` + a typed `meta` extension; the components read only the `Table<TData>` instance. Three examples (client / server / rich Twenty-like) and an MDX doc with a copy-paste nuqs URL-sync recipe.
+
+**Tech Stack:** React 19, TanStack Table v8 (`@tanstack/react-table`), Tailwind v4, shadcn/ui primitives (button, input, popover, command, select, separator, checkbox, and a new `table` primitive), lucide-react, Biome.
+
+**No test runner exists in this repo** (the project CLAUDE.md says propose a setup before adding tests — out of scope here). Verification gates are `bun registry:generate` and `bun build:docs` (the authoritative type gate), plus manual preview checks. TDD's test cycle is therefore replaced by generate/build verification at each task.
+
+---
+
+### Task 1: Add the shadcn `table` primitive to `packages/ui`
+
+**Files:**
+- Create: `packages/ui/src/components/ui/table.tsx`
+
+- [ ] **Step 1: Create the table primitive**
+
+```tsx
+'use client';
+
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div data-slot='table-container' className='relative w-full overflow-x-auto'>
+      <table data-slot='table' className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot='table-header' className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return <tbody data-slot='table-body' className={cn('[&_tr:last-child]:border-0', className)} {...props} />;
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot='table-footer'
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot='table-row'
+      className={cn('hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors', className)}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot='table-head'
+      className={cn(
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot='table-cell'
+      className={cn(
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return <caption data-slot='table-caption' className={cn('text-muted-foreground mt-4 text-sm', className)} {...props} />;
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };
+```
+
+- [ ] **Step 2: Verify it typechecks in `packages/ui`**
+
+Run: `cd packages/ui && bunx tsc --noEmit`
+Expected: no errors referencing `table.tsx` (a pre-existing `baseUrl` TS5101 deprecation notice elsewhere is harmless).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/ui/table.tsx
+git commit -m "feat(ui): add table primitive"
+```
+
+---
+
+### Task 2: Add `@tanstack/react-table` to the catalog and registry deps
+
+**Files:**
+- Modify: `package.json` (root `workspaces.catalog`)
+- Modify: `packages/registry/package.json` (dependencies)
+
+- [ ] **Step 1: Add the dependency to the root catalog**
+
+In `package.json`, inside `"workspaces"."catalog"`, add this line after the `"@dnd-kit/utilities"` entry (keep valid JSON — add a comma to the previous last entry):
+
+```json
+"@tanstack/react-table": "^8.21.3"
+```
+
+- [ ] **Step 2: Reference it from the registry workspace**
+
+In `packages/registry/package.json`, inside `"dependencies"`, add after the `"@tanstack/react-query"` line:
+
+```json
+"@tanstack/react-table": "catalog:",
+```
+
+- [ ] **Step 3: Install**
+
+Run: `bun install`
+Expected: lockfile updates, `@tanstack/react-table` resolves to the catalog version, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json packages/registry/package.json bun.lock
+git commit -m "build(deps): add @tanstack/react-table to catalog"
+```
+
+---
+
+### Task 3: Create the data-table `component.tsx`
+
+**Files:**
+- Create: `packages/registry/items/blocks/data-table/component.tsx`
+
+This is the whole system. It imports `@/components/ui/table` (→ auto-detected `registryDependencies: ["table"]`) and `@tanstack/react-table` (→ auto-detected `dependencies`).
+
+- [ ] **Step 1: Write the full component**
+
+```tsx
+'use client';
+
+import {
+  type Column,
+  type ColumnDef,
+  type ColumnFiltersState,
+  type ColumnPinningState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type OnChangeFn,
+  type PaginationState,
+  type RowData,
+  type RowSelectionState,
+  type SortingState,
+  type Table,
+  useReactTable,
+  type VisibilityState,
+} from '@tanstack/react-table';
+import {
+  ArrowDown,
+  ArrowUp,
+  CheckIcon,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  ChevronsUpDown,
+  EyeOff,
+  PlusCircle,
+  Settings2,
+  X,
+} from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import {
+  Table as TableRoot,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+export type DataTableFilterOption = {
+  label: string;
+  value: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  count?: number;
+};
+
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    label?: string;
+    placeholder?: string;
+    variant?: 'text' | 'number' | 'date' | 'select' | 'multiSelect';
+    options?: DataTableFilterOption[];
+    icon?: React.ComponentType<{ className?: string }>;
+  }
+}
+
+export type UseDataTableProps<TData> = {
+  data: TData[];
+  columns: ColumnDef<TData, unknown>[];
+  pageCount?: number;
+  getRowId?: (row: TData, index: number) => string;
+  enableRowSelection?: boolean;
+  enableColumnPinning?: boolean;
+  initialState?: {
+    pagination?: PaginationState;
+    sorting?: SortingState;
+    columnVisibility?: VisibilityState;
+    columnPinning?: ColumnPinningState;
+  };
+  state?: {
+    pagination?: PaginationState;
+    sorting?: SortingState;
+    columnFilters?: ColumnFiltersState;
+    globalFilter?: string;
+  };
+  onPaginationChange?: OnChangeFn<PaginationState>;
+  onSortingChange?: OnChangeFn<SortingState>;
+  onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>;
+  onGlobalFilterChange?: OnChangeFn<string>;
+};
+
+export function useDataTable<TData>(props: UseDataTableProps<TData>) {
+  const {
+    data,
+    columns,
+    pageCount,
+    getRowId,
+    enableRowSelection = false,
+    enableColumnPinning = false,
+    initialState,
+  } = props;
+
+  const manual = pageCount != null;
+
+  const [sorting, setSorting] = React.useState<SortingState>(initialState?.sorting ?? []);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState('');
+  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>(
+    initialState?.columnVisibility ?? {},
+  );
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+  const [pagination, setPagination] = React.useState<PaginationState>(
+    initialState?.pagination ?? { pageIndex: 0, pageSize: 10 },
+  );
+  const [columnPinning, setColumnPinning] = React.useState<ColumnPinningState>({
+    left: initialState?.columnPinning?.left ?? [],
+    right: initialState?.columnPinning?.right ?? [],
+  });
+
+  const table = useReactTable({
+    data,
+    columns,
+    pageCount: pageCount ?? undefined,
+    state: {
+      sorting: props.state?.sorting ?? sorting,
+      columnFilters: props.state?.columnFilters ?? columnFilters,
+      globalFilter: props.state?.globalFilter ?? globalFilter,
+      columnVisibility,
+      rowSelection,
+      pagination: props.state?.pagination ?? pagination,
+      columnPinning,
+    },
+    enableRowSelection,
+    enableColumnPinning,
+    getRowId,
+    manualPagination: manual,
+    manualSorting: manual,
+    manualFiltering: manual,
+    onSortingChange: props.onSortingChange ?? setSorting,
+    onColumnFiltersChange: props.onColumnFiltersChange ?? setColumnFilters,
+    onGlobalFilterChange: props.onGlobalFilterChange ?? setGlobalFilter,
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    onPaginationChange: props.onPaginationChange ?? setPagination,
+    onColumnPinningChange: setColumnPinning,
+    getCoreRowModel: getCoreRowModel(),
+    ...(manual
+      ? {}
+      : {
+          getSortedRowModel: getSortedRowModel(),
+          getFilteredRowModel: getFilteredRowModel(),
+          getPaginationRowModel: getPaginationRowModel(),
+          getFacetedRowModel: getFacetedRowModel(),
+          getFacetedUniqueValues: getFacetedUniqueValues(),
+        }),
+  });
+
+  return { table };
+}
+
+function getPinStyles<TData>(column: Column<TData>): React.CSSProperties {
+  const pinned = column.getIsPinned();
+  if (!pinned) return {};
+  return {
+    position: 'sticky',
+    left: pinned === 'left' ? column.getStart('left') : undefined,
+    right: pinned === 'right' ? column.getAfter('right') : undefined,
+    zIndex: 1,
+  };
+}
+
+function getPinClass<TData>(column: Column<TData>): string | undefined {
+  return column.getIsPinned() ? 'bg-background' : undefined;
+}
+
+export type DataTableProps<TData> = {
+  table: Table<TData>;
+  isLoading?: boolean;
+  emptyState?: React.ReactNode;
+  onRowClick?: (row: TData) => void;
+  className?: string;
+};
+
+export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, className }: DataTableProps<TData>) {
+  const columnCount = table.getAllLeafColumns().length;
+  const rows = table.getRowModel().rows;
+
+  return (
+    <div className={cn('rounded-md border', className)}>
+      <TableRoot>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} style={getPinStyles(header.column)} className={getPinClass(header.column)}>
+                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {isLoading ? (
+            Array.from({ length: table.getState().pagination.pageSize }).map((_, rowIndex) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+              <TableRow key={rowIndex}>
+                {Array.from({ length: columnCount }).map((__, cellIndex) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+                  <TableCell key={cellIndex}>
+                    <div className='h-5 w-full animate-pulse rounded bg-muted' />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : rows.length ? (
+            rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() ? 'selected' : undefined}
+                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                className={onRowClick ? 'cursor-pointer' : undefined}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} style={getPinStyles(cell.column)} className={getPinClass(cell.column)}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columnCount} className='h-24 text-center'>
+                {emptyState ?? 'No results.'}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </TableRoot>
+    </div>
+  );
+}
+
+export type DataTableColumnHeaderProps<TData, TValue> = {
+  column: Column<TData, TValue>;
+  title: string;
+  className?: string;
+};
+
+export function DataTableColumnHeader<TData, TValue>({
+  column,
+  title,
+  className,
+}: DataTableColumnHeaderProps<TData, TValue>) {
+  if (!column.getCanSort() && !column.getCanHide()) {
+    return <div className={className}>{title}</div>;
+  }
+
+  const sorted = column.getIsSorted();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='ghost' size='sm' className={cn('-ml-3 h-8 data-[state=open]:bg-accent', className)}>
+          <span>{title}</span>
+          {sorted === 'desc' ? (
+            <ArrowDown className='ml-2 size-4' />
+          ) : sorted === 'asc' ? (
+            <ArrowUp className='ml-2 size-4' />
+          ) : (
+            <ChevronsUpDown className='ml-2 size-4' />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='start' className='flex w-40 flex-col gap-0.5 p-1'>
+        {column.getCanSort() && (
+          <>
+            <Button variant='ghost' size='sm' className='justify-start' onClick={() => column.toggleSorting(false)}>
+              <ArrowUp className='mr-2 size-3.5 text-muted-foreground/70' /> Asc
+            </Button>
+            <Button variant='ghost' size='sm' className='justify-start' onClick={() => column.toggleSorting(true)}>
+              <ArrowDown className='mr-2 size-3.5 text-muted-foreground/70' /> Desc
+            </Button>
+          </>
+        )}
+        {column.getCanHide() && (
+          <Button variant='ghost' size='sm' className='justify-start' onClick={() => column.toggleVisibility(false)}>
+            <EyeOff className='mr-2 size-3.5 text-muted-foreground/70' /> Hide
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export type DataTableFacetedFilterProps<TData, TValue> = {
+  column?: Column<TData, TValue>;
+  title?: string;
+  options: DataTableFilterOption[];
+};
+
+export function DataTableFacetedFilter<TData, TValue>({
+  column,
+  title,
+  options,
+}: DataTableFacetedFilterProps<TData, TValue>) {
+  const facets = column?.getFacetedUniqueValues();
+  const selectedValues = new Set((column?.getFilterValue() as string[]) ?? []);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='h-8 border-dashed'>
+          <PlusCircle className='mr-2 size-4' />
+          {title}
+          {selectedValues.size > 0 && (
+            <>
+              <Separator orientation='vertical' className='mx-2 h-4' />
+              <span className='rounded-sm bg-secondary px-1 font-normal text-xs'>{selectedValues.size}</span>
+            </>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className='w-48 p-0' align='start'>
+        <Command>
+          <CommandInput placeholder={title} />
+          <CommandList>
+            <CommandEmpty>No results.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = selectedValues.has(option.value);
+                return (
+                  <CommandItem
+                    key={option.value}
+                    onSelect={() => {
+                      if (isSelected) selectedValues.delete(option.value);
+                      else selectedValues.add(option.value);
+                      const filterValues = Array.from(selectedValues);
+                      column?.setFilterValue(filterValues.length ? filterValues : undefined);
+                    }}
+                  >
+                    <div
+                      className={cn(
+                        'mr-2 flex size-4 items-center justify-center rounded-sm border border-primary',
+                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible',
+                      )}
+                    >
+                      <CheckIcon className='size-3.5' />
+                    </div>
+                    {option.icon && <option.icon className='mr-2 size-4 text-muted-foreground' />}
+                    <span>{option.label}</span>
+                    {facets?.get(option.value) && (
+                      <span className='ml-auto flex size-4 items-center justify-center font-mono text-xs'>
+                        {facets.get(option.value)}
+                      </span>
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            {selectedValues.size > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem onSelect={() => column?.setFilterValue(undefined)} className='justify-center text-center'>
+                    Clear filters
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function DataTableViewOptions<TData>({ table }: { table: Table<TData> }) {
+  const columns = table.getAllColumns().filter((column) => typeof column.accessorFn !== 'undefined' && column.getCanHide());
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='ml-auto hidden h-8 lg:flex'>
+          <Settings2 className='mr-2 size-4' /> View
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='w-44 p-0'>
+        <Command>
+          <CommandInput placeholder='Search columns...' />
+          <CommandList>
+            <CommandEmpty>No columns.</CommandEmpty>
+            <CommandGroup>
+              {columns.map((column) => (
+                <CommandItem key={column.id} onSelect={() => column.toggleVisibility(!column.getIsVisible())}>
+                  <CheckIcon className={cn('mr-2 size-4', column.getIsVisible() ? 'opacity-100' : 'opacity-0')} />
+                  <span className='truncate'>{column.columnDef.meta?.label ?? column.id}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export type DataTableToolbarProps<TData> = {
+  table: Table<TData>;
+  searchPlaceholder?: string;
+  children?: React.ReactNode;
+};
+
+export function DataTableToolbar<TData>({ table, searchPlaceholder = 'Search...', children }: DataTableToolbarProps<TData>) {
+  const isFiltered = table.getState().columnFilters.length > 0 || Boolean(table.getState().globalFilter);
+  const filterableColumns = table
+    .getAllColumns()
+    .filter((column) => column.getCanFilter() && column.columnDef.meta?.variant);
+
+  return (
+    <div className='flex flex-wrap items-center gap-2'>
+      <Input
+        placeholder={searchPlaceholder}
+        value={(table.getState().globalFilter as string) ?? ''}
+        onChange={(event) => table.setGlobalFilter(event.target.value)}
+        className='h-8 w-40 lg:w-56'
+      />
+      {filterableColumns.map((column) => {
+        const meta = column.columnDef.meta;
+        if ((meta?.variant === 'select' || meta?.variant === 'multiSelect') && meta.options) {
+          return (
+            <DataTableFacetedFilter
+              key={column.id}
+              column={column}
+              title={meta.label ?? column.id}
+              options={meta.options}
+            />
+          );
+        }
+        return null;
+      })}
+      {isFiltered && (
+        <Button
+          variant='ghost'
+          size='sm'
+          className='h-8 px-2'
+          onClick={() => {
+            table.resetColumnFilters();
+            table.setGlobalFilter('');
+          }}
+        >
+          Reset <X className='ml-2 size-4' />
+        </Button>
+      )}
+      {children}
+      <DataTableViewOptions table={table} />
+    </div>
+  );
+}
+
+export type DataTablePaginationProps<TData> = {
+  table: Table<TData>;
+  pageSizeOptions?: number[];
+};
+
+export function DataTablePagination<TData>({
+  table,
+  pageSizeOptions = [10, 20, 30, 40, 50],
+}: DataTablePaginationProps<TData>) {
+  return (
+    <div className='flex flex-wrap items-center justify-between gap-4'>
+      <div className='text-muted-foreground text-sm'>
+        {table.getFilteredSelectedRowModel().rows.length} of {table.getFilteredRowModel().rows.length} row(s) selected.
+      </div>
+      <div className='flex flex-wrap items-center gap-4 lg:gap-6'>
+        <div className='flex items-center gap-2'>
+          <p className='font-medium text-sm'>Rows per page</p>
+          <Select
+            value={`${table.getState().pagination.pageSize}`}
+            onValueChange={(value) => table.setPageSize(Number(value))}
+          >
+            <SelectTrigger className='h-8 w-[72px]'>
+              <SelectValue placeholder={table.getState().pagination.pageSize} />
+            </SelectTrigger>
+            <SelectContent side='top'>
+              {pageSizeOptions.map((size) => (
+                <SelectItem key={size} value={`${size}`}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className='flex items-center font-medium text-sm'>
+          Page {table.getState().pagination.pageIndex + 1} of {Math.max(table.getPageCount(), 1)}
+        </div>
+        <div className='flex items-center gap-2'>
+          <Button
+            variant='outline'
+            size='icon-sm'
+            className='hidden lg:flex'
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronsLeft className='size-4' />
+          </Button>
+          <Button
+            variant='outline'
+            size='icon-sm'
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronLeft className='size-4' />
+          </Button>
+          <Button variant='outline' size='icon-sm' onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+            <ChevronRight className='size-4' />
+          </Button>
+          <Button
+            variant='outline'
+            size='icon-sm'
+            className='hidden lg:flex'
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <ChevronsRight className='size-4' />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit** (full verification happens in Task 8 after generate)
+
+```bash
+git add packages/registry/items/blocks/data-table/component.tsx
+git commit -m "feat(data-table): add entity-agnostic data-table block component"
+```
+
+---
+
+### Task 4: Create the default (client-side) example
+
+**Files:**
+- Create: `packages/registry/items/blocks/data-table/default.example.tsx`
+
+Blocks are imported via the `@/components/block/shuip/<name>` stub alias (mirrors the kanban example).
+
+- [ ] **Step 1: Write the example**
+
+```tsx
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'editor' | 'viewer';
+  status: 'active' | 'invited' | 'suspended';
+};
+
+const users: User[] = [
+  { id: '1', name: 'Ava Mercer', email: 'ava@acme.io', role: 'admin', status: 'active' },
+  { id: '2', name: 'Liam Cho', email: 'liam@acme.io', role: 'editor', status: 'active' },
+  { id: '3', name: 'Noah Patel', email: 'noah@acme.io', role: 'editor', status: 'invited' },
+  { id: '4', name: 'Mia Rossi', email: 'mia@acme.io', role: 'viewer', status: 'suspended' },
+  { id: '5', name: 'Ethan Wood', email: 'ethan@acme.io', role: 'viewer', status: 'active' },
+  { id: '6', name: 'Zoe Bauer', email: 'zoe@acme.io', role: 'admin', status: 'invited' },
+  { id: '7', name: 'Kai Nguyen', email: 'kai@acme.io', role: 'editor', status: 'active' },
+  { id: '8', name: 'Lena Fox', email: 'lena@acme.io', role: 'viewer', status: 'suspended' },
+];
+
+const roleOptions = [
+  { label: 'Admin', value: 'admin' },
+  { label: 'Editor', value: 'editor' },
+  { label: 'Viewer', value: 'viewer' },
+];
+
+const statusOptions = [
+  { label: 'Active', value: 'active' },
+  { label: 'Invited', value: 'invited' },
+  { label: 'Suspended', value: 'suspended' },
+];
+
+export default function DataTableDefaultExample() {
+  const columns = React.useMemo<ColumnDef<User>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        meta: { label: 'Name' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.name}</span>,
+      },
+      {
+        accessorKey: 'email',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
+        meta: { label: 'Email' },
+        cell: ({ row }) => <span className='text-muted-foreground'>{row.original.email}</span>,
+      },
+      {
+        accessorKey: 'role',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Role' />,
+        meta: { label: 'Role', variant: 'multiSelect', options: roleOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => <span className='capitalize'>{row.original.role}</span>,
+      },
+      {
+        accessorKey: 'status',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        meta: { label: 'Status', variant: 'multiSelect', options: statusOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: users,
+    columns,
+    getRowId: (row) => row.id,
+    initialState: { pagination: { pageIndex: 0, pageSize: 5 } },
+  });
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <DataTableToolbar table={table} searchPlaceholder='Search users...' />
+      <DataTable table={table} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/registry/items/blocks/data-table/default.example.tsx
+git commit -m "feat(data-table): add client-side example"
+```
+
+---
+
+### Task 5: Create the server-side example
+
+**Files:**
+- Create: `packages/registry/items/blocks/data-table/server.example.tsx`
+
+Simulates a backend: an in-memory dataset queried with a `setTimeout` delay, driven by controlled pagination/sorting/filter state passed into `useDataTable` with `pageCount`.
+
+- [ ] **Step 1: Write the example**
+
+```tsx
+'use client';
+
+import type { ColumnDef, ColumnFiltersState, PaginationState, SortingState } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+
+type Order = {
+  id: string;
+  customer: string;
+  total: number;
+  status: 'paid' | 'pending' | 'refunded';
+};
+
+const STATUSES: Order['status'][] = ['paid', 'pending', 'refunded'];
+const CUSTOMERS = ['Acme', 'Globex', 'Initech', 'Umbrella', 'Hooli', 'Soylent', 'Stark', 'Wayne'];
+
+const ALL_ORDERS: Order[] = Array.from({ length: 47 }, (_, index) => ({
+  id: `ORD-${1000 + index}`,
+  customer: CUSTOMERS[index % CUSTOMERS.length],
+  total: Math.round(50 + ((index * 73) % 950)),
+  status: STATUSES[index % STATUSES.length],
+}));
+
+const statusOptions = [
+  { label: 'Paid', value: 'paid' },
+  { label: 'Pending', value: 'pending' },
+  { label: 'Refunded', value: 'refunded' },
+];
+
+type QueryArgs = {
+  pagination: PaginationState;
+  sorting: SortingState;
+  columnFilters: ColumnFiltersState;
+  globalFilter: string;
+};
+
+function queryOrders({ pagination, sorting, columnFilters, globalFilter }: QueryArgs): { rows: Order[]; total: number } {
+  let rows = [...ALL_ORDERS];
+
+  const search = globalFilter.trim().toLowerCase();
+  if (search) {
+    rows = rows.filter((order) => `${order.id} ${order.customer}`.toLowerCase().includes(search));
+  }
+
+  const statusFilter = columnFilters.find((filter) => filter.id === 'status')?.value as string[] | undefined;
+  if (statusFilter?.length) {
+    rows = rows.filter((order) => statusFilter.includes(order.status));
+  }
+
+  const sort = sorting[0];
+  if (sort) {
+    rows.sort((a, b) => {
+      const left = a[sort.id as keyof Order];
+      const right = b[sort.id as keyof Order];
+      if (left < right) return sort.desc ? 1 : -1;
+      if (left > right) return sort.desc ? -1 : 1;
+      return 0;
+    });
+  }
+
+  const total = rows.length;
+  const start = pagination.pageIndex * pagination.pageSize;
+  return { rows: rows.slice(start, start + pagination.pageSize), total };
+}
+
+export default function DataTableServerExample() {
+  const [pagination, setPagination] = React.useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState('');
+  const [result, setResult] = React.useState<{ rows: Order[]; total: number }>({ rows: [], total: 0 });
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      setResult(queryOrders({ pagination, sorting, columnFilters, globalFilter }));
+      setIsLoading(false);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [pagination, sorting, columnFilters, globalFilter]);
+
+  const columns = React.useMemo<ColumnDef<Order>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Order' />,
+        meta: { label: 'Order' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.id}</span>,
+      },
+      {
+        accessorKey: 'customer',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Customer' />,
+        meta: { label: 'Customer' },
+      },
+      {
+        accessorKey: 'total',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Total' />,
+        meta: { label: 'Total' },
+        cell: ({ row }) => <span className='tabular-nums'>${row.original.total}</span>,
+      },
+      {
+        accessorKey: 'status',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        meta: { label: 'Status', variant: 'multiSelect', options: statusOptions },
+        cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: result.rows,
+    columns,
+    pageCount: Math.ceil(result.total / pagination.pageSize),
+    getRowId: (row) => row.id,
+    state: { pagination, sorting, columnFilters, globalFilter },
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+  });
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <DataTableToolbar table={table} searchPlaceholder='Search orders...' />
+      <DataTable table={table} isLoading={isLoading} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/registry/items/blocks/data-table/server.example.tsx
+git commit -m "feat(data-table): add server-side example"
+```
+
+---
+
+### Task 6: Create the rich (Twenty-like) example
+
+**Files:**
+- Create: `packages/registry/items/blocks/data-table/rich.example.tsx`
+
+Demonstrates row selection (checkbox column), column pinning (sticky select + name), and typed cells (avatar, status pill, chips) rendered inline with Tailwind.
+
+- [ ] **Step 1: Write the example**
+
+```tsx
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+
+type Person = {
+  id: string;
+  name: string;
+  email: string;
+  team: string;
+  stage: 'lead' | 'qualified' | 'won';
+  tags: string[];
+};
+
+const people: Person[] = [
+  { id: '1', name: 'Ava Mercer', email: 'ava@acme.io', team: 'Growth', stage: 'won', tags: ['VIP', 'EU'] },
+  { id: '2', name: 'Liam Cho', email: 'liam@acme.io', team: 'Sales', stage: 'qualified', tags: ['US'] },
+  { id: '3', name: 'Noah Patel', email: 'noah@acme.io', team: 'Sales', stage: 'lead', tags: ['Inbound'] },
+  { id: '4', name: 'Mia Rossi', email: 'mia@acme.io', team: 'Success', stage: 'won', tags: ['VIP'] },
+  { id: '5', name: 'Ethan Wood', email: 'ethan@acme.io', team: 'Growth', stage: 'lead', tags: ['EU', 'Trial'] },
+  { id: '6', name: 'Zoe Bauer', email: 'zoe@acme.io', team: 'Success', stage: 'qualified', tags: ['US'] },
+];
+
+const stageStyles: Record<Person['stage'], string> = {
+  lead: 'bg-muted text-muted-foreground',
+  qualified: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+  won: 'bg-green-500/15 text-green-600 dark:text-green-400',
+};
+
+const stageOptions = [
+  { label: 'Lead', value: 'lead' },
+  { label: 'Qualified', value: 'qualified' },
+  { label: 'Won', value: 'won' },
+];
+
+function Avatar({ name }: { name: string }) {
+  const initials = name
+    .split(' ')
+    .map((part) => part[0])
+    .slice(0, 2)
+    .join('');
+  return (
+    <span className='flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 font-medium text-primary text-xs'>
+      {initials}
+    </span>
+  );
+}
+
+export default function DataTableRichExample() {
+  const columns = React.useMemo<ColumnDef<Person>[]>(
+    () => [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <Checkbox
+            checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(Boolean(value))}
+            aria-label='Select all'
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
+            aria-label='Select row'
+          />
+        ),
+        enableSorting: false,
+        enableHiding: false,
+        size: 40,
+      },
+      {
+        accessorKey: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        meta: { label: 'Name' },
+        cell: ({ row }) => (
+          <div className='flex items-center gap-2'>
+            <Avatar name={row.original.name} />
+            <span className='font-medium'>{row.original.name}</span>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'email',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
+        meta: { label: 'Email' },
+        cell: ({ row }) => <span className='text-muted-foreground'>{row.original.email}</span>,
+      },
+      {
+        accessorKey: 'team',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Team' />,
+        meta: { label: 'Team' },
+      },
+      {
+        accessorKey: 'stage',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Stage' />,
+        meta: { label: 'Stage', variant: 'multiSelect', options: stageOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => (
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium text-xs capitalize ${stageStyles[row.original.stage]}`}
+          >
+            {row.original.stage}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'tags',
+        header: 'Tags',
+        enableSorting: false,
+        meta: { label: 'Tags' },
+        cell: ({ row }) => (
+          <div className='flex flex-wrap gap-1'>
+            {row.original.tags.map((tag) => (
+              <span key={tag} className='rounded border bg-muted px-1.5 py-0.5 text-muted-foreground text-xs'>
+                {tag}
+              </span>
+            ))}
+          </div>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: people,
+    columns,
+    getRowId: (row) => row.id,
+    enableRowSelection: true,
+    enableColumnPinning: true,
+    initialState: { columnPinning: { left: ['select', 'name'], right: [] } },
+  });
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <DataTableToolbar table={table} searchPlaceholder='Search people...' />
+      <DataTable table={table} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/registry/items/blocks/data-table/rich.example.tsx
+git commit -m "feat(data-table): add rich Twenty-like example"
+```
+
+---
+
+### Task 7: Create the docs MDX page (with nuqs URL-sync recipe)
+
+**Files:**
+- Create: `apps/docs/content/blocks/data-table.mdx`
+
+Blocks docs are real MDX files under `content/blocks/` (NOT `index.mdx` in the item folder). Match the kanban MDX frontmatter shape (`title`, `description`, `registryName`).
+
+- [ ] **Step 1: Write the MDX**
+
+````mdx
+---
+title: Data Table
+description: An entity-agnostic, dual-mode data table built on TanStack Table. Define your columns and drop in your data — client-side out of the box, or server-side with pagination, sorting, and filtering.
+registryName: data-table
+---
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+`DataTable` is a generic table system (`useDataTable<TData>` + composable sub-components) that renders any array of typed rows. All per-entity configuration lives in your TanStack `ColumnDef[]` and a typed `meta` extension; the components only ever read the table instance, so nothing is hardcoded to a domain.
+
+### Built-in features
+
+- **Generic data model**: `useDataTable<T>` works with any row type via `ColumnDef<T>[]`.
+- **Dual mode**: client-side out of the box (sorting, filtering, pagination computed in memory) or server-side by passing `pageCount` + controlled state and `on*Change` handlers.
+- **Auto-generated toolbar**: faceted filters are derived from each column's `meta.variant` / `meta.options` — no per-table wiring.
+- **Composable**: drop `DataTableToolbar`, `DataTable`, and `DataTablePagination` where you want them; swap any piece.
+- **Row selection, column visibility, column pinning** (sticky columns), sortable headers, global search.
+- **States**: loading skeleton, empty, and no-results-after-filter.
+
+## Examples
+
+<ItemExamples registryName={'data-table'} />
+
+## The `meta` convention
+
+Per-entity configuration rides on TanStack's `ColumnMeta`, augmented by this block:
+
+```ts
+interface ColumnMeta {
+  label?: string;
+  placeholder?: string;
+  variant?: 'text' | 'number' | 'date' | 'select' | 'multiSelect';
+  options?: { label: string; value: string; icon?: React.ComponentType; count?: number }[];
+  icon?: React.ComponentType;
+}
+```
+
+A column with `meta.variant: 'multiSelect'` and `meta.options` automatically gets a faceted filter in the toolbar. For client-side multi-select filtering, set `filterFn: 'arrIncludesSome'` on that column.
+
+## Client vs server mode
+
+Client mode is the default — pass `data` and `columns` and the table computes everything:
+
+```tsx
+const { table } = useDataTable({ data, columns, getRowId: (row) => row.id });
+```
+
+Server mode activates when you pass `pageCount`. Control the state yourself and react to changes by refetching:
+
+```tsx
+const { table } = useDataTable({
+  data: result.rows,
+  columns,
+  pageCount: Math.ceil(result.total / pagination.pageSize),
+  state: { pagination, sorting, columnFilters, globalFilter },
+  onPaginationChange: setPagination,
+  onSortingChange: setSorting,
+  onColumnFiltersChange: setColumnFilters,
+  onGlobalFilterChange: setGlobalFilter,
+});
+```
+
+## Recipe: sync state to the URL with nuqs
+
+Server mode pairs naturally with shareable, bookmarkable URLs. This is opt-in and not bundled with the block (it would force a router dependency on every consumer). Install nuqs and wrap your app once:
+
+```bash
+bun add nuqs
+```
+
+```tsx
+// app/layout.tsx
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang='en'>
+      <body>
+        <NuqsAdapter>{children}</NuqsAdapter>
+      </body>
+    </html>
+  );
+}
+```
+
+Then drop in this hook and feed its output straight into `useDataTable`:
+
+```tsx
+// hooks/use-data-table-url-state.ts
+'use client';
+
+import type { ColumnFiltersState, PaginationState, SortingState } from '@tanstack/react-table';
+import { parseAsInteger, parseAsJson, parseAsString, useQueryStates } from 'nuqs';
+
+export function useDataTableUrlState() {
+  const [state, setState] = useQueryStates(
+    {
+      pageIndex: parseAsInteger.withDefault(0),
+      pageSize: parseAsInteger.withDefault(10),
+      sorting: parseAsJson<SortingState>((value) => value as SortingState).withDefault([]),
+      columnFilters: parseAsJson<ColumnFiltersState>((value) => value as ColumnFiltersState).withDefault([]),
+      globalFilter: parseAsString.withDefault(''),
+    },
+    { history: 'push', shallow: false, throttleMs: 50, clearOnDefault: true },
+  );
+
+  const pagination: PaginationState = { pageIndex: state.pageIndex, pageSize: state.pageSize };
+
+  return {
+    pagination,
+    sorting: state.sorting,
+    columnFilters: state.columnFilters,
+    globalFilter: state.globalFilter,
+    onPaginationChange: (updater: PaginationState | ((old: PaginationState) => PaginationState)) => {
+      const next = typeof updater === 'function' ? updater(pagination) : updater;
+      void setState({ pageIndex: next.pageIndex, pageSize: next.pageSize });
+    },
+    onSortingChange: (updater: SortingState | ((old: SortingState) => SortingState)) => {
+      const next = typeof updater === 'function' ? updater(state.sorting) : updater;
+      void setState({ sorting: next, pageIndex: 0 });
+    },
+    onColumnFiltersChange: (updater: ColumnFiltersState | ((old: ColumnFiltersState) => ColumnFiltersState)) => {
+      const next = typeof updater === 'function' ? updater(state.columnFilters) : updater;
+      void setState({ columnFilters: next, pageIndex: 0 });
+    },
+    onGlobalFilterChange: (updater: string | ((old: string) => string)) => {
+      const next = typeof updater === 'function' ? updater(state.globalFilter) : updater;
+      void setState({ globalFilter: next, pageIndex: 0 });
+    },
+  };
+}
+```
+
+```tsx
+const url = useDataTableUrlState();
+const { table } = useDataTable({
+  data: result.rows,
+  columns,
+  pageCount: Math.ceil(result.total / url.pagination.pageSize),
+  state: url,
+  onPaginationChange: url.onPaginationChange,
+  onSortingChange: url.onSortingChange,
+  onColumnFiltersChange: url.onColumnFiltersChange,
+  onGlobalFilterChange: url.onGlobalFilterChange,
+});
+```
+
+## Props
+
+<TypeTable
+  type={{
+    data: { description: 'The rows to render.', type: 'TData[]' },
+    columns: { description: 'TanStack column definitions. Carry per-entity config in meta.', type: 'ColumnDef<TData>[]' },
+    pageCount: { description: 'Total page count. Passing it switches the table to server-side (manual) mode.', type: 'number?' },
+    getRowId: { description: 'Stable row id, so selection survives pagination/sorting/refetch.', type: '(row: TData, index: number) => string' },
+    enableRowSelection: { description: 'Enable row selection.', type: 'boolean', default: 'false' },
+    enableColumnPinning: { description: 'Enable sticky pinned columns.', type: 'boolean', default: 'false' },
+    initialState: { description: 'Initial pagination / sorting / columnVisibility / columnPinning.', type: 'object?' },
+    state: { description: 'Controlled state for server mode (pagination, sorting, columnFilters, globalFilter).', type: 'object?' },
+    onPaginationChange: { description: 'Pagination change handler (server mode).', type: 'OnChangeFn<PaginationState>?' },
+    onSortingChange: { description: 'Sorting change handler (server mode).', type: 'OnChangeFn<SortingState>?' },
+    onColumnFiltersChange: { description: 'Column filters change handler (server mode).', type: 'OnChangeFn<ColumnFiltersState>?' },
+    onGlobalFilterChange: { description: 'Global filter change handler (server mode).', type: 'OnChangeFn<string>?' },
+  }}
+/>
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/docs/content/blocks/data-table.mdx
+git commit -m "docs(data-table): add docs page with nuqs url-sync recipe"
+```
+
+---
+
+### Task 8: Generate registry artifacts and verify the item
+
+**Files:**
+- (generated) `packages/registry/registry.json`, `packages/registry/__index__.ts`, `packages/registry/stubs/blocks/data-table.ts`, `apps/docs/public/r/data-table.json`
+
+- [ ] **Step 1: Run the generator**
+
+Run: `bun registry:generate`
+Expected: console shows `[generate] N items processed` with N increased by one vs before. No "missing component.tsx" warning for `data-table`.
+
+- [ ] **Step 2: Verify the generated registry entry**
+
+Run: `grep -A8 '"name": "data-table"' packages/registry/registry.json`
+Expected: the entry has `"type": "registry:block"`, `dependencies` containing `@tanstack/react-table`, and `registryDependencies` containing `table`. (The four example files are not in the registry `files` array — that is correct; examples are preview-only.)
+
+- [ ] **Step 3: Verify the stub re-exports the named exports**
+
+Run: `cat packages/registry/stubs/blocks/data-table.ts`
+Expected: a re-export (`export * from ...`) pointing at the item's `component`. The examples import named symbols (`useDataTable`, `DataTable`, ...) through `@/components/block/shuip/data-table`, so the stub must surface them. If the generator emits a default-only stub, stop and report — the block needs named exports.
+
+- [ ] **Step 4: Regenerate fumadocs source types**
+
+Run: `cd apps/docs && bunx fumadocs-mdx`
+Expected: `.source` regenerates without error; the `data-table` block doc is picked up.
+
+- [ ] **Step 5: Commit generated artifacts**
+
+```bash
+git add packages/registry/registry.json packages/registry/__index__.ts packages/registry/stubs apps/docs/public/r apps/docs/content/components
+git commit -m "chore(registry): regenerate artifacts for data-table block"
+```
+
+---
+
+### Task 9: Full build / type gate
+
+- [ ] **Step 1: Biome check**
+
+Run: `bun check`
+Expected: no errors. Fix any reported issues (formatting is auto-written).
+
+- [ ] **Step 2: Authoritative type gate via docs build**
+
+Run: `NODE_OPTIONS=--max-old-space-size=6144 bun build:docs`
+Expected: build succeeds. `next build` is the authoritative type gate — all four data-table files (component + 3 examples) and the MDX must compile. If it OOMs (exit 137), re-run with the same `NODE_OPTIONS` already set.
+
+- [ ] **Step 3: If anything failed, fix at the root and re-run**
+
+Do not patch around type errors. Common causes: a primitive export name mismatch (re-check against `packages/ui/src/components/ui/*`), a missing `filterFn: 'arrIncludesSome'` on a multiSelect column, or the `meta` augmentation not being visible (it lives in `component.tsx` and must be imported transitively via the stub — it is).
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(data-table): resolve type/lint issues from build"
+```
+
+---
+
+### Task 10: Manual preview verification
+
+- [ ] **Step 1: Run the docs dev server**
+
+Run: `bun dev:docs`
+Then open `/blocks/data-table`.
+
+- [ ] **Step 2: Verify each example**
+
+- Default: sort via header menu, type in search, open a faceted filter (Role/Status) and toggle values, hide a column via View, paginate. Counts appear in faceted options.
+- Server: paginate/sort/filter — a brief skeleton appears on each change (the 400ms simulated fetch), and results update.
+- Rich: the select + name columns stay pinned while scrolling horizontally; checkboxes select rows; status pills and tag chips render.
+
+- [ ] **Step 3: Stop the dev server.** No commit (verification only).
+
+---
+
+## Self-review notes (for the executor)
+
+- The `meta` module augmentation is declared once in `component.tsx`; it is global to the package once imported. Examples rely on it for `meta.options`.
+- `getFilteredSelectedRowModel()` / `getFilteredRowModel()` in `DataTablePagination` fall back to the core row model in server mode (no faceted/filtered models registered) — the "selected" count then reflects the current page, which is acceptable for the demo.
+- Faceted filter counts only appear in client mode (server mode has no faceted row model); this is expected.
+- If `bun check` reformats the long Tailwind class strings, accept its formatting (Biome is the source of truth).

--- a/docs/superpowers/specs/2026-06-14-data-table-block-design.md
+++ b/docs/superpowers/specs/2026-06-14-data-table-block-design.md
@@ -1,0 +1,136 @@
+# DataTable block — design
+
+## Goal
+
+Ship one entity-agnostic, dual-mode `data-table` block for the shuip registry. A consumer drops in their entity type and column definitions and gets a working table — smooth client-side with zero config, or server-side with pagination/sorting/filtering driven by their backend. All per-entity knowledge lives in the column definitions; the components stay generic.
+
+Built on TanStack Table v8, shadcn/ui primitives, Tailwind v4. No external table CSS, no design-system lock-in — it must drop into any shadcn project.
+
+## Scope
+
+In scope (v1):
+
+- Generic `useDataTable<TData>` hook wrapping `useReactTable`, auto-selecting client vs server mode.
+- `DataTable` rendering + composable sub-components: column header, toolbar, faceted filter, view options, pagination.
+- Sorting, global search, per-column faceted filters (auto-generated from column `meta`), column visibility, row selection, column pinning.
+- Client mode (all row models registered, zero config) and server mode (`manual*` flags + controlled state + `pageCount`).
+- Empty / loading (skeleton) / no-results states.
+- Three example previews: simple client-side, server-side, and a Twenty-like rich rendering example.
+- A documented copy-paste recipe for URL state sync via nuqs.
+
+Out of scope (v1):
+
+- Advanced compound-filter toolbar (Linear/Notion-style filter builder, multi-column sort builder, command-palette filter entry). Deferred — roughly doubles surface area.
+- Inline cell editing, keyboard cell navigation, drag-to-reorder columns, virtualization.
+- A shipped nuqs URL-state file (see "URL state sync" — recipe instead).
+- Shipping Badge/Avatar/status primitives (rich rendering is demonstrated in examples, not shipped as core).
+
+## Repo prerequisites
+
+Done before the block itself, because the block depends on them:
+
+1. **`packages/ui/src/components/ui/table.tsx`** — the shadcn New York `table` primitive. Currently absent from `packages/ui`. `component.tsx` imports it via `@/components/ui/table`, which `generate.ts` auto-detects as `registryDependencies: ["table"]` so consumers install the shadcn primitive.
+2. **`@tanstack/react-table`** added to root `package.json` → `workspaces.catalog`, then referenced as `"catalog:"` from `packages/registry`.
+3. No `dropdown-menu` primitive exists in shuip. View-options and header menus are built on the existing **`popover` + `command`** primitives, consistent with the faceted filter. No new primitive is introduced.
+
+## Item structure
+
+```
+packages/registry/items/blocks/data-table/
+  component.tsx          whole system, multiple named exports, generic <TData>
+  default.example.tsx    client-side "smooth", zero config
+  server.example.tsx     server-side (manual pagination/sorting/filtering + pageCount, simulated backend)
+  rich.example.tsx       Twenty-like: typed cells (status pill, avatar, chips), sticky/pinned columns
+apps/docs/content/blocks/data-table.mdx   doc page + URL-sync recipe (NOT index.mdx — blocks doc flow)
+```
+
+`data-table` is a `blocks` item: type `registry:block`, no name prefix, docs as a real MDX file under `content/blocks/` (per the blocks doc flow — no `index.mdx` in the item folder).
+
+## Component architecture (`component.tsx`)
+
+Everything generic over `TData`. Sub-components receive the `Table<TData>` instance, never raw rows, so they hold no entity-specific code.
+
+### `useDataTable<TData>(options)`
+
+Wraps `useReactTable` and selects the mode:
+
+- **Client mode (default):** registers `getCoreRowModel`, `getSortedRowModel`, `getFilteredRowModel`, `getPaginationRowModel`, `getFacetedRowModel`, `getFacetedUniqueValues`. The table does all the work in memory. Zero backend wiring required.
+- **Server mode:** triggered by passing `pageCount`. Sets `manualPagination`, `manualSorting`, `manualFiltering`; state (`pagination`, `sorting`, `columnFilters`, `globalFilter`) is controlled via props with `on*Change` callbacks; only `getCoreRowModel` is registered.
+
+Common: configurable `getRowId` (so row selection survives pagination/sorting/refetch), resets `pageIndex` to 0 on filter change. Returns `{ table }`.
+
+### Rendering + sub-components
+
+- **`DataTable({ table, children })`** — renders `<Table>` markup from `table.getHeaderGroups()` / `table.getRowModel()` via `flexRender`. Slots `children` (toolbar above, pagination below). Handles empty / loading (skeleton rows) / no-results-after-filter states. Owns no business logic.
+- **`DataTableColumnHeader`** — per-column sort toggle (asc → desc → clear) + "hide column" action. Reads `column.getCanSort()` / `getToggleSortingHandler()` / `getIsSorted()`.
+- **`DataTableToolbar`** — global search input + per-column faceted filters auto-generated from `meta.variant` / `meta.options` + a "Reset" button when filters are active + `DataTableViewOptions`.
+- **`DataTableFacetedFilter`** — multi-select popover (command list) for one column; counts from `column.getFacetedUniqueValues()` (client) or `meta.options[].count` (server). Filter value is a string array.
+- **`DataTableViewOptions`** — column visibility toggle; lists only `column.getCanHide()` columns.
+- **`DataTablePagination`** — selected-row count, page-size select, page index display, first/prev/next/last buttons.
+
+### The `meta` convention (the agnosticism pivot)
+
+Declaration merging on TanStack's `ColumnMeta` carries all entity-specific config so the toolbar/filters/visibility derive automatically:
+
+```ts
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    label?: string
+    placeholder?: string
+    variant?: 'text' | 'number' | 'date' | 'select' | 'multiSelect'
+    options?: { label: string; value: string; icon?: React.FC; count?: number }[]
+    icon?: React.FC
+  }
+}
+```
+
+The toolbar does `table.getAllColumns().filter(c => c.getCanFilter())` and switches on `meta.variant` to render the right control. Adding a new table = writing column defs only.
+
+### Column pinning
+
+Supported in core via `enableColumnPinning` + `column.getIsPinned()` → sticky CSS offsets. Light to add in TanStack, carries the Twenty-like rich example, opt-in (off by default).
+
+## Cells — essential, composable
+
+The core ships no cell primitives. Rich rendering (status pills, avatars, chips, sticky columns — Twenty-like) is demonstrated in `rich.example.tsx` via inline `cell` render functions in Tailwind, to give consumers ideas without imposing a design. Consumers supply their own `cell`/`render` per column, exactly as in the reference CRMs (kodex/edik).
+
+## URL state sync — documented recipe, not a shipped file
+
+Rationale: `generate.ts` scans only `component.tsx` for dependencies, and `extras/` files are always installed. A nuqs hook in `extras/` would land an always-installed file importing an undeclared `nuqs` on every consumer — a TS error for those who use plain `useState`. A second registry item would force a non-visual entry into the `/blocks` gallery.
+
+So: server mode lives in the core (driven by controlled state). URL sync ships in v1 as a **copy-paste recipe in `data-table.mdx`**: a `useDataTableUrlState` built on nuqs that produces exactly the `{ pagination, sorting, columnFilters, on*Change }` shape `useDataTable` expects, with install notes (`bun add nuqs`, wrap app in `<NuqsAdapter>`). Opt-in, zero pollution for `useState` users. The recipe wires the smoothness knobs that separate a janky server table from a smooth one: `shallow`, `debounceMs` for filter text, `throttleMs` for pagination, `startTransition`.
+
+## Data flow
+
+```
+consumer columns + data + (optional) controlled state
+        │
+        ▼
+   useDataTable<TData>  ──client──▶ row models compute in memory
+        │              ──server──▶ manual flags; consumer fetches on state change
+        ▼
+   Table<TData> instance ──▶ DataTable / Toolbar / Pagination / etc. (read instance API only)
+```
+
+## Reuse from reference projects
+
+- **edik** — dual-mode pattern (one component, client or server), server pagination utilities, the controlled-state shape. The backbone.
+- **kodex** — `meta.label`, toolbar slots, custom search accessor, distinct empty vs filtered-empty states.
+- **twenty-fields** — dense/spreadsheet aesthetic, sticky/pinned columns, field-type-driven cell rendering, checkbox row selection. Demonstrated in `rich.example.tsx`.
+- **shadcn/diceui reference** — the canonical 6-component decomposition and the typed `meta` convention as the automatic-toolbar pivot.
+
+## Production-quality guards (built in, not afterthoughts)
+
+- Stable `columns`/`data` references (memoization) to avoid instance re-creation loops.
+- `getRowId` set so selection survives pagination/sort/refetch.
+- `pageCount` required in server mode; pagination resets to page 0 on filter change.
+- Empty / loading / no-results states handled, not bare tables.
+- Faceted counts and a visible "reset filters" affordance.
+
+## Testing
+
+No test runner is configured in this repo, and adding one is out of scope here. Verification is the authoritative type gate plus the doc build:
+
+- `bun registry:generate` — confirms the item is scanned and `[generate] N items processed` increases; check `registryDependencies` includes `table` and `dependencies` includes `@tanstack/react-table`.
+- `bun build:docs` end-to-end (with `NODE_OPTIONS=--max-old-space-size=6144` if low RAM) — `next build` is the authoritative type gate; the three examples must compile and render in the docs.
+- Manual check of the three previews in `/blocks/data-table`: client sort/filter/search/visibility/selection; server mode paginating against a simulated backend; rich example with pinned columns and typed cells.

--- a/docs/superpowers/specs/2026-06-16-data-table-variants-design.md
+++ b/docs/superpowers/specs/2026-06-16-data-table-variants-design.md
@@ -1,0 +1,99 @@
+# Data Table — UI/UX variants design
+
+Status: approved (design + build method), 2026-06-16
+Branch: `feat/data-table-block` · Item: `packages/registry/items/blocks/data-table/`
+
+## Goal
+
+Give the composable data-table kit per-zone UI/UX variants, exposed shadcn-style
+through `variant` props on the relevant sub-components. The kit stays a single
+registry block (entity-agnostic, dual-mode client/server). Pure-styling variants
+go through `cva`; variants that change structure or interaction use conditional
+rendering.
+
+## Scope — four zones
+
+### 1. Pagination (split by semantics)
+
+Page-based variants are pure presentation of the existing TanStack pagination
+state — one `variant` prop:
+
+```tsx
+<DataTablePagination variant="simple" | "numbered" />
+```
+
+- `simple` — arrows + "Page X of Y" + rows-per-page (current behaviour, cleaned).
+- `numbered` — numbered pages with truncation (`1 … 4 5 6 … 20`), active page
+  `bg-primary text-primary-foreground`, siblings `ghost`, ellipsis `muted`,
+  `size-8` hit targets, `tabular-nums`. Rows-per-page optional on the left.
+
+Progressive loading changes the data model (accumulate rows instead of paging),
+needs `onLoadMore` / `hasMore`, and "page" stops meaning anything — so it is a
+separate component, not a pagination variant:
+
+```tsx
+<DataTableLoadMore mode="button" | "infinite" onLoadMore hasMore isLoading />
+```
+
+- `button` — centered "Load more" outline button + "Showing N of M" muted text.
+- `infinite` — sentinel + `IntersectionObserver`, bottom mini-spinner while
+  loading, "All caught up" when `hasMore` is false.
+
+### 2. Toolbar / filters — `<DataTableToolbar variant>`
+
+- `default` — current (search + inline faceted filters + View options).
+- `inline-chips` — row 1: search + filter triggers; row 2: active filters as
+  removable chips (`secondary`, `rounded-full`, X on hover) + "Clear all".
+- `minimal` — search + View only, no faceted filters.
+
+### 3. Empty state
+
+Keep `emptyState?: ReactNode` on `<DataTable>` for full composability, and add a
+ready-made brick to drop into it:
+
+```tsx
+<DataTableEmpty variant="text" | "illustrated" | "with-action"
+  title description icon action />
+```
+
+- `illustrated` — lucide icon in a `bg-muted/50 size-12` circle, title +
+  subtext, vertical rhythm, `text-balance`.
+- `with-action` — illustrated + a button (auto "Reset filters" when filtered,
+  else custom CTA).
+
+### 4. Loading — `loadingVariant` on `<DataTable>`
+
+- `skeleton` — current (skeleton bars per cell, `pageSize` rows).
+- `overlay` — keep previous rows, dim them (`opacity-60 pointer-events-none`),
+  centered spinner over `bg-background/60 backdrop-blur-[1px]`. Best for server
+  mode: no context flash on refetch.
+- `shimmer` — skeleton with an animated gradient sweep + `prefers-reduced-motion`
+  fallback (crossfade / static).
+
+## Styling principles (impeccable)
+
+- Body/placeholder text ≥ 4.5:1 contrast; no light-gray-on-tint.
+- Use existing shuip/shadcn tokens (`bg-primary`, `text-muted-foreground`, …),
+  no hardcoded colors.
+- Motion: ease-out, no bounce; every animation has a reduced-motion alternative.
+- No nested cards, no side-stripe accents, semantic z-index for the overlay.
+
+## Build method
+
+Real components in the registry (no throwaway mockups). After each zone, run the
+docs dev server and screenshot every variant to verify styling against the
+impeccable rules, iterate, then commit.
+
+## Verification
+
+- `bunx tsc --noEmit` clean (registry + docs) apart from the known `baseUrl`
+  TS5101 deprecation.
+- `bunx biome check` clean on touched files.
+- `bun registry:generate` still processes the item; examples render.
+- Visual screenshot pass per variant.
+
+## Open notes
+
+- No test runner configured in the repo; verification is type-check + biome +
+  visual screenshots. Propose a runner separately if unit tests are wanted.
+- This design doc can be excluded from the final PR if undesired.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
       "date-fns": "^4.2.1",
       "@dnd-kit/core": "^6.3.1",
       "@dnd-kit/sortable": "^10.0.0",
-      "@dnd-kit/utilities": "^3.2.2"
+      "@dnd-kit/utilities": "^3.2.2",
+      "@tanstack/react-table": "^8.21.3"
     },
     "catalogs": {
       "fumadocs": {

--- a/packages/registry/items/blocks/data-table/advanced-filters.example.tsx
+++ b/packages/registry/items/blocks/data-table/advanced-filters.example.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTableFilterMenu,
+  DataTablePagination,
+  DataTableSortMenu,
+  DataTableViews,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+import { Button } from '@/components/ui/button';
+
+type Deal = {
+  id: string;
+  company: string;
+  stage: 'lead' | 'qualified' | 'won' | 'lost';
+  amount: number;
+  createdAt: string;
+};
+
+const stageOptions = [
+  { label: 'Lead', value: 'lead' },
+  { label: 'Qualified', value: 'qualified' },
+  { label: 'Won', value: 'won' },
+  { label: 'Lost', value: 'lost' },
+];
+
+const stages: Deal['stage'][] = ['lead', 'qualified', 'won', 'lost'];
+
+const deals: Deal[] = Array.from({ length: 40 }, (_, index) => ({
+  id: `deal-${index + 1}`,
+  company: `Company ${String.fromCharCode(65 + (index % 26))}${index + 1}`,
+  stage: stages[index % stages.length],
+  amount: 1000 + ((index * 617) % 9000),
+  createdAt: `2026-${String((index % 12) + 1).padStart(2, '0')}-${String((index % 27) + 1).padStart(2, '0')}`,
+}));
+
+export default function DataTableAdvancedFiltersExample() {
+  const [surface, setSurface] = React.useState<'popover' | 'dialog'>('popover');
+
+  const columns = React.useMemo<ColumnDef<Deal>[]>(
+    () => [
+      {
+        accessorKey: 'company',
+        size: 200,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Company' />,
+        meta: { label: 'Company', variant: 'text' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.company}</span>,
+      },
+      {
+        accessorKey: 'stage',
+        size: 140,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Stage' />,
+        meta: { label: 'Stage', variant: 'select', options: stageOptions },
+        cell: ({ row }) => <span className='capitalize'>{row.original.stage}</span>,
+      },
+      {
+        accessorKey: 'amount',
+        size: 130,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Amount' />,
+        meta: { label: 'Amount', variant: 'number' },
+        cell: ({ row }) => <span className='tabular-nums'>${row.original.amount.toLocaleString()}</span>,
+      },
+      {
+        accessorKey: 'createdAt',
+        size: 150,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Created' />,
+        meta: { label: 'Created', variant: 'date' },
+        cell: ({ row }) => <span className='text-muted-foreground tabular-nums'>{row.original.createdAt}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: deals,
+    columns,
+    getRowId: (row) => row.id,
+    initialState: { pagination: { pageIndex: 0, pageSize: 8 } },
+  });
+
+  return (
+    <div className='flex w-full min-w-0 flex-col gap-3'>
+      <div className='flex flex-wrap items-center gap-2'>
+        <DataTableFilterMenu table={table} variant={surface} />
+        <DataTableSortMenu table={table} />
+        <DataTableViews table={table} storageKey='deals' />
+        <div className='ml-auto flex items-center gap-1 rounded-md bg-muted p-0.5'>
+          {(['popover', 'dialog'] as const).map((value) => (
+            <Button
+              key={value}
+              variant={surface === value ? 'default' : 'ghost'}
+              size='sm'
+              className='h-7 capitalize'
+              onClick={() => setSurface(value)}
+            >
+              {value}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <DataTable table={table} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -494,6 +494,10 @@ export function DataTablePagination<TData>({
   table,
   pageSizeOptions = [10, 20, 30, 40, 50],
 }: DataTablePaginationProps<TData>) {
+  const pageSize = table.getState().pagination.pageSize;
+  const options = pageSizeOptions.includes(pageSize)
+    ? pageSizeOptions
+    : [...pageSizeOptions, pageSize].sort((a, b) => a - b);
   return (
     <div className='flex flex-wrap items-center justify-between gap-4'>
       <div className='text-muted-foreground text-sm'>
@@ -502,15 +506,12 @@ export function DataTablePagination<TData>({
       <div className='flex flex-wrap items-center gap-4 lg:gap-6'>
         <div className='flex items-center gap-2'>
           <p className='font-medium text-sm'>Rows per page</p>
-          <Select
-            value={`${table.getState().pagination.pageSize}`}
-            onValueChange={(value) => table.setPageSize(Number(value))}
-          >
+          <Select value={`${pageSize}`} onValueChange={(value) => table.setPageSize(Number(value))}>
             <SelectTrigger className='h-8 w-[72px]'>
-              <SelectValue placeholder={table.getState().pagination.pageSize} />
+              <SelectValue placeholder={pageSize} />
             </SelectTrigger>
             <SelectContent side='top'>
-              {pageSizeOptions.map((size) => (
+              {options.map((size) => (
                 <SelectItem key={size} value={`${size}`}>
                   {size}
                 </SelectItem>

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -1,0 +1,544 @@
+'use client';
+
+import {
+  type Column,
+  type ColumnDef,
+  type ColumnFiltersState,
+  type ColumnPinningState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type OnChangeFn,
+  type PaginationState,
+  type RowData,
+  type RowSelectionState,
+  type SortingState,
+  type Table,
+  useReactTable,
+  type VisibilityState,
+} from '@tanstack/react-table';
+import {
+  ArrowDown,
+  ArrowUp,
+  CheckIcon,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  ChevronsUpDown,
+  EyeOff,
+  PlusCircle,
+  Settings2,
+  X,
+} from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import { TableBody, TableCell, TableHead, TableHeader, Table as TableRoot, TableRow } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+export type DataTableFilterOption = {
+  label: string;
+  value: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  count?: number;
+};
+
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    label?: string;
+    placeholder?: string;
+    variant?: 'text' | 'number' | 'date' | 'select' | 'multiSelect';
+    options?: DataTableFilterOption[];
+    icon?: React.ComponentType<{ className?: string }>;
+  }
+}
+
+export type UseDataTableProps<TData> = {
+  data: TData[];
+  columns: ColumnDef<TData, unknown>[];
+  pageCount?: number;
+  getRowId?: (row: TData, index: number) => string;
+  enableRowSelection?: boolean;
+  enableColumnPinning?: boolean;
+  initialState?: {
+    pagination?: PaginationState;
+    sorting?: SortingState;
+    columnVisibility?: VisibilityState;
+    columnPinning?: ColumnPinningState;
+  };
+  state?: {
+    pagination?: PaginationState;
+    sorting?: SortingState;
+    columnFilters?: ColumnFiltersState;
+    globalFilter?: string;
+  };
+  onPaginationChange?: OnChangeFn<PaginationState>;
+  onSortingChange?: OnChangeFn<SortingState>;
+  onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>;
+  onGlobalFilterChange?: OnChangeFn<string>;
+};
+
+export function useDataTable<TData>(props: UseDataTableProps<TData>) {
+  const {
+    data,
+    columns,
+    pageCount,
+    getRowId,
+    enableRowSelection = false,
+    enableColumnPinning = false,
+    initialState,
+  } = props;
+
+  const manual = pageCount != null;
+
+  const [sorting, setSorting] = React.useState<SortingState>(initialState?.sorting ?? []);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState('');
+  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>(initialState?.columnVisibility ?? {});
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+  const [pagination, setPagination] = React.useState<PaginationState>(
+    initialState?.pagination ?? { pageIndex: 0, pageSize: 10 },
+  );
+  const [columnPinning, setColumnPinning] = React.useState<ColumnPinningState>({
+    left: initialState?.columnPinning?.left ?? [],
+    right: initialState?.columnPinning?.right ?? [],
+  });
+
+  const table = useReactTable({
+    data,
+    columns,
+    pageCount: pageCount ?? undefined,
+    state: {
+      sorting: props.state?.sorting ?? sorting,
+      columnFilters: props.state?.columnFilters ?? columnFilters,
+      globalFilter: props.state?.globalFilter ?? globalFilter,
+      columnVisibility,
+      rowSelection,
+      pagination: props.state?.pagination ?? pagination,
+      columnPinning,
+    },
+    enableRowSelection,
+    enableColumnPinning,
+    getRowId,
+    manualPagination: manual,
+    manualSorting: manual,
+    manualFiltering: manual,
+    onSortingChange: props.onSortingChange ?? setSorting,
+    onColumnFiltersChange: props.onColumnFiltersChange ?? setColumnFilters,
+    onGlobalFilterChange: props.onGlobalFilterChange ?? setGlobalFilter,
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    onPaginationChange: props.onPaginationChange ?? setPagination,
+    onColumnPinningChange: setColumnPinning,
+    getCoreRowModel: getCoreRowModel(),
+    ...(manual
+      ? {}
+      : {
+          getSortedRowModel: getSortedRowModel(),
+          getFilteredRowModel: getFilteredRowModel(),
+          getPaginationRowModel: getPaginationRowModel(),
+          getFacetedRowModel: getFacetedRowModel(),
+          getFacetedUniqueValues: getFacetedUniqueValues(),
+        }),
+  });
+
+  return { table };
+}
+
+function getPinStyles<TData>(column: Column<TData>): React.CSSProperties {
+  const pinned = column.getIsPinned();
+  if (!pinned) return {};
+  return {
+    position: 'sticky',
+    left: pinned === 'left' ? column.getStart('left') : undefined,
+    right: pinned === 'right' ? column.getAfter('right') : undefined,
+    zIndex: 1,
+  };
+}
+
+function getPinClass<TData>(column: Column<TData>): string | undefined {
+  return column.getIsPinned() ? 'bg-background' : undefined;
+}
+
+export type DataTableProps<TData> = {
+  table: Table<TData>;
+  isLoading?: boolean;
+  emptyState?: React.ReactNode;
+  onRowClick?: (row: TData) => void;
+  className?: string;
+};
+
+export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, className }: DataTableProps<TData>) {
+  const columnCount = table.getAllLeafColumns().length;
+  const rows = table.getRowModel().rows;
+
+  return (
+    <div className={cn('rounded-md border', className)}>
+      <TableRoot>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} style={getPinStyles(header.column)} className={getPinClass(header.column)}>
+                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {isLoading ? (
+            Array.from({ length: table.getState().pagination.pageSize }).map((_, rowIndex) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+              <TableRow key={rowIndex}>
+                {Array.from({ length: columnCount }).map((__, cellIndex) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+                  <TableCell key={cellIndex}>
+                    <div className='h-5 w-full animate-pulse rounded bg-muted' />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : rows.length ? (
+            rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() ? 'selected' : undefined}
+                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                className={onRowClick ? 'cursor-pointer' : undefined}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} style={getPinStyles(cell.column)} className={getPinClass(cell.column)}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columnCount} className='h-24 text-center'>
+                {emptyState ?? 'No results.'}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </TableRoot>
+    </div>
+  );
+}
+
+export type DataTableColumnHeaderProps<TData, TValue> = {
+  column: Column<TData, TValue>;
+  title: string;
+  className?: string;
+};
+
+export function DataTableColumnHeader<TData, TValue>({
+  column,
+  title,
+  className,
+}: DataTableColumnHeaderProps<TData, TValue>) {
+  if (!column.getCanSort() && !column.getCanHide()) {
+    return <div className={className}>{title}</div>;
+  }
+
+  const sorted = column.getIsSorted();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='ghost' size='sm' className={cn('-ml-3 h-8 data-[state=open]:bg-accent', className)}>
+          <span>{title}</span>
+          {sorted === 'desc' ? (
+            <ArrowDown className='ml-2 size-4' />
+          ) : sorted === 'asc' ? (
+            <ArrowUp className='ml-2 size-4' />
+          ) : (
+            <ChevronsUpDown className='ml-2 size-4' />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='start' className='flex w-40 flex-col gap-0.5 p-1'>
+        {column.getCanSort() && (
+          <>
+            <Button variant='ghost' size='sm' className='justify-start' onClick={() => column.toggleSorting(false)}>
+              <ArrowUp className='mr-2 size-3.5 text-muted-foreground/70' /> Asc
+            </Button>
+            <Button variant='ghost' size='sm' className='justify-start' onClick={() => column.toggleSorting(true)}>
+              <ArrowDown className='mr-2 size-3.5 text-muted-foreground/70' /> Desc
+            </Button>
+          </>
+        )}
+        {column.getCanHide() && (
+          <Button variant='ghost' size='sm' className='justify-start' onClick={() => column.toggleVisibility(false)}>
+            <EyeOff className='mr-2 size-3.5 text-muted-foreground/70' /> Hide
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export type DataTableFacetedFilterProps<TData, TValue> = {
+  column?: Column<TData, TValue>;
+  title?: string;
+  options: DataTableFilterOption[];
+};
+
+export function DataTableFacetedFilter<TData, TValue>({
+  column,
+  title,
+  options,
+}: DataTableFacetedFilterProps<TData, TValue>) {
+  const facets = column?.getFacetedUniqueValues();
+  const selectedValues = new Set((column?.getFilterValue() as string[]) ?? []);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='h-8 border-dashed'>
+          <PlusCircle className='mr-2 size-4' />
+          {title}
+          {selectedValues.size > 0 && (
+            <>
+              <Separator orientation='vertical' className='mx-2 h-4' />
+              <span className='rounded-sm bg-secondary px-1 font-normal text-xs'>{selectedValues.size}</span>
+            </>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className='w-48 p-0' align='start'>
+        <Command>
+          <CommandInput placeholder={title} />
+          <CommandList>
+            <CommandEmpty>No results.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = selectedValues.has(option.value);
+                return (
+                  <CommandItem
+                    key={option.value}
+                    onSelect={() => {
+                      if (isSelected) selectedValues.delete(option.value);
+                      else selectedValues.add(option.value);
+                      const filterValues = Array.from(selectedValues);
+                      column?.setFilterValue(filterValues.length ? filterValues : undefined);
+                    }}
+                  >
+                    <div
+                      className={cn(
+                        'mr-2 flex size-4 items-center justify-center rounded-sm border border-primary',
+                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible',
+                      )}
+                    >
+                      <CheckIcon className='size-3.5' />
+                    </div>
+                    {option.icon && <option.icon className='mr-2 size-4 text-muted-foreground' />}
+                    <span>{option.label}</span>
+                    {facets?.get(option.value) && (
+                      <span className='ml-auto flex size-4 items-center justify-center font-mono text-xs'>
+                        {facets.get(option.value)}
+                      </span>
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            {selectedValues.size > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    onSelect={() => column?.setFilterValue(undefined)}
+                    className='justify-center text-center'
+                  >
+                    Clear filters
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function DataTableViewOptions<TData>({ table }: { table: Table<TData> }) {
+  const columns = table
+    .getAllColumns()
+    .filter((column) => typeof column.accessorFn !== 'undefined' && column.getCanHide());
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='ml-auto hidden h-8 lg:flex'>
+          <Settings2 className='mr-2 size-4' /> View
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='w-44 p-0'>
+        <Command>
+          <CommandInput placeholder='Search columns...' />
+          <CommandList>
+            <CommandEmpty>No columns.</CommandEmpty>
+            <CommandGroup>
+              {columns.map((column) => (
+                <CommandItem key={column.id} onSelect={() => column.toggleVisibility(!column.getIsVisible())}>
+                  <CheckIcon className={cn('mr-2 size-4', column.getIsVisible() ? 'opacity-100' : 'opacity-0')} />
+                  <span className='truncate'>{column.columnDef.meta?.label ?? column.id}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export type DataTableToolbarProps<TData> = {
+  table: Table<TData>;
+  searchPlaceholder?: string;
+  children?: React.ReactNode;
+};
+
+export function DataTableToolbar<TData>({
+  table,
+  searchPlaceholder = 'Search...',
+  children,
+}: DataTableToolbarProps<TData>) {
+  const isFiltered = table.getState().columnFilters.length > 0 || Boolean(table.getState().globalFilter);
+  const filterableColumns = table
+    .getAllColumns()
+    .filter((column) => column.getCanFilter() && column.columnDef.meta?.variant);
+
+  return (
+    <div className='flex flex-wrap items-center gap-2'>
+      <Input
+        placeholder={searchPlaceholder}
+        value={(table.getState().globalFilter as string) ?? ''}
+        onChange={(event) => table.setGlobalFilter(event.target.value)}
+        className='h-8 w-40 lg:w-56'
+      />
+      {filterableColumns.map((column) => {
+        const meta = column.columnDef.meta;
+        if ((meta?.variant === 'select' || meta?.variant === 'multiSelect') && meta.options) {
+          return (
+            <DataTableFacetedFilter
+              key={column.id}
+              column={column}
+              title={meta.label ?? column.id}
+              options={meta.options}
+            />
+          );
+        }
+        return null;
+      })}
+      {isFiltered && (
+        <Button
+          variant='ghost'
+          size='sm'
+          className='h-8 px-2'
+          onClick={() => {
+            table.resetColumnFilters();
+            table.setGlobalFilter('');
+          }}
+        >
+          Reset <X className='ml-2 size-4' />
+        </Button>
+      )}
+      {children}
+      <DataTableViewOptions table={table} />
+    </div>
+  );
+}
+
+export type DataTablePaginationProps<TData> = {
+  table: Table<TData>;
+  pageSizeOptions?: number[];
+};
+
+export function DataTablePagination<TData>({
+  table,
+  pageSizeOptions = [10, 20, 30, 40, 50],
+}: DataTablePaginationProps<TData>) {
+  return (
+    <div className='flex flex-wrap items-center justify-between gap-4'>
+      <div className='text-muted-foreground text-sm'>
+        {table.getFilteredSelectedRowModel().rows.length} of {table.getFilteredRowModel().rows.length} row(s) selected.
+      </div>
+      <div className='flex flex-wrap items-center gap-4 lg:gap-6'>
+        <div className='flex items-center gap-2'>
+          <p className='font-medium text-sm'>Rows per page</p>
+          <Select
+            value={`${table.getState().pagination.pageSize}`}
+            onValueChange={(value) => table.setPageSize(Number(value))}
+          >
+            <SelectTrigger className='h-8 w-[72px]'>
+              <SelectValue placeholder={table.getState().pagination.pageSize} />
+            </SelectTrigger>
+            <SelectContent side='top'>
+              {pageSizeOptions.map((size) => (
+                <SelectItem key={size} value={`${size}`}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className='flex items-center font-medium text-sm'>
+          Page {table.getState().pagination.pageIndex + 1} of {Math.max(table.getPageCount(), 1)}
+        </div>
+        <div className='flex items-center gap-2'>
+          <Button
+            variant='outline'
+            size='icon-sm'
+            className='hidden lg:flex'
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronsLeft className='size-4' />
+          </Button>
+          <Button
+            variant='outline'
+            size='icon-sm'
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronLeft className='size-4' />
+          </Button>
+          <Button variant='outline' size='icon-sm' onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+            <ChevronRight className='size-4' />
+          </Button>
+          <Button
+            variant='outline'
+            size='icon-sm'
+            className='hidden lg:flex'
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <ChevronsRight className='size-4' />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -31,6 +31,8 @@ import {
   ChevronsRight,
   ChevronsUpDown,
   EyeOff,
+  Inbox,
+  Loader2,
   PlusCircle,
   Settings2,
   X,
@@ -184,21 +186,45 @@ function getPinClass<TData>(column: Column<TData>): string | undefined {
 
 const skeletonBar = <div className='h-5 w-full animate-pulse rounded bg-muted' />;
 
+const shimmerBar = (
+  <div className='relative h-5 w-full overflow-hidden rounded bg-muted'>
+    <div
+      className='absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-foreground/10 to-transparent motion-reduce:hidden'
+      style={{ animation: 'shuip-dt-shimmer 1.5s infinite' }}
+    />
+  </div>
+);
+
+const shimmerKeyframes = <style>{'@keyframes shuip-dt-shimmer{100%{transform:translateX(100%)}}'}</style>;
+
 export type DataTableProps<TData> = {
   table: Table<TData>;
   isLoading?: boolean;
+  loadingVariant?: 'skeleton' | 'overlay' | 'shimmer';
   emptyState?: React.ReactNode;
   onRowClick?: (row: TData) => void;
   className?: string;
 };
 
-export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, className }: DataTableProps<TData>) {
+export function DataTable<TData>({
+  table,
+  isLoading,
+  loadingVariant = 'skeleton',
+  emptyState,
+  onRowClick,
+  className,
+}: DataTableProps<TData>) {
   const columnCount = table.getVisibleLeafColumns().length;
   const rows = table.getRowModel().rows;
+  const showSkeleton = isLoading && loadingVariant !== 'overlay';
+  const showOverlay = isLoading && loadingVariant === 'overlay';
 
   return (
-    <div className={cn('rounded-md border', className)}>
-      <TableRoot className='table-fixed' style={{ minWidth: table.getTotalSize() }}>
+    <div className={cn('relative rounded-md border', className)}>
+      <TableRoot
+        className={cn('table-fixed', showOverlay && 'pointer-events-none opacity-60')}
+        style={{ minWidth: table.getTotalSize() }}
+      >
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
@@ -216,12 +242,12 @@ export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, cla
           ))}
         </TableHeader>
         <TableBody>
-          {isLoading ? (
+          {showSkeleton ? (
             Array.from({ length: table.getState().pagination.pageSize }).map((_, rowIndex) => (
               <TableRow key={rowIndex}>
                 {table.getVisibleLeafColumns().map((column) => (
                   <TableCell key={column.id} style={getColumnStyles(column)} className={getPinClass(column)}>
-                    {skeletonBar}
+                    {loadingVariant === 'shimmer' ? shimmerBar : skeletonBar}
                   </TableCell>
                 ))}
               </TableRow>
@@ -254,6 +280,45 @@ export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, cla
           )}
         </TableBody>
       </TableRoot>
+      {showOverlay && (
+        <div className='absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-[1px]'>
+          <Loader2 className='size-5 animate-spin text-muted-foreground' />
+        </div>
+      )}
+      {loadingVariant === 'shimmer' && shimmerKeyframes}
+    </div>
+  );
+}
+
+export type DataTableEmptyProps = {
+  variant?: 'text' | 'illustrated' | 'with-action';
+  title?: string;
+  description?: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  action?: React.ReactNode;
+};
+
+export function DataTableEmpty({
+  variant = 'text',
+  title = 'No results',
+  description,
+  icon: Icon = Inbox,
+  action,
+}: DataTableEmptyProps) {
+  if (variant === 'text') {
+    return <span className='text-muted-foreground text-sm'>{title}</span>;
+  }
+
+  return (
+    <div className='flex flex-col items-center justify-center gap-3 py-6 text-center'>
+      <div className='flex size-12 items-center justify-center rounded-full bg-muted/50'>
+        <Icon className='size-6 text-muted-foreground' />
+      </div>
+      <div className='space-y-1'>
+        <p className='text-balance font-medium text-sm'>{title}</p>
+        {description && <p className='mx-auto max-w-xs text-balance text-muted-foreground text-sm'>{description}</p>}
+      </div>
+      {variant === 'with-action' && action}
     </div>
   );
 }
@@ -428,76 +493,164 @@ export function DataTableViewOptions<TData>({ table }: { table: Table<TData> }) 
   );
 }
 
+type FilterChip = { key: string; label: string; onRemove: () => void };
+
+function getFilterChips<TData>(table: Table<TData>): FilterChip[] {
+  const chips: FilterChip[] = [];
+  const globalFilter = table.getState().globalFilter as string;
+  if (globalFilter) {
+    chips.push({ key: 'global', label: `Search: ${globalFilter}`, onRemove: () => table.setGlobalFilter('') });
+  }
+  for (const filter of table.getState().columnFilters) {
+    const column = table.getColumn(filter.id);
+    const meta = column?.columnDef.meta;
+    const columnLabel = meta?.label ?? filter.id;
+    const values = Array.isArray(filter.value) ? (filter.value as string[]) : [filter.value as string];
+    for (const value of values) {
+      const optionLabel = meta?.options?.find((option) => option.value === value)?.label ?? String(value);
+      chips.push({
+        key: `${filter.id}-${value}`,
+        label: `${columnLabel}: ${optionLabel}`,
+        onRemove: () => {
+          const next = values.filter((item) => item !== value);
+          column?.setFilterValue(next.length ? next : undefined);
+        },
+      });
+    }
+  }
+  return chips;
+}
+
 export type DataTableToolbarProps<TData> = {
   table: Table<TData>;
   searchPlaceholder?: string;
+  variant?: 'default' | 'inline-chips' | 'minimal';
   children?: React.ReactNode;
 };
 
 export function DataTableToolbar<TData>({
   table,
   searchPlaceholder = 'Search...',
+  variant = 'default',
   children,
 }: DataTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0 || Boolean(table.getState().globalFilter);
+  const showFacets = variant !== 'minimal';
+  const showChips = variant === 'inline-chips';
   const filterableColumns = table
     .getAllColumns()
     .filter((column) => column.getCanFilter() && column.columnDef.meta?.variant);
+  const chips = showChips ? getFilterChips(table) : [];
+
+  const clearAll = () => {
+    table.resetColumnFilters();
+    table.setGlobalFilter('');
+  };
 
   return (
-    <div className='flex flex-wrap items-center gap-2'>
-      <Input
-        placeholder={searchPlaceholder}
-        value={(table.getState().globalFilter as string) ?? ''}
-        onChange={(event) => table.setGlobalFilter(event.target.value)}
-        className='h-8 w-40 lg:w-56'
-      />
-      {filterableColumns.map((column) => {
-        const meta = column.columnDef.meta;
-        if ((meta?.variant === 'select' || meta?.variant === 'multiSelect') && meta.options) {
-          return (
-            <DataTableFacetedFilter
-              key={column.id}
-              column={column}
-              title={meta.label ?? column.id}
-              options={meta.options}
-            />
-          );
-        }
-        return null;
-      })}
-      {isFiltered && (
-        <Button
-          variant='ghost'
-          size='sm'
-          className='h-8 px-2'
-          onClick={() => {
-            table.resetColumnFilters();
-            table.setGlobalFilter('');
-          }}
-        >
-          Reset <X className='ml-2 size-4' />
-        </Button>
+    <div className='flex flex-col gap-2'>
+      <div className='flex flex-wrap items-center gap-2'>
+        <Input
+          placeholder={searchPlaceholder}
+          value={(table.getState().globalFilter as string) ?? ''}
+          onChange={(event) => table.setGlobalFilter(event.target.value)}
+          className='h-8 w-40 lg:w-56'
+        />
+        {showFacets &&
+          filterableColumns.map((column) => {
+            const meta = column.columnDef.meta;
+            if ((meta?.variant === 'select' || meta?.variant === 'multiSelect') && meta.options) {
+              return (
+                <DataTableFacetedFilter
+                  key={column.id}
+                  column={column}
+                  title={meta.label ?? column.id}
+                  options={meta.options}
+                />
+              );
+            }
+            return null;
+          })}
+        {isFiltered && !showChips && (
+          <Button variant='ghost' size='sm' className='h-8 px-2' onClick={clearAll}>
+            Reset <X className='ml-2 size-4' />
+          </Button>
+        )}
+        {children}
+        <DataTableViewOptions table={table} />
+      </div>
+      {showChips && chips.length > 0 && (
+        <div className='flex flex-wrap items-center gap-1.5'>
+          {chips.map((chip) => (
+            <span
+              key={chip.key}
+              className='inline-flex items-center gap-1 rounded-full bg-secondary py-0.5 pr-1 pl-2 text-secondary-foreground text-xs'
+            >
+              {chip.label}
+              <button
+                type='button'
+                onClick={chip.onRemove}
+                aria-label={`Remove ${chip.label}`}
+                className='flex size-4 items-center justify-center rounded-full hover:bg-background/60'
+              >
+                <X className='size-3' />
+              </button>
+            </span>
+          ))}
+          <Button variant='ghost' size='sm' className='h-6 px-2 text-xs' onClick={clearAll}>
+            Clear all
+          </Button>
+        </div>
       )}
-      {children}
-      <DataTableViewOptions table={table} />
     </div>
   );
+}
+
+function getPaginationRange(currentPage: number, pageCount: number, siblings = 1): (number | 'ellipsis')[] {
+  const totalPageNumbers = siblings * 2 + 5;
+  if (pageCount <= totalPageNumbers) {
+    return Array.from({ length: pageCount }, (_, index) => index + 1);
+  }
+
+  const leftSibling = Math.max(currentPage - siblings, 1);
+  const rightSibling = Math.min(currentPage + siblings, pageCount);
+  const showLeftEllipsis = leftSibling > 2;
+  const showRightEllipsis = rightSibling < pageCount - 1;
+  const edgeCount = 3 + 2 * siblings;
+
+  if (!showLeftEllipsis && showRightEllipsis) {
+    return [...Array.from({ length: edgeCount }, (_, index) => index + 1), 'ellipsis', pageCount];
+  }
+  if (showLeftEllipsis && !showRightEllipsis) {
+    return [1, 'ellipsis', ...Array.from({ length: edgeCount }, (_, index) => pageCount - edgeCount + 1 + index)];
+  }
+  return [
+    1,
+    'ellipsis',
+    ...Array.from({ length: rightSibling - leftSibling + 1 }, (_, index) => leftSibling + index),
+    'ellipsis',
+    pageCount,
+  ];
 }
 
 export type DataTablePaginationProps<TData> = {
   table: Table<TData>;
   pageSizeOptions?: number[];
+  variant?: 'simple' | 'numbered';
 };
 
 export function DataTablePagination<TData>({
   table,
   pageSizeOptions = [10, 20, 30, 40, 50],
+  variant = 'simple',
 }: DataTablePaginationProps<TData>) {
   const pageSize = table.getState().pagination.pageSize;
+  const pageIndex = table.getState().pagination.pageIndex;
+  const pageCount = Math.max(table.getPageCount(), 1);
   const options = pageSizeOptions.includes(pageSize)
     ? pageSizeOptions
     : [...pageSizeOptions, pageSize].sort((a, b) => a - b);
+
   return (
     <div className='flex flex-wrap items-center justify-between gap-4'>
       <div className='text-muted-foreground text-sm'>
@@ -519,41 +672,163 @@ export function DataTablePagination<TData>({
             </SelectContent>
           </Select>
         </div>
-        <div className='flex items-center font-medium text-sm'>
-          Page {table.getState().pagination.pageIndex + 1} of {Math.max(table.getPageCount(), 1)}
-        </div>
-        <div className='flex items-center gap-2'>
-          <Button
-            variant='outline'
-            size='icon-sm'
-            className='hidden lg:flex'
-            onClick={() => table.setPageIndex(0)}
-            disabled={!table.getCanPreviousPage()}
-          >
-            <ChevronsLeft className='size-4' />
-          </Button>
-          <Button
-            variant='outline'
-            size='icon-sm'
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            <ChevronLeft className='size-4' />
-          </Button>
-          <Button variant='outline' size='icon-sm' onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
-            <ChevronRight className='size-4' />
-          </Button>
-          <Button
-            variant='outline'
-            size='icon-sm'
-            className='hidden lg:flex'
-            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-            disabled={!table.getCanNextPage()}
-          >
-            <ChevronsRight className='size-4' />
-          </Button>
-        </div>
+        {variant === 'numbered' ? (
+          <div className='flex items-center gap-1'>
+            <Button
+              variant='outline'
+              size='icon-sm'
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+              aria-label='Previous page'
+            >
+              <ChevronLeft className='size-4' />
+            </Button>
+            {getPaginationRange(pageIndex + 1, pageCount).map((page, index) =>
+              page === 'ellipsis' ? (
+                <span
+                  key={`ellipsis-${index}`}
+                  className='flex size-8 items-center justify-center text-muted-foreground text-sm'
+                >
+                  &hellip;
+                </span>
+              ) : (
+                <Button
+                  key={page}
+                  variant={page === pageIndex + 1 ? 'default' : 'ghost'}
+                  size='icon-sm'
+                  className='tabular-nums'
+                  aria-current={page === pageIndex + 1 ? 'page' : undefined}
+                  onClick={() => table.setPageIndex(page - 1)}
+                >
+                  {page}
+                </Button>
+              ),
+            )}
+            <Button
+              variant='outline'
+              size='icon-sm'
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+              aria-label='Next page'
+            >
+              <ChevronRight className='size-4' />
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className='flex items-center font-medium text-sm'>
+              Page {pageIndex + 1} of {pageCount}
+            </div>
+            <div className='flex items-center gap-2'>
+              <Button
+                variant='outline'
+                size='icon-sm'
+                className='hidden lg:flex'
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+                aria-label='First page'
+              >
+                <ChevronsLeft className='size-4' />
+              </Button>
+              <Button
+                variant='outline'
+                size='icon-sm'
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+                aria-label='Previous page'
+              >
+                <ChevronLeft className='size-4' />
+              </Button>
+              <Button
+                variant='outline'
+                size='icon-sm'
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+                aria-label='Next page'
+              >
+                <ChevronRight className='size-4' />
+              </Button>
+              <Button
+                variant='outline'
+                size='icon-sm'
+                className='hidden lg:flex'
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage()}
+                aria-label='Last page'
+              >
+                <ChevronsRight className='size-4' />
+              </Button>
+            </div>
+          </>
+        )}
       </div>
+    </div>
+  );
+}
+
+export type DataTableLoadMoreProps = {
+  onLoadMore: () => void;
+  hasMore: boolean;
+  mode?: 'button' | 'infinite';
+  isLoading?: boolean;
+  loaded?: number;
+  total?: number;
+};
+
+export function DataTableLoadMore({
+  onLoadMore,
+  hasMore,
+  mode = 'button',
+  isLoading = false,
+  loaded,
+  total,
+}: DataTableLoadMoreProps) {
+  const sentinelRef = React.useRef<HTMLDivElement>(null);
+  const onLoadMoreRef = React.useRef(onLoadMore);
+  onLoadMoreRef.current = onLoadMore;
+
+  React.useEffect(() => {
+    if (mode !== 'infinite' || !hasMore || isLoading) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) onLoadMoreRef.current();
+      },
+      { rootMargin: '120px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [mode, hasMore, isLoading]);
+
+  const count = loaded != null && total != null ? `Showing ${loaded} of ${total}` : null;
+
+  if (mode === 'infinite') {
+    return (
+      <div className='flex min-h-9 flex-col items-center justify-center gap-2 py-4 text-muted-foreground text-sm'>
+        {hasMore ? (
+          <>
+            <div ref={sentinelRef} aria-hidden className='h-px w-full' />
+            {isLoading && <Loader2 className='size-4 animate-spin' />}
+          </>
+        ) : (
+          <span>All caught up</span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col items-center gap-2 py-4'>
+      {hasMore ? (
+        <Button variant='outline' size='sm' onClick={onLoadMore} disabled={isLoading}>
+          {isLoading && <Loader2 className='mr-2 size-4 animate-spin' />}
+          Load more
+        </Button>
+      ) : (
+        <span className='text-muted-foreground text-sm'>All caught up</span>
+      )}
+      {count && <span className='text-muted-foreground text-xs'>{count}</span>}
     </div>
   );
 }

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -348,9 +348,10 @@ export function DataTableFacetedFilter<TData, TValue>({
                   <CommandItem
                     key={option.value}
                     onSelect={() => {
-                      if (isSelected) selectedValues.delete(option.value);
-                      else selectedValues.add(option.value);
-                      const filterValues = Array.from(selectedValues);
+                      const next = new Set(selectedValues);
+                      if (isSelected) next.delete(option.value);
+                      else next.add(option.value);
+                      const filterValues = Array.from(next);
                       column?.setFilterValue(filterValues.length ? filterValues : undefined);
                     }}
                   >
@@ -364,9 +365,9 @@ export function DataTableFacetedFilter<TData, TValue>({
                     </div>
                     {option.icon && <option.icon className='mr-2 size-4 text-muted-foreground' />}
                     <span>{option.label}</span>
-                    {facets?.get(option.value) && (
+                    {(facets?.get(option.value) ?? 0) > 0 && (
                       <span className='ml-auto flex size-4 items-center justify-center font-mono text-xs'>
-                        {facets.get(option.value)}
+                        {facets?.get(option.value)}
                       </span>
                     )}
                   </CommandItem>

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -163,14 +163,18 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
   return { table };
 }
 
-function getPinStyles<TData>(column: Column<TData>): React.CSSProperties {
+function getColumnStyles<TData>(column: Column<TData>): React.CSSProperties {
   const pinned = column.getIsPinned();
-  if (!pinned) return {};
   return {
-    position: 'sticky',
-    left: pinned === 'left' ? column.getStart('left') : undefined,
-    right: pinned === 'right' ? column.getAfter('right') : undefined,
-    zIndex: 1,
+    width: column.getSize(),
+    ...(pinned
+      ? {
+          position: 'sticky',
+          left: pinned === 'left' ? column.getStart('left') : undefined,
+          right: pinned === 'right' ? column.getAfter('right') : undefined,
+          zIndex: 1,
+        }
+      : {}),
   };
 }
 
@@ -187,17 +191,22 @@ export type DataTableProps<TData> = {
 };
 
 export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, className }: DataTableProps<TData>) {
-  const columnCount = table.getAllLeafColumns().length;
+  const columnCount = table.getVisibleLeafColumns().length;
   const rows = table.getRowModel().rows;
 
   return (
     <div className={cn('rounded-md border', className)}>
-      <TableRoot>
+      <TableRoot className='table-fixed' style={{ minWidth: table.getTotalSize() }}>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id} style={getPinStyles(header.column)} className={getPinClass(header.column)}>
+                <TableHead
+                  key={header.id}
+                  colSpan={header.colSpan}
+                  style={getColumnStyles(header.column)}
+                  className={getPinClass(header.column)}
+                >
                   {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                 </TableHead>
               ))}
@@ -208,8 +217,8 @@ export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, cla
           {isLoading ? (
             Array.from({ length: table.getState().pagination.pageSize }).map((_, rowIndex) => (
               <TableRow key={rowIndex}>
-                {Array.from({ length: columnCount }).map((__, cellIndex) => (
-                  <TableCell key={cellIndex}>
+                {table.getVisibleLeafColumns().map((column) => (
+                  <TableCell key={column.id} style={getColumnStyles(column)} className={getPinClass(column)}>
                     <div className='h-5 w-full animate-pulse rounded bg-muted' />
                   </TableCell>
                 ))}
@@ -224,7 +233,11 @@ export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, cla
                 className={onRowClick ? 'cursor-pointer' : undefined}
               >
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id} style={getPinStyles(cell.column)} className={getPinClass(cell.column)}>
+                  <TableCell
+                    key={cell.id}
+                    style={getColumnStyles(cell.column)}
+                    className={cn('overflow-hidden', getPinClass(cell.column))}
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -5,6 +5,7 @@ import {
   type ColumnDef,
   type ColumnFiltersState,
   type ColumnPinningState,
+  type FilterFn,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -23,8 +24,11 @@ import {
 } from '@tanstack/react-table';
 import {
   ArrowDown,
+  ArrowDownUp,
   ArrowUp,
+  Bookmark,
   CheckIcon,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
@@ -32,14 +36,18 @@ import {
   ChevronsUpDown,
   EyeOff,
   Inbox,
+  ListFilter,
   Loader2,
+  Plus,
   PlusCircle,
   Settings2,
+  Trash2,
   X,
 } from 'lucide-react';
 import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Command,
   CommandEmpty,
@@ -49,6 +57,15 @@ import {
   CommandList,
   CommandSeparator,
 } from '@/components/ui/command';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -72,6 +89,131 @@ declare module '@tanstack/react-table' {
     icon?: React.ComponentType<{ className?: string }>;
   }
 }
+
+export type FilterVariant = NonNullable<DataTableColumnMetaVariant>;
+type DataTableColumnMetaVariant = 'text' | 'number' | 'date' | 'select' | 'multiSelect';
+
+export type FilterOperator =
+  | 'contains'
+  | 'notContains'
+  | 'is'
+  | 'isNot'
+  | 'isEmpty'
+  | 'isNotEmpty'
+  | 'eq'
+  | 'ne'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'lte'
+  | 'before'
+  | 'after'
+  | 'onOrBefore'
+  | 'onOrAfter'
+  | 'isAnyOf'
+  | 'isNoneOf';
+
+export type FilterCondition = { operator: FilterOperator; value: unknown };
+
+const OPERATOR_LABELS: Record<FilterOperator, string> = {
+  contains: 'contains',
+  notContains: 'does not contain',
+  is: 'is',
+  isNot: 'is not',
+  isEmpty: 'is empty',
+  isNotEmpty: 'is not empty',
+  eq: '=',
+  ne: '≠',
+  gt: '>',
+  lt: '<',
+  gte: '≥',
+  lte: '≤',
+  before: 'is before',
+  after: 'is after',
+  onOrBefore: 'is on or before',
+  onOrAfter: 'is on or after',
+  isAnyOf: 'is any of',
+  isNoneOf: 'is none of',
+};
+
+const OPERATORS_BY_VARIANT: Record<FilterVariant, FilterOperator[]> = {
+  text: ['contains', 'notContains', 'is', 'isNot', 'isEmpty', 'isNotEmpty'],
+  number: ['eq', 'ne', 'gt', 'lt', 'gte', 'lte', 'isEmpty', 'isNotEmpty'],
+  date: ['is', 'before', 'after', 'onOrBefore', 'onOrAfter', 'isEmpty'],
+  select: ['is', 'isNot', 'isAnyOf', 'isNoneOf'],
+  multiSelect: ['isAnyOf', 'isNoneOf', 'is', 'isNot'],
+};
+
+const MULTI_VALUE_OPERATORS: FilterOperator[] = ['isAnyOf', 'isNoneOf'];
+
+function operatorTakesValue(operator: FilterOperator): boolean {
+  return operator !== 'isEmpty' && operator !== 'isNotEmpty';
+}
+
+function isFilterCondition(value: unknown): value is FilterCondition {
+  return typeof value === 'object' && value !== null && 'operator' in value;
+}
+
+function conditionIsEmpty(condition: FilterCondition): boolean {
+  if (!operatorTakesValue(condition.operator)) return false;
+  const { value } = condition;
+  return value == null || value === '' || (Array.isArray(value) && value.length === 0);
+}
+
+export const dataTableFilterFn: FilterFn<unknown> = (row, columnId, filterValue) => {
+  if (Array.isArray(filterValue)) {
+    const cell = row.getValue(columnId);
+    return filterValue.length === 0 || filterValue.includes(cell);
+  }
+  if (!isFilterCondition(filterValue)) return true;
+  const { operator, value } = filterValue;
+  if (conditionIsEmpty(filterValue)) return true;
+
+  const cell = row.getValue(columnId);
+  const text = String(cell ?? '').toLowerCase();
+  const target = String(value ?? '').toLowerCase();
+
+  switch (operator) {
+    case 'isEmpty':
+      return cell == null || cell === '';
+    case 'isNotEmpty':
+      return !(cell == null || cell === '');
+    case 'contains':
+      return text.includes(target);
+    case 'notContains':
+      return !text.includes(target);
+    case 'is':
+      return text === target;
+    case 'isNot':
+      return text !== target;
+    case 'eq':
+      return Number(cell) === Number(value);
+    case 'ne':
+      return Number(cell) !== Number(value);
+    case 'gt':
+      return Number(cell) > Number(value);
+    case 'lt':
+      return Number(cell) < Number(value);
+    case 'gte':
+      return Number(cell) >= Number(value);
+    case 'lte':
+      return Number(cell) <= Number(value);
+    case 'before':
+      return new Date(String(cell)) < new Date(String(value));
+    case 'after':
+      return new Date(String(cell)) > new Date(String(value));
+    case 'onOrBefore':
+      return new Date(String(cell)) <= new Date(String(value));
+    case 'onOrAfter':
+      return new Date(String(cell)) >= new Date(String(value));
+    case 'isAnyOf':
+      return Array.isArray(value) ? value.includes(cell) : true;
+    case 'isNoneOf':
+      return Array.isArray(value) ? !value.includes(cell) : true;
+    default:
+      return true;
+  }
+};
 
 export type UseDataTableProps<TData> = {
   data: TData[];
@@ -128,6 +270,7 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
     data,
     columns,
     pageCount: pageCount ?? undefined,
+    defaultColumn: { filterFn: dataTableFilterFn },
     state: {
       sorting: props.state?.sorting ?? sorting,
       columnFilters: props.state?.columnFilters ?? columnFilters,
@@ -351,6 +494,11 @@ export function DataTableColumnHeader<TData, TValue>({
             <ArrowUp className='ml-2 size-4' />
           ) : (
             <ChevronsUpDown className='ml-2 size-4' />
+          )}
+          {sorted && column.getSortIndex() >= 1 && (
+            <span className='ml-1 rounded bg-muted px-1 font-mono text-[10px] text-muted-foreground tabular-nums'>
+              {column.getSortIndex() + 1}
+            </span>
           )}
         </Button>
       </PopoverTrigger>
@@ -830,5 +978,520 @@ export function DataTableLoadMore({
       )}
       {count && <span className='text-muted-foreground text-xs'>{count}</span>}
     </div>
+  );
+}
+
+type FilterField = { id: string; label: string; variant: FilterVariant; options?: DataTableFilterOption[] };
+type SortField = { id: string; label: string };
+
+function getFilterableFields<TData>(table: Table<TData>): FilterField[] {
+  return table
+    .getAllColumns()
+    .filter((column) => column.getCanFilter() && column.columnDef.meta?.variant)
+    .map((column) => ({
+      id: column.id,
+      label: column.columnDef.meta?.label ?? column.id,
+      variant: column.columnDef.meta?.variant as FilterVariant,
+      options: column.columnDef.meta?.options,
+    }));
+}
+
+function getSortableFields<TData>(table: Table<TData>): SortField[] {
+  return table
+    .getAllColumns()
+    .filter((column) => column.getCanSort())
+    .map((column) => ({ id: column.id, label: column.columnDef.meta?.label ?? column.id }));
+}
+
+function defaultOperatorFor(variant: FilterVariant): FilterOperator {
+  return OPERATORS_BY_VARIANT[variant][0];
+}
+
+function defaultValueFor(variant: FilterVariant): unknown {
+  return MULTI_VALUE_OPERATORS.includes(defaultOperatorFor(variant)) ? [] : '';
+}
+
+function FieldSelect({
+  fields,
+  value,
+  onChange,
+}: {
+  fields: { id: string; label: string }[];
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className='h-8 w-[120px] shrink-0'>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {fields.map((field) => (
+          <SelectItem key={field.id} value={field.id}>
+            {field.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function OperatorSelect({
+  variant,
+  value,
+  onChange,
+}: {
+  variant: FilterVariant;
+  value: FilterOperator;
+  onChange: (value: FilterOperator) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={(next) => onChange(next as FilterOperator)}>
+      <SelectTrigger className='h-8 w-[136px] shrink-0'>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {OPERATORS_BY_VARIANT[variant].map((operator) => (
+          <SelectItem key={operator} value={operator}>
+            {OPERATOR_LABELS[operator]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function MultiSelectValue({
+  options,
+  selected,
+  onChange,
+}: {
+  options: DataTableFilterOption[];
+  selected: string[];
+  onChange: (value: string[]) => void;
+}) {
+  const toggle = (value: string) =>
+    onChange(selected.includes(value) ? selected.filter((item) => item !== value) : [...selected, value]);
+  const label =
+    selected.length === 0
+      ? 'Select…'
+      : selected.length === 1
+        ? (options.find((option) => option.value === selected[0])?.label ?? selected[0])
+        : `${selected.length} selected`;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='h-8 flex-1 justify-between font-normal'>
+          <span className='truncate'>{label}</span>
+          <ChevronDown className='ml-1 size-3.5 shrink-0 text-muted-foreground' />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='start' className='w-48 p-1'>
+        <div className='flex flex-col gap-0.5'>
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type='button'
+              onClick={() => toggle(option.value)}
+              className='flex items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent'
+            >
+              <Checkbox checked={selected.includes(option.value)} className='pointer-events-none' />
+              <span>{option.label}</span>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function FilterValueControl({
+  field,
+  condition,
+  onChange,
+}: {
+  field: FilterField;
+  condition: FilterCondition;
+  onChange: (value: unknown) => void;
+}) {
+  if (!operatorTakesValue(condition.operator)) {
+    return <div className='h-8 flex-1 rounded-md border border-dashed bg-muted/30' aria-hidden />;
+  }
+
+  if ((field.variant === 'select' || field.variant === 'multiSelect') && field.options) {
+    if (MULTI_VALUE_OPERATORS.includes(condition.operator)) {
+      const selected = Array.isArray(condition.value) ? (condition.value as string[]) : [];
+      return <MultiSelectValue options={field.options} selected={selected} onChange={onChange} />;
+    }
+    return (
+      <Select value={(condition.value as string) ?? ''} onValueChange={onChange}>
+        <SelectTrigger className='h-8 flex-1'>
+          <SelectValue placeholder='Select…' />
+        </SelectTrigger>
+        <SelectContent>
+          {field.options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <Input
+      value={(condition.value as string) ?? ''}
+      onChange={(event) => onChange(event.target.value)}
+      type={field.variant === 'number' ? 'number' : field.variant === 'date' ? 'date' : 'text'}
+      placeholder='Value'
+      className='h-8 flex-1'
+    />
+  );
+}
+
+function FilterBuilder<TData>({ table }: { table: Table<TData> }) {
+  const fields = getFilterableFields(table);
+  const columnFilters = table.getState().columnFilters;
+
+  const rows = columnFilters
+    .map((columnFilter) => {
+      const field = fields.find((candidate) => candidate.id === columnFilter.id);
+      if (!field) return null;
+      const condition = isFilterCondition(columnFilter.value)
+        ? columnFilter.value
+        : { operator: defaultOperatorFor(field.variant), value: columnFilter.value };
+      return { field, condition };
+    })
+    .filter((row): row is { field: FilterField; condition: FilterCondition } => row !== null);
+
+  const setCondition = (columnId: string, condition: FilterCondition) => {
+    table.setColumnFilters((current) => [
+      ...current.filter((item) => item.id !== columnId),
+      { id: columnId, value: condition },
+    ]);
+  };
+
+  const removeCondition = (columnId: string) =>
+    table.setColumnFilters((current) => current.filter((item) => item.id !== columnId));
+
+  const changeField = (oldId: string, newId: string) => {
+    const field = fields.find((candidate) => candidate.id === newId);
+    if (!field) return;
+    table.setColumnFilters((current) => [
+      ...current.filter((item) => item.id !== oldId && item.id !== newId),
+      { id: newId, value: { operator: defaultOperatorFor(field.variant), value: defaultValueFor(field.variant) } },
+    ]);
+  };
+
+  const changeOperator = (field: FilterField, previous: FilterCondition, operator: FilterOperator) => {
+    const wasMulti = Array.isArray(previous.value);
+    const willMulti = MULTI_VALUE_OPERATORS.includes(operator);
+    const value = willMulti ? (wasMulti ? previous.value : []) : wasMulti ? '' : previous.value;
+    setCondition(field.id, { operator, value });
+  };
+
+  const addCondition = () => {
+    const used = new Set(columnFilters.map((item) => item.id));
+    const next = fields.find((field) => !used.has(field.id));
+    if (!next) return;
+    setCondition(next.id, { operator: defaultOperatorFor(next.variant), value: defaultValueFor(next.variant) });
+  };
+
+  const allUsed = fields.length > 0 && fields.every((field) => columnFilters.some((item) => item.id === field.id));
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {rows.length === 0 ? (
+        <p className='px-1 py-2 text-muted-foreground text-sm'>No filters applied to this view.</p>
+      ) : (
+        rows.map((row, index) => (
+          <div key={row.field.id} className='flex items-center gap-2'>
+            <span className='w-12 shrink-0 pl-1 text-muted-foreground text-sm'>{index === 0 ? 'Where' : 'And'}</span>
+            <FieldSelect fields={fields} value={row.field.id} onChange={(value) => changeField(row.field.id, value)} />
+            <OperatorSelect
+              variant={row.field.variant}
+              value={row.condition.operator}
+              onChange={(operator) => changeOperator(row.field, row.condition, operator)}
+            />
+            <FilterValueControl
+              field={row.field}
+              condition={row.condition}
+              onChange={(value) => setCondition(row.field.id, { ...row.condition, value })}
+            />
+            <Button
+              variant='ghost'
+              size='icon-sm'
+              className='shrink-0 text-muted-foreground'
+              onClick={() => removeCondition(row.field.id)}
+              aria-label='Remove filter'
+            >
+              <X className='size-4' />
+            </Button>
+          </div>
+        ))
+      )}
+      <div className='flex items-center justify-between pt-1'>
+        <Button
+          variant='ghost'
+          size='sm'
+          className='h-8 px-2 text-muted-foreground'
+          onClick={addCondition}
+          disabled={allUsed}
+        >
+          <Plus className='mr-1.5 size-4' /> Add filter
+        </Button>
+        {rows.length > 0 && (
+          <Button
+            variant='ghost'
+            size='sm'
+            className='h-8 px-2 text-muted-foreground'
+            onClick={() => table.setColumnFilters([])}
+          >
+            <Trash2 className='mr-1.5 size-4' /> Clear
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export type DataTableFilterMenuProps<TData> = {
+  table: Table<TData>;
+  variant?: 'popover' | 'dialog';
+};
+
+export function DataTableFilterMenu<TData>({ table, variant = 'popover' }: DataTableFilterMenuProps<TData>) {
+  const count = table.getState().columnFilters.length;
+  const trigger = (
+    <Button variant='outline' size='sm' className='h-8 border-dashed'>
+      <ListFilter className='mr-2 size-4' /> Filter
+      {count > 0 && <span className='ml-2 rounded-sm bg-secondary px-1.5 font-normal text-xs'>{count}</span>}
+      {variant === 'popover' && <ChevronDown className='ml-1 size-3.5 text-muted-foreground' />}
+    </Button>
+  );
+
+  if (variant === 'dialog') {
+    return (
+      <Dialog>
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <DialogContent className='max-w-2xl'>
+          <DialogHeader>
+            <DialogTitle>Filters</DialogTitle>
+            <DialogDescription>Show rows that match all of these conditions.</DialogDescription>
+          </DialogHeader>
+          <FilterBuilder table={table} />
+          <DialogFooter>
+            <Button variant='ghost' size='sm' onClick={() => table.setColumnFilters([])}>
+              Clear all
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align='start' className='w-[560px] p-2'>
+        <FilterBuilder table={table} />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function SortBuilder<TData>({ table }: { table: Table<TData> }) {
+  const fields = getSortableFields(table);
+  const sorting = table.getState().sorting;
+
+  const setDir = (id: string, desc: boolean) =>
+    table.setSorting((current) => current.map((sort) => (sort.id === id ? { ...sort, desc } : sort)));
+
+  const remove = (id: string) => table.setSorting((current) => current.filter((sort) => sort.id !== id));
+
+  const changeField = (oldId: string, newId: string) =>
+    table.setSorting((current) => [
+      ...current.filter((sort) => sort.id !== oldId && sort.id !== newId),
+      { id: newId, desc: false },
+    ]);
+
+  const add = () => {
+    const used = new Set(sorting.map((sort) => sort.id));
+    const next = fields.find((field) => !used.has(field.id));
+    if (next) table.setSorting((current) => [...current, { id: next.id, desc: false }]);
+  };
+
+  const allUsed = fields.length > 0 && fields.every((field) => sorting.some((sort) => sort.id === field.id));
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {sorting.length === 0 ? (
+        <p className='px-1 py-2 text-muted-foreground text-sm'>No sorts applied to this view.</p>
+      ) : (
+        sorting.map((sort, index) => (
+          <div key={sort.id} className='flex items-center gap-2'>
+            <span className='w-12 shrink-0 pl-1 text-muted-foreground text-sm'>{index === 0 ? 'Sort' : 'Then'}</span>
+            <FieldSelect fields={fields} value={sort.id} onChange={(value) => changeField(sort.id, value)} />
+            <Select value={sort.desc ? 'desc' : 'asc'} onValueChange={(value) => setDir(sort.id, value === 'desc')}>
+              <SelectTrigger className='h-8 flex-1'>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='asc'>Ascending</SelectItem>
+                <SelectItem value='desc'>Descending</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              variant='ghost'
+              size='icon-sm'
+              className='shrink-0 text-muted-foreground'
+              onClick={() => remove(sort.id)}
+              aria-label='Remove sort'
+            >
+              <X className='size-4' />
+            </Button>
+          </div>
+        ))
+      )}
+      <div className='pt-1'>
+        <Button variant='ghost' size='sm' className='h-8 px-2 text-muted-foreground' onClick={add} disabled={allUsed}>
+          <Plus className='mr-1.5 size-4' /> Add sort
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function DataTableSortMenu<TData>({ table }: { table: Table<TData> }) {
+  const count = table.getState().sorting.length;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='h-8 border-dashed'>
+          <ArrowDownUp className='mr-2 size-4' /> Sort
+          {count > 0 && <span className='ml-2 rounded-sm bg-secondary px-1.5 font-normal text-xs'>{count}</span>}
+          <ChevronDown className='ml-1 size-3.5 text-muted-foreground' />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='start' className='w-[420px] p-2'>
+        <SortBuilder table={table} />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export type DataTableView = { name: string; filters: ColumnFiltersState; sorting: SortingState };
+
+export type DataTableViewsProps<TData> = {
+  table: Table<TData>;
+  storageKey: string;
+};
+
+export function DataTableViews<TData>({ table, storageKey }: DataTableViewsProps<TData>) {
+  const key = `shuip:dt-views:${storageKey}`;
+  const [views, setViews] = React.useState<DataTableView[]>([]);
+  const [name, setName] = React.useState('');
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw) setViews(JSON.parse(raw) as DataTableView[]);
+    } catch {
+      setViews([]);
+    }
+  }, [key]);
+
+  const persist = (next: DataTableView[]) => {
+    setViews(next);
+    try {
+      localStorage.setItem(key, JSON.stringify(next));
+    } catch {
+      /* storage unavailable */
+    }
+  };
+
+  const save = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const view: DataTableView = {
+      name: trimmed,
+      filters: table.getState().columnFilters,
+      sorting: table.getState().sorting,
+    };
+    persist([...views.filter((current) => current.name !== trimmed), view]);
+    setName('');
+    setSaving(false);
+  };
+
+  const apply = (view: DataTableView) => {
+    table.setColumnFilters(view.filters);
+    table.setSorting(view.sorting);
+  };
+
+  const remove = (viewName: string) => persist(views.filter((current) => current.name !== viewName));
+
+  return (
+    <Popover onOpenChange={(open) => !open && setSaving(false)}>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='sm' className='h-8'>
+          <Bookmark className='mr-2 size-4' /> Views
+          {views.length > 0 && (
+            <span className='ml-2 rounded-sm bg-secondary px-1.5 font-normal text-xs'>{views.length}</span>
+          )}
+          <ChevronDown className='ml-1 size-3.5 text-muted-foreground' />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='w-60 p-1'>
+        <div className='flex flex-col gap-0.5'>
+          {views.length === 0 ? (
+            <p className='px-2 py-1.5 text-muted-foreground text-sm'>No saved views.</p>
+          ) : (
+            views.map((view) => (
+              <div key={view.name} className='flex items-center'>
+                <button
+                  type='button'
+                  onClick={() => apply(view)}
+                  className='flex-1 truncate rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent'
+                >
+                  {view.name}
+                </button>
+                <Button
+                  variant='ghost'
+                  size='icon-sm'
+                  className='shrink-0 text-muted-foreground'
+                  onClick={() => remove(view.name)}
+                  aria-label={`Delete ${view.name}`}
+                >
+                  <Trash2 className='size-3.5' />
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+        <Separator className='my-1' />
+        {saving ? (
+          <div className='flex items-center gap-1.5 p-1'>
+            <Input
+              autoFocus
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => event.key === 'Enter' && save()}
+              placeholder='View name'
+              className='h-8'
+            />
+            <Button size='sm' className='h-8' onClick={save} disabled={!name.trim()}>
+              Save
+            </Button>
+          </div>
+        ) : (
+          <Button variant='ghost' size='sm' className='w-full justify-start' onClick={() => setSaving(true)}>
+            <Plus className='mr-2 size-4' /> Save current view
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -117,10 +117,10 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
   const [pagination, setPagination] = React.useState<PaginationState>(
     initialState?.pagination ?? { pageIndex: 0, pageSize: 10 },
   );
-  const [columnPinning, setColumnPinning] = React.useState<ColumnPinningState>({
+  const [columnPinning, setColumnPinning] = React.useState<ColumnPinningState>(() => ({
     left: initialState?.columnPinning?.left ?? [],
     right: initialState?.columnPinning?.right ?? [],
-  });
+  }));
 
   const table = useReactTable({
     data,
@@ -182,6 +182,8 @@ function getPinClass<TData>(column: Column<TData>): string | undefined {
   return column.getIsPinned() ? 'bg-background' : undefined;
 }
 
+const skeletonBar = <div className='h-5 w-full animate-pulse rounded bg-muted' />;
+
 export type DataTableProps<TData> = {
   table: Table<TData>;
   isLoading?: boolean;
@@ -219,7 +221,7 @@ export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, cla
               <TableRow key={rowIndex}>
                 {table.getVisibleLeafColumns().map((column) => (
                   <TableCell key={column.id} style={getColumnStyles(column)} className={getPinClass(column)}>
-                    <div className='h-5 w-full animate-pulse rounded bg-muted' />
+                    {skeletonBar}
                   </TableCell>
                 ))}
               </TableRow>

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -1,6 +1,23 @@
 'use client';
 
 import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
   type Column,
   type ColumnDef,
   type ColumnFiltersState,
@@ -35,6 +52,7 @@ import {
   ChevronsRight,
   ChevronsUpDown,
   EyeOff,
+  GripVertical,
   Inbox,
   ListFilter,
   Loader2,
@@ -1011,6 +1029,32 @@ function defaultValueFor(variant: FilterVariant): unknown {
   return MULTI_VALUE_OPERATORS.includes(defaultOperatorFor(variant)) ? [] : '';
 }
 
+function useReorderSensors() {
+  return useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+}
+
+function SortableRow({ id, children }: { id: string; children: React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style: React.CSSProperties = { transform: CSS.Transform.toString(transform), transition };
+  return (
+    <div ref={setNodeRef} style={style} className={cn('flex items-center gap-2', isDragging && 'opacity-60')}>
+      <button
+        type='button'
+        className='shrink-0 cursor-grab touch-none text-muted-foreground/50 active:cursor-grabbing'
+        aria-label='Reorder'
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className='size-4' />
+      </button>
+      {children}
+    </div>
+  );
+}
+
 function FieldSelect({
   fields,
   value,
@@ -1201,36 +1245,58 @@ function FilterBuilder<TData>({ table }: { table: Table<TData> }) {
 
   const allUsed = fields.length > 0 && fields.every((field) => columnFilters.some((item) => item.id === field.id));
 
+  const sensors = useReorderSensors();
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    table.setColumnFilters((current) => {
+      const oldIndex = current.findIndex((item) => item.id === active.id);
+      const newIndex = current.findIndex((item) => item.id === over.id);
+      if (oldIndex < 0 || newIndex < 0) return current;
+      return arrayMove(current, oldIndex, newIndex);
+    });
+  };
+
   return (
     <div className='flex flex-col gap-2'>
       {rows.length === 0 ? (
         <p className='px-1 py-2 text-muted-foreground text-sm'>No filters applied to this view.</p>
       ) : (
-        rows.map((row, index) => (
-          <div key={row.field.id} className='flex items-center gap-2'>
-            <span className='w-12 shrink-0 pl-1 text-muted-foreground text-sm'>{index === 0 ? 'Where' : 'And'}</span>
-            <FieldSelect fields={fields} value={row.field.id} onChange={(value) => changeField(row.field.id, value)} />
-            <OperatorSelect
-              variant={row.field.variant}
-              value={row.condition.operator}
-              onChange={(operator) => changeOperator(row.field, row.condition, operator)}
-            />
-            <FilterValueControl
-              field={row.field}
-              condition={row.condition}
-              onChange={(value) => setCondition(row.field.id, { ...row.condition, value })}
-            />
-            <Button
-              variant='ghost'
-              size='icon-sm'
-              className='shrink-0 text-muted-foreground'
-              onClick={() => removeCondition(row.field.id)}
-              aria-label='Remove filter'
-            >
-              <X className='size-4' />
-            </Button>
-          </div>
-        ))
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={rows.map((row) => row.field.id)} strategy={verticalListSortingStrategy}>
+            <div className='flex flex-col gap-2'>
+              {rows.map((row, index) => (
+                <SortableRow key={row.field.id} id={row.field.id}>
+                  <span className='w-12 shrink-0 text-muted-foreground text-sm'>{index === 0 ? 'Where' : 'And'}</span>
+                  <FieldSelect
+                    fields={fields}
+                    value={row.field.id}
+                    onChange={(value) => changeField(row.field.id, value)}
+                  />
+                  <OperatorSelect
+                    variant={row.field.variant}
+                    value={row.condition.operator}
+                    onChange={(operator) => changeOperator(row.field, row.condition, operator)}
+                  />
+                  <FilterValueControl
+                    field={row.field}
+                    condition={row.condition}
+                    onChange={(value) => setCondition(row.field.id, { ...row.condition, value })}
+                  />
+                  <Button
+                    variant='ghost'
+                    size='icon-sm'
+                    className='shrink-0 text-muted-foreground'
+                    onClick={() => removeCondition(row.field.id)}
+                    aria-label='Remove filter'
+                  >
+                    <X className='size-4' />
+                  </Button>
+                </SortableRow>
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
       )}
       <div className='flex items-center justify-between pt-1'>
         <Button
@@ -1325,35 +1391,56 @@ function SortBuilder<TData>({ table }: { table: Table<TData> }) {
 
   const allUsed = fields.length > 0 && fields.every((field) => sorting.some((sort) => sort.id === field.id));
 
+  const sensors = useReorderSensors();
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    table.setSorting((current) => {
+      const oldIndex = current.findIndex((sort) => sort.id === active.id);
+      const newIndex = current.findIndex((sort) => sort.id === over.id);
+      if (oldIndex < 0 || newIndex < 0) return current;
+      return arrayMove(current, oldIndex, newIndex);
+    });
+  };
+
   return (
     <div className='flex flex-col gap-2'>
       {sorting.length === 0 ? (
         <p className='px-1 py-2 text-muted-foreground text-sm'>No sorts applied to this view.</p>
       ) : (
-        sorting.map((sort, index) => (
-          <div key={sort.id} className='flex items-center gap-2'>
-            <span className='w-12 shrink-0 pl-1 text-muted-foreground text-sm'>{index === 0 ? 'Sort' : 'Then'}</span>
-            <FieldSelect fields={fields} value={sort.id} onChange={(value) => changeField(sort.id, value)} />
-            <Select value={sort.desc ? 'desc' : 'asc'} onValueChange={(value) => setDir(sort.id, value === 'desc')}>
-              <SelectTrigger className='h-8 flex-1'>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='asc'>Ascending</SelectItem>
-                <SelectItem value='desc'>Descending</SelectItem>
-              </SelectContent>
-            </Select>
-            <Button
-              variant='ghost'
-              size='icon-sm'
-              className='shrink-0 text-muted-foreground'
-              onClick={() => remove(sort.id)}
-              aria-label='Remove sort'
-            >
-              <X className='size-4' />
-            </Button>
-          </div>
-        ))
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={sorting.map((sort) => sort.id)} strategy={verticalListSortingStrategy}>
+            <div className='flex flex-col gap-2'>
+              {sorting.map((sort, index) => (
+                <SortableRow key={sort.id} id={sort.id}>
+                  <span className='w-12 shrink-0 text-muted-foreground text-sm'>{index === 0 ? 'Sort' : 'Then'}</span>
+                  <FieldSelect fields={fields} value={sort.id} onChange={(value) => changeField(sort.id, value)} />
+                  <Select
+                    value={sort.desc ? 'desc' : 'asc'}
+                    onValueChange={(value) => setDir(sort.id, value === 'desc')}
+                  >
+                    <SelectTrigger className='h-8 flex-1'>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='asc'>Ascending</SelectItem>
+                      <SelectItem value='desc'>Descending</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant='ghost'
+                    size='icon-sm'
+                    className='shrink-0 text-muted-foreground'
+                    onClick={() => remove(sort.id)}
+                    aria-label='Remove sort'
+                  >
+                    <X className='size-4' />
+                  </Button>
+                </SortableRow>
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
       )}
       <div className='pt-1'>
         <Button variant='ghost' size='sm' className='h-8 px-2 text-muted-foreground' onClick={add} disabled={allUsed}>

--- a/packages/registry/items/blocks/data-table/component.tsx
+++ b/packages/registry/items/blocks/data-table/component.tsx
@@ -207,10 +207,8 @@ export function DataTable<TData>({ table, isLoading, emptyState, onRowClick, cla
         <TableBody>
           {isLoading ? (
             Array.from({ length: table.getState().pagination.pageSize }).map((_, rowIndex) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
               <TableRow key={rowIndex}>
                 {Array.from({ length: columnCount }).map((__, cellIndex) => (
-                  // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
                   <TableCell key={cellIndex}>
                     <div className='h-5 w-full animate-pulse rounded bg-muted' />
                   </TableCell>

--- a/packages/registry/items/blocks/data-table/default.example.tsx
+++ b/packages/registry/items/blocks/data-table/default.example.tsx
@@ -47,18 +47,21 @@ export default function DataTableDefaultExample() {
     () => [
       {
         accessorKey: 'name',
+        size: 190,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
         meta: { label: 'Name' },
         cell: ({ row }) => <span className='font-medium'>{row.original.name}</span>,
       },
       {
         accessorKey: 'email',
+        size: 220,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
         meta: { label: 'Email' },
         cell: ({ row }) => <span className='text-muted-foreground'>{row.original.email}</span>,
       },
       {
         accessorKey: 'role',
+        size: 120,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Role' />,
         meta: { label: 'Role', variant: 'multiSelect', options: roleOptions },
         filterFn: 'arrIncludesSome',
@@ -66,6 +69,7 @@ export default function DataTableDefaultExample() {
       },
       {
         accessorKey: 'status',
+        size: 120,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
         meta: { label: 'Status', variant: 'multiSelect', options: statusOptions },
         filterFn: 'arrIncludesSome',
@@ -83,7 +87,7 @@ export default function DataTableDefaultExample() {
   });
 
   return (
-    <div className='flex flex-col gap-3'>
+    <div className='flex w-full min-w-0 flex-col gap-3'>
       <DataTableToolbar table={table} searchPlaceholder='Search users...' />
       <DataTable table={table} />
       <DataTablePagination table={table} />

--- a/packages/registry/items/blocks/data-table/default.example.tsx
+++ b/packages/registry/items/blocks/data-table/default.example.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'editor' | 'viewer';
+  status: 'active' | 'invited' | 'suspended';
+};
+
+const users: User[] = [
+  { id: '1', name: 'Ava Mercer', email: 'ava@acme.io', role: 'admin', status: 'active' },
+  { id: '2', name: 'Liam Cho', email: 'liam@acme.io', role: 'editor', status: 'active' },
+  { id: '3', name: 'Noah Patel', email: 'noah@acme.io', role: 'editor', status: 'invited' },
+  { id: '4', name: 'Mia Rossi', email: 'mia@acme.io', role: 'viewer', status: 'suspended' },
+  { id: '5', name: 'Ethan Wood', email: 'ethan@acme.io', role: 'viewer', status: 'active' },
+  { id: '6', name: 'Zoe Bauer', email: 'zoe@acme.io', role: 'admin', status: 'invited' },
+  { id: '7', name: 'Kai Nguyen', email: 'kai@acme.io', role: 'editor', status: 'active' },
+  { id: '8', name: 'Lena Fox', email: 'lena@acme.io', role: 'viewer', status: 'suspended' },
+];
+
+const roleOptions = [
+  { label: 'Admin', value: 'admin' },
+  { label: 'Editor', value: 'editor' },
+  { label: 'Viewer', value: 'viewer' },
+];
+
+const statusOptions = [
+  { label: 'Active', value: 'active' },
+  { label: 'Invited', value: 'invited' },
+  { label: 'Suspended', value: 'suspended' },
+];
+
+export default function DataTableDefaultExample() {
+  const columns = React.useMemo<ColumnDef<User>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        meta: { label: 'Name' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.name}</span>,
+      },
+      {
+        accessorKey: 'email',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
+        meta: { label: 'Email' },
+        cell: ({ row }) => <span className='text-muted-foreground'>{row.original.email}</span>,
+      },
+      {
+        accessorKey: 'role',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Role' />,
+        meta: { label: 'Role', variant: 'multiSelect', options: roleOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => <span className='capitalize'>{row.original.role}</span>,
+      },
+      {
+        accessorKey: 'status',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        meta: { label: 'Status', variant: 'multiSelect', options: statusOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: users,
+    columns,
+    getRowId: (row) => row.id,
+    initialState: { pagination: { pageIndex: 0, pageSize: 5 } },
+  });
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <DataTableToolbar table={table} searchPlaceholder='Search users...' />
+      <DataTable table={table} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/empty.example.tsx
+++ b/packages/registry/items/blocks/data-table/empty.example.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import { UserPlus } from 'lucide-react';
+import * as React from 'react';
+
+import { DataTable, DataTableColumnHeader, DataTableEmpty, useDataTable } from '@/components/block/shuip/data-table';
+import { Button } from '@/components/ui/button';
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+export default function DataTableEmptyExample() {
+  const [variant, setVariant] = React.useState<'text' | 'illustrated' | 'with-action'>('illustrated');
+
+  const columns = React.useMemo<ColumnDef<User>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        size: 220,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        meta: { label: 'Name' },
+      },
+      {
+        accessorKey: 'email',
+        size: 260,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
+        meta: { label: 'Email' },
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable<User>({ data: [], columns, getRowId: (row) => row.id });
+
+  return (
+    <div className='flex w-full min-w-0 flex-col gap-3'>
+      <div className='flex items-center gap-2'>
+        {(['text', 'illustrated', 'with-action'] as const).map((value) => (
+          <Button
+            key={value}
+            variant={variant === value ? 'default' : 'outline'}
+            size='sm'
+            onClick={() => setVariant(value)}
+          >
+            {value}
+          </Button>
+        ))}
+      </div>
+      <DataTable
+        table={table}
+        emptyState={
+          <DataTableEmpty
+            variant={variant}
+            icon={UserPlus}
+            title='No users yet'
+            description='Invite teammates to see them listed here.'
+            action={<Button size='sm'>Invite user</Button>}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/empty.example.tsx
+++ b/packages/registry/items/blocks/data-table/empty.example.tsx
@@ -13,6 +13,8 @@ type User = {
   email: string;
 };
 
+const noUsers: User[] = [];
+
 export default function DataTableEmptyExample() {
   const [variant, setVariant] = React.useState<'text' | 'illustrated' | 'with-action'>('illustrated');
 
@@ -34,7 +36,7 @@ export default function DataTableEmptyExample() {
     [],
   );
 
-  const { table } = useDataTable<User>({ data: [], columns, getRowId: (row) => row.id });
+  const { table } = useDataTable<User>({ data: noUsers, columns, getRowId: (row) => row.id });
 
   return (
     <div className='flex w-full min-w-0 flex-col gap-3'>

--- a/packages/registry/items/blocks/data-table/load-more.example.tsx
+++ b/packages/registry/items/blocks/data-table/load-more.example.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+
+import { DataTable, DataTableColumnHeader, DataTableLoadMore, useDataTable } from '@/components/block/shuip/data-table';
+import { Button } from '@/components/ui/button';
+
+type Event = {
+  id: string;
+  name: string;
+  channel: string;
+  at: string;
+};
+
+const channels = ['web', 'mobile', 'api', 'import'];
+
+const allEvents: Event[] = Array.from({ length: 60 }, (_, index) => ({
+  id: `evt-${index + 1}`,
+  name: `event.${['created', 'updated', 'deleted', 'viewed'][index % 4]}`,
+  channel: channels[index % channels.length],
+  at: `2026-06-${String((index % 28) + 1).padStart(2, '0')} 09:${String(index % 60).padStart(2, '0')}`,
+}));
+
+const PAGE = 10;
+
+export default function DataTableLoadMoreExample() {
+  const [mode, setMode] = React.useState<'button' | 'infinite'>('button');
+  const [loaded, setLoaded] = React.useState(PAGE);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const rows = React.useMemo(() => allEvents.slice(0, loaded), [loaded]);
+  const hasMore = loaded < allEvents.length;
+
+  const onLoadMore = React.useCallback(() => {
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      setLoaded((current) => Math.min(current + PAGE, allEvents.length));
+      setIsLoading(false);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const columns = React.useMemo<ColumnDef<Event>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        size: 200,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Event' />,
+        meta: { label: 'Event' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.name}</span>,
+      },
+      {
+        accessorKey: 'channel',
+        size: 140,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Channel' />,
+        meta: { label: 'Channel' },
+        cell: ({ row }) => <span className='capitalize'>{row.original.channel}</span>,
+      },
+      {
+        accessorKey: 'at',
+        size: 180,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='When' />,
+        meta: { label: 'When' },
+        cell: ({ row }) => <span className='text-muted-foreground tabular-nums'>{row.original.at}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: rows,
+    columns,
+    getRowId: (row) => row.id,
+    initialState: { pagination: { pageIndex: 0, pageSize: allEvents.length } },
+  });
+
+  return (
+    <div className='flex w-full min-w-0 flex-col gap-3'>
+      <div className='flex items-center gap-2'>
+        <Button variant={mode === 'button' ? 'default' : 'outline'} size='sm' onClick={() => setMode('button')}>
+          Button
+        </Button>
+        <Button variant={mode === 'infinite' ? 'default' : 'outline'} size='sm' onClick={() => setMode('infinite')}>
+          Infinite
+        </Button>
+      </div>
+      <DataTable table={table} />
+      <DataTableLoadMore
+        mode={mode}
+        onLoadMore={onLoadMore}
+        hasMore={hasMore}
+        isLoading={isLoading}
+        loaded={rows.length}
+        total={allEvents.length}
+      />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/loading.example.tsx
+++ b/packages/registry/items/blocks/data-table/loading.example.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+import { Button } from '@/components/ui/button';
+
+type Project = {
+  id: string;
+  name: string;
+  owner: string;
+  status: 'active' | 'archived';
+};
+
+const projects: Project[] = [
+  { id: '1', name: 'Apollo', owner: 'Ava Mercer', status: 'active' },
+  { id: '2', name: 'Borealis', owner: 'Liam Cho', status: 'active' },
+  { id: '3', name: 'Cobalt', owner: 'Noah Patel', status: 'archived' },
+  { id: '4', name: 'Driftwood', owner: 'Mia Rossi', status: 'active' },
+  { id: '5', name: 'Ember', owner: 'Ethan Wood', status: 'archived' },
+];
+
+export default function DataTableLoadingExample() {
+  const [variant, setVariant] = React.useState<'skeleton' | 'overlay' | 'shimmer'>('skeleton');
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const trigger = React.useCallback((next: 'skeleton' | 'overlay' | 'shimmer') => {
+    setVariant(next);
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 2000);
+  }, []);
+
+  const columns = React.useMemo<ColumnDef<Project>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        size: 200,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Project' />,
+        meta: { label: 'Project' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.name}</span>,
+      },
+      {
+        accessorKey: 'owner',
+        size: 220,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Owner' />,
+        meta: { label: 'Owner' },
+      },
+      {
+        accessorKey: 'status',
+        size: 120,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        meta: { label: 'Status' },
+        cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({ data: projects, columns, getRowId: (row) => row.id });
+
+  return (
+    <div className='flex w-full min-w-0 flex-col gap-3'>
+      <div className='flex items-center gap-2'>
+        {(['skeleton', 'overlay', 'shimmer'] as const).map((value) => (
+          <Button
+            key={value}
+            variant={variant === value ? 'default' : 'outline'}
+            size='sm'
+            onClick={() => trigger(value)}
+            disabled={isLoading}
+          >
+            {value}
+          </Button>
+        ))}
+      </div>
+      <DataTable table={table} isLoading={isLoading} loadingVariant={variant} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/pagination-numbered.example.tsx
+++ b/packages/registry/items/blocks/data-table/pagination-numbered.example.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+
+type Invoice = {
+  id: string;
+  customer: string;
+  amount: number;
+  status: 'paid' | 'pending' | 'overdue';
+};
+
+const statuses: Invoice['status'][] = ['paid', 'pending', 'overdue'];
+
+const invoices: Invoice[] = Array.from({ length: 84 }, (_, index) => ({
+  id: `INV-${String(index + 1).padStart(4, '0')}`,
+  customer: `Customer ${index + 1}`,
+  amount: 100 + ((index * 37) % 900),
+  status: statuses[index % statuses.length],
+}));
+
+export default function DataTablePaginationNumberedExample() {
+  const columns = React.useMemo<ColumnDef<Invoice>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        size: 140,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Invoice' />,
+        meta: { label: 'Invoice' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.id}</span>,
+      },
+      {
+        accessorKey: 'customer',
+        size: 220,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Customer' />,
+        meta: { label: 'Customer' },
+      },
+      {
+        accessorKey: 'amount',
+        size: 120,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Amount' />,
+        meta: { label: 'Amount' },
+        cell: ({ row }) => <span className='tabular-nums'>${row.original.amount}</span>,
+      },
+      {
+        accessorKey: 'status',
+        size: 120,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        meta: { label: 'Status' },
+        cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: invoices,
+    columns,
+    getRowId: (row) => row.id,
+    initialState: { pagination: { pageIndex: 0, pageSize: 8 } },
+  });
+
+  return (
+    <div className='flex w-full min-w-0 flex-col gap-3'>
+      <DataTable table={table} />
+      <DataTablePagination table={table} variant='numbered' />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/rich.example.tsx
+++ b/packages/registry/items/blocks/data-table/rich.example.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import * as React from 'react';
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+import { Checkbox } from '@/components/ui/checkbox';
+
+type Person = {
+  id: string;
+  name: string;
+  email: string;
+  team: string;
+  stage: 'lead' | 'qualified' | 'won';
+  tags: string[];
+};
+
+const people: Person[] = [
+  { id: '1', name: 'Ava Mercer', email: 'ava@acme.io', team: 'Growth', stage: 'won', tags: ['VIP', 'EU'] },
+  { id: '2', name: 'Liam Cho', email: 'liam@acme.io', team: 'Sales', stage: 'qualified', tags: ['US'] },
+  { id: '3', name: 'Noah Patel', email: 'noah@acme.io', team: 'Sales', stage: 'lead', tags: ['Inbound'] },
+  { id: '4', name: 'Mia Rossi', email: 'mia@acme.io', team: 'Success', stage: 'won', tags: ['VIP'] },
+  { id: '5', name: 'Ethan Wood', email: 'ethan@acme.io', team: 'Growth', stage: 'lead', tags: ['EU', 'Trial'] },
+  { id: '6', name: 'Zoe Bauer', email: 'zoe@acme.io', team: 'Success', stage: 'qualified', tags: ['US'] },
+];
+
+const stageStyles: Record<Person['stage'], string> = {
+  lead: 'bg-muted text-muted-foreground',
+  qualified: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+  won: 'bg-green-500/15 text-green-600 dark:text-green-400',
+};
+
+const stageOptions = [
+  { label: 'Lead', value: 'lead' },
+  { label: 'Qualified', value: 'qualified' },
+  { label: 'Won', value: 'won' },
+];
+
+function Avatar({ name }: { name: string }) {
+  const initials = name
+    .split(' ')
+    .map((part) => part[0])
+    .slice(0, 2)
+    .join('');
+  return (
+    <span className='flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 font-medium text-primary text-xs'>
+      {initials}
+    </span>
+  );
+}
+
+export default function DataTableRichExample() {
+  const columns = React.useMemo<ColumnDef<Person>[]>(
+    () => [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <Checkbox
+            checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(Boolean(value))}
+            aria-label='Select all'
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
+            aria-label='Select row'
+          />
+        ),
+        enableSorting: false,
+        enableHiding: false,
+        size: 40,
+      },
+      {
+        accessorKey: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        meta: { label: 'Name' },
+        cell: ({ row }) => (
+          <div className='flex items-center gap-2'>
+            <Avatar name={row.original.name} />
+            <span className='font-medium'>{row.original.name}</span>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'email',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
+        meta: { label: 'Email' },
+        cell: ({ row }) => <span className='text-muted-foreground'>{row.original.email}</span>,
+      },
+      {
+        accessorKey: 'team',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Team' />,
+        meta: { label: 'Team' },
+      },
+      {
+        accessorKey: 'stage',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Stage' />,
+        meta: { label: 'Stage', variant: 'multiSelect', options: stageOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => (
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium text-xs capitalize ${stageStyles[row.original.stage]}`}
+          >
+            {row.original.stage}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'tags',
+        header: 'Tags',
+        enableSorting: false,
+        meta: { label: 'Tags' },
+        cell: ({ row }) => (
+          <div className='flex flex-wrap gap-1'>
+            {row.original.tags.map((tag) => (
+              <span key={tag} className='rounded border bg-muted px-1.5 py-0.5 text-muted-foreground text-xs'>
+                {tag}
+              </span>
+            ))}
+          </div>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: people,
+    columns,
+    getRowId: (row) => row.id,
+    enableRowSelection: true,
+    enableColumnPinning: true,
+    initialState: { columnPinning: { left: ['select', 'name'], right: [] } },
+  });
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <DataTableToolbar table={table} searchPlaceholder='Search people...' />
+      <DataTable table={table} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/rich.example.tsx
+++ b/packages/registry/items/blocks/data-table/rich.example.tsx
@@ -75,10 +75,11 @@ export default function DataTableRichExample() {
         ),
         enableSorting: false,
         enableHiding: false,
-        size: 40,
+        size: 48,
       },
       {
         accessorKey: 'name',
+        size: 220,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
         meta: { label: 'Name' },
         cell: ({ row }) => (
@@ -90,17 +91,20 @@ export default function DataTableRichExample() {
       },
       {
         accessorKey: 'email',
+        size: 240,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
         meta: { label: 'Email' },
         cell: ({ row }) => <span className='text-muted-foreground'>{row.original.email}</span>,
       },
       {
         accessorKey: 'team',
+        size: 150,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Team' />,
         meta: { label: 'Team' },
       },
       {
         accessorKey: 'stage',
+        size: 150,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Stage' />,
         meta: { label: 'Stage', variant: 'multiSelect', options: stageOptions },
         filterFn: 'arrIncludesSome',
@@ -114,6 +118,7 @@ export default function DataTableRichExample() {
       },
       {
         accessorKey: 'tags',
+        size: 180,
         header: 'Tags',
         enableSorting: false,
         meta: { label: 'Tags' },
@@ -141,7 +146,7 @@ export default function DataTableRichExample() {
   });
 
   return (
-    <div className='flex flex-col gap-3'>
+    <div className='flex w-full min-w-0 flex-col gap-3'>
       <DataTableToolbar table={table} searchPlaceholder='Search people...' />
       <DataTable table={table} />
       <DataTablePagination table={table} />

--- a/packages/registry/items/blocks/data-table/server.example.tsx
+++ b/packages/registry/items/blocks/data-table/server.example.tsx
@@ -94,23 +94,27 @@ export default function DataTableServerExample() {
     () => [
       {
         accessorKey: 'id',
+        size: 130,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Order' />,
         meta: { label: 'Order' },
         cell: ({ row }) => <span className='font-medium'>{row.original.id}</span>,
       },
       {
         accessorKey: 'customer',
+        size: 210,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Customer' />,
         meta: { label: 'Customer' },
       },
       {
         accessorKey: 'total',
+        size: 110,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Total' />,
         meta: { label: 'Total' },
         cell: ({ row }) => <span className='tabular-nums'>${row.original.total}</span>,
       },
       {
         accessorKey: 'status',
+        size: 130,
         header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
         meta: { label: 'Status', variant: 'multiSelect', options: statusOptions },
         cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
@@ -132,7 +136,7 @@ export default function DataTableServerExample() {
   });
 
   return (
-    <div className='flex flex-col gap-3'>
+    <div className='flex w-full min-w-0 flex-col gap-3'>
       <DataTableToolbar table={table} searchPlaceholder='Search orders...' />
       <DataTable table={table} isLoading={isLoading} />
       <DataTablePagination table={table} />

--- a/packages/registry/items/blocks/data-table/server.example.tsx
+++ b/packages/registry/items/blocks/data-table/server.example.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import type { ColumnDef, ColumnFiltersState, PaginationState, SortingState } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+
+type Order = {
+  id: string;
+  customer: string;
+  total: number;
+  status: 'paid' | 'pending' | 'refunded';
+};
+
+const STATUSES: Order['status'][] = ['paid', 'pending', 'refunded'];
+const CUSTOMERS = ['Acme', 'Globex', 'Initech', 'Umbrella', 'Hooli', 'Soylent', 'Stark', 'Wayne'];
+
+const ALL_ORDERS: Order[] = Array.from({ length: 47 }, (_, index) => ({
+  id: `ORD-${1000 + index}`,
+  customer: CUSTOMERS[index % CUSTOMERS.length],
+  total: Math.round(50 + ((index * 73) % 950)),
+  status: STATUSES[index % STATUSES.length],
+}));
+
+const statusOptions = [
+  { label: 'Paid', value: 'paid' },
+  { label: 'Pending', value: 'pending' },
+  { label: 'Refunded', value: 'refunded' },
+];
+
+type QueryArgs = {
+  pagination: PaginationState;
+  sorting: SortingState;
+  columnFilters: ColumnFiltersState;
+  globalFilter: string;
+};
+
+function queryOrders({ pagination, sorting, columnFilters, globalFilter }: QueryArgs): {
+  rows: Order[];
+  total: number;
+} {
+  let rows = [...ALL_ORDERS];
+
+  const search = globalFilter.trim().toLowerCase();
+  if (search) {
+    rows = rows.filter((order) => `${order.id} ${order.customer}`.toLowerCase().includes(search));
+  }
+
+  const statusFilter = columnFilters.find((filter) => filter.id === 'status')?.value as string[] | undefined;
+  if (statusFilter?.length) {
+    rows = rows.filter((order) => statusFilter.includes(order.status));
+  }
+
+  const sort = sorting[0];
+  if (sort) {
+    rows.sort((a, b) => {
+      const left = a[sort.id as keyof Order];
+      const right = b[sort.id as keyof Order];
+      if (left < right) return sort.desc ? 1 : -1;
+      if (left > right) return sort.desc ? -1 : 1;
+      return 0;
+    });
+  }
+
+  const total = rows.length;
+  const start = pagination.pageIndex * pagination.pageSize;
+  return { rows: rows.slice(start, start + pagination.pageSize), total };
+}
+
+export default function DataTableServerExample() {
+  const [pagination, setPagination] = React.useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState('');
+  const [result, setResult] = React.useState<{ rows: Order[]; total: number }>({ rows: [], total: 0 });
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      setResult(queryOrders({ pagination, sorting, columnFilters, globalFilter }));
+      setIsLoading(false);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [pagination, sorting, columnFilters, globalFilter]);
+
+  const columns = React.useMemo<ColumnDef<Order>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Order' />,
+        meta: { label: 'Order' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.id}</span>,
+      },
+      {
+        accessorKey: 'customer',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Customer' />,
+        meta: { label: 'Customer' },
+      },
+      {
+        accessorKey: 'total',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Total' />,
+        meta: { label: 'Total' },
+        cell: ({ row }) => <span className='tabular-nums'>${row.original.total}</span>,
+      },
+      {
+        accessorKey: 'status',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        meta: { label: 'Status', variant: 'multiSelect', options: statusOptions },
+        cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
+      },
+    ],
+    [],
+  );
+
+  const { table } = useDataTable({
+    data: result.rows,
+    columns,
+    pageCount: Math.ceil(result.total / pagination.pageSize),
+    getRowId: (row) => row.id,
+    state: { pagination, sorting, columnFilters, globalFilter },
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+  });
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <DataTableToolbar table={table} searchPlaceholder='Search orders...' />
+      <DataTable table={table} isLoading={isLoading} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/data-table/toolbar-chips.example.tsx
+++ b/packages/registry/items/blocks/data-table/toolbar-chips.example.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { ColumnDef, ColumnFiltersState } from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+  useDataTable,
+} from '@/components/block/shuip/data-table';
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'editor' | 'viewer';
+  status: 'active' | 'invited' | 'suspended';
+};
+
+const users: User[] = [
+  { id: '1', name: 'Ava Mercer', email: 'ava@acme.io', role: 'admin', status: 'active' },
+  { id: '2', name: 'Liam Cho', email: 'liam@acme.io', role: 'editor', status: 'active' },
+  { id: '3', name: 'Noah Patel', email: 'noah@acme.io', role: 'editor', status: 'invited' },
+  { id: '4', name: 'Mia Rossi', email: 'mia@acme.io', role: 'viewer', status: 'suspended' },
+  { id: '5', name: 'Ethan Wood', email: 'ethan@acme.io', role: 'viewer', status: 'active' },
+  { id: '6', name: 'Zoe Bauer', email: 'zoe@acme.io', role: 'admin', status: 'invited' },
+];
+
+const roleOptions = [
+  { label: 'Admin', value: 'admin' },
+  { label: 'Editor', value: 'editor' },
+  { label: 'Viewer', value: 'viewer' },
+];
+
+const statusOptions = [
+  { label: 'Active', value: 'active' },
+  { label: 'Invited', value: 'invited' },
+  { label: 'Suspended', value: 'suspended' },
+];
+
+export default function DataTableToolbarChipsExample() {
+  const columns = React.useMemo<ColumnDef<User>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        size: 190,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        meta: { label: 'Name' },
+        cell: ({ row }) => <span className='font-medium'>{row.original.name}</span>,
+      },
+      {
+        accessorKey: 'email',
+        size: 220,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Email' />,
+        meta: { label: 'Email' },
+        cell: ({ row }) => <span className='text-muted-foreground'>{row.original.email}</span>,
+      },
+      {
+        accessorKey: 'role',
+        size: 120,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Role' />,
+        meta: { label: 'Role', variant: 'multiSelect', options: roleOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => <span className='capitalize'>{row.original.role}</span>,
+      },
+      {
+        accessorKey: 'status',
+        size: 120,
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        meta: { label: 'Status', variant: 'multiSelect', options: statusOptions },
+        filterFn: 'arrIncludesSome',
+        cell: ({ row }) => <span className='capitalize'>{row.original.status}</span>,
+      },
+    ],
+    [],
+  );
+
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([
+    { id: 'role', value: ['admin', 'editor'] },
+  ]);
+
+  const { table } = useDataTable({
+    data: users,
+    columns,
+    getRowId: (row) => row.id,
+    state: { columnFilters },
+    onColumnFiltersChange: setColumnFilters,
+  });
+
+  return (
+    <div className='flex w-full min-w-0 flex-col gap-3'>
+      <DataTableToolbar table={table} variant='inline-chips' searchPlaceholder='Search users...' />
+      <DataTable table={table} />
+      <DataTablePagination table={table} />
+    </div>
+  );
+}

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -19,6 +19,7 @@
     "@hookform/lenses": "catalog:forms",
     "@tanstack/react-form": "catalog:forms",
     "@tanstack/react-query": "catalog:forms",
+    "@tanstack/react-table": "catalog:",
     "react-error-boundary": "catalog:forms",
     "zod": "catalog:",
     "date-fns": "catalog:",

--- a/packages/ui/src/components/ui/table.tsx
+++ b/packages/ui/src/components/ui/table.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div data-slot='table-container' className='relative w-full overflow-x-auto'>
+      <table data-slot='table' className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot='table-header' className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return <tbody data-slot='table-body' className={cn('[&_tr:last-child]:border-0', className)} {...props} />;
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot='table-footer'
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot='table-row'
+      className={cn('hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors', className)}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot='table-head'
+      className={cn(
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot='table-cell'
+      className={cn(
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return <caption data-slot='table-caption' className={cn('text-muted-foreground mt-4 text-sm', className)} {...props} />;
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };


### PR DESCRIPTION
## Summary

Adds a generic, entity-agnostic **`data-table` block** built on TanStack Table v8 + shadcn/ui primitives. One block, dual-mode: client-side with zero config, or server-side with controlled pagination/sorting/filtering. All per-entity knowledge lives in the column defs + a typed `meta` extension — the components only read the `Table<TData>` instance, so nothing is hardcoded to a domain.

Design + plan committed under `docs/superpowers/`. Synthesised from the kodex/edik/twenty-fields CRMs and the shadcn/diceui reference implementations.

## What's included

- **`useDataTable<TData>`** — wraps `useReactTable`, auto-selects client vs server mode (server mode triggered by passing `pageCount`).
- Composable sub-components: `DataTable`, `DataTableToolbar`, `DataTableColumnHeader`, `DataTableFacetedFilter`, `DataTableViewOptions`, `DataTablePagination`.
- **`meta` convention** (declaration-merged onto `ColumnMeta`): `label` / `variant` / `options` / `icon`. Faceted filters in the toolbar are auto-generated from `meta` — no per-table wiring.
- Sorting, global search, faceted filters, column visibility, row selection, column pinning (sticky), loading/empty/no-results states.
- Three examples: **client** (smooth, zero-config), **server** (simulated backend + skeleton), **rich** (Twenty-like — pinned columns, avatars, status pills, tag chips).
- Docs page with a copy-paste **nuqs URL-sync recipe** (kept opt-in / out of the installed block so it doesn't force a router dependency on consumers).

## Repo changes

- New `table` primitive in `packages/ui` (was absent).
- `@tanstack/react-table` added to the root catalog and referenced from `packages/registry`.
- View-options / header menus built on `popover` + `command` (no `dropdown-menu` primitive in shuip).

## Verification

- `bun registry:generate` → 44 items processed; `data-table` entry has `registryDependencies: [button, command, input, popover, select, separator, table]` and `dependencies: [@tanstack/react-table, lucide-react, react]`.
- `bun check` → pass.
- `NODE_OPTIONS=--max-old-space-size=6144 bun build:docs` → pass (compiled successfully, 165/165 static pages, data-table doc + OG image prerendered).
- Browser interaction checks (sort/filter/pin/skeleton) not yet done — needs a human in the preview at `/blocks/data-table`.

## Note for review

`biome.json` now excludes `**/.claude/**` — a pre-existing unrelated git worktree under `.claude/worktrees/` ships its own `root: true` biome config that aborted `bun check`. Narrow, reversible; flag if you'd rather handle that worktree differently.
