### PR TITLE
feat(calendar): generic responsive calendar block

### DIFF
--- a/apps/docs/content/blocks/calendar.mdx
+++ b/apps/docs/content/blocks/calendar.mdx
@@ -1,0 +1,14 @@
+---
+title: Calendar
+description: A generic, responsive calendar with month, week, day, and agenda views, driven by your typed event model.
+registryName: calendar
+---
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+`Calendar` is a generic calendar (`Calendar<T>`) that renders any array of typed events. The
+event id, title, start, end, and all-day fields are mapped against your own data shape.
+
+## Examples
+
+<ItemExamples registryName={'calendar'} />

--- a/apps/docs/content/blocks/calendar.mdx
+++ b/apps/docs/content/blocks/calendar.mdx
@@ -6,8 +6,25 @@ registryName: calendar
 
 import { TypeTable } from 'fumadocs-ui/components/type-table';
 
-`Calendar` is a generic calendar (`Calendar<T>`) that renders any array of typed events. The
+`Calendar` is a generic, responsive calendar that renders any array of typed events. The
 event id, title, start, end, and all-day fields are mapped against your own data shape.
+
+It is split into composable parts that share state through context, so you can drop in the
+default toolbar or build your own navigation without prop drilling:
+
+```tsx
+import { Calendar, useCalendar } from '@/components/block/shuip/calendar';
+
+<Calendar.Root events={events} onEventsChange={setEvents} titleField='title' startField='start' endField='end' editable>
+  <Calendar.Nav />   {/* default toolbar — or your own navbar via useCalendar() */}
+  <Calendar.View />  {/* the views: month / week / day / agenda */}
+</Calendar.Root>;
+```
+
+- **`Calendar.Root`** holds all state and config. The props below live here.
+- **`Calendar.Nav`** is the default navigation (today, previous/next, period label, view switcher).
+- **`Calendar.View`** is the calendar surface itself.
+- **`useCalendar()`** exposes `view`, `date`, `periodLabel`, `goToToday`, `goToPrevious`, `goToNext`, `setView`, and more — read it from any descendant of `Calendar.Root` to build a custom toolbar.
 
 ### Built-in features
 
@@ -21,13 +38,15 @@ event id, title, start, end, and all-day fields are mapped against your own data
 - **Per-event colors**: derive a color per event with `color(item)`.
 - **Custom event content**: replace the default event label with `renderEvent(item)`.
 
-> Define your event type with a `type` alias, not an `interface` — `Calendar<T>` requires `T extends Record<string, unknown>`, which a TypeScript `interface` does not satisfy.
+> Define your event type with a `type` alias, not an `interface` — `Calendar.Root<T>` requires `T extends Record<string, unknown>`, which a TypeScript `interface` does not satisfy.
 
 ## Examples
 
 <ItemExamples registryName={'calendar'} />
 
 ## Props
+
+Props are passed to `Calendar.Root`.
 
 <TypeTable
   type={{

--- a/apps/docs/content/blocks/calendar.mdx
+++ b/apps/docs/content/blocks/calendar.mdx
@@ -9,6 +9,117 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 `Calendar` is a generic calendar (`Calendar<T>`) that renders any array of typed events. The
 event id, title, start, end, and all-day fields are mapped against your own data shape.
 
+### Built-in features
+
+- **Generic typed event model**: works with any item type `T`; the id, title, start, end, and all-day fields are mapped via `idField` / `titleField` / `startField` / `endField` / `allDayField`.
+- **Four views**: month, week, day, and agenda, switched from the toolbar or controlled via `view` / `defaultView`.
+- **Responsive week → day**: the week view falls back to a single-day view on narrow screens.
+- **Hybrid state**: works standalone from `defaultEvents`, or controlled via `events` + `onEventsChange`.
+- **Drag to move**: drag an event to another day (month) or time slot (week/day) when `editable`.
+- **Resize**: drag an event's bottom edge in week/day to change its end time when `editable`.
+- **Drag to create**: drag across an empty range to emit `onSlotSelect` when `editable`.
+- **Per-event colors**: derive a color per event with `color(item)`.
+- **Custom event content**: replace the default event label with `renderEvent(item)`.
+
+> Define your event type with a `type` alias, not an `interface` — `Calendar<T>` requires `T extends Record<string, unknown>`, which a TypeScript `interface` does not satisfy.
+
 ## Examples
 
 <ItemExamples registryName={'calendar'} />
+
+## Props
+
+<TypeTable
+  type={{
+    events: {
+      description: 'Controlled events. When provided, you own the state via onEventsChange.',
+      type: 'T[]?',
+    },
+    defaultEvents: {
+      description: 'Initial events for uncontrolled mode.',
+      type: 'T[]?',
+    },
+    onEventsChange: {
+      description: 'Fires with the full updated array after a move, resize, or other mutation.',
+      type: '(next: T[]) => void',
+    },
+    idField: {
+      description: 'Field holding the stable event id.',
+      type: 'keyof T',
+      default: "'id'",
+    },
+    titleField: {
+      description: 'Field rendered as the event label.',
+      type: 'keyof T',
+    },
+    startField: {
+      description: 'Field holding the event start Date.',
+      type: 'keyof T',
+    },
+    endField: {
+      description: 'Field holding the event end Date.',
+      type: 'keyof T',
+    },
+    allDayField: {
+      description: 'Field marking an event as all-day. Omit to treat day-spanning events as all-day.',
+      type: 'keyof T?',
+    },
+    color: {
+      description: 'Returns the color accent for an event.',
+      type: '(item: T) => CalendarEventColor | undefined',
+    },
+    renderEvent: {
+      description: 'Replaces the default event label across every view.',
+      type: '(item: T) => ReactNode',
+    },
+    view: {
+      description: 'Controlled active view.',
+      type: 'CalendarView?',
+    },
+    defaultView: {
+      description: 'Initial view for uncontrolled mode.',
+      type: 'CalendarView',
+      default: "'month'",
+    },
+    onViewChange: {
+      description: 'Fires when the active view changes.',
+      type: '(v: CalendarView) => void',
+    },
+    date: {
+      description: 'Controlled focused date.',
+      type: 'Date?',
+    },
+    defaultDate: {
+      description: 'Initial focused date for uncontrolled mode.',
+      type: 'Date?',
+      default: 'today',
+    },
+    onDateChange: {
+      description: 'Fires when the focused date changes.',
+      type: '(d: Date) => void',
+    },
+    views: {
+      description: 'Which views are selectable in the toolbar.',
+      type: 'CalendarView[]',
+      default: "['month', 'week', 'day', 'agenda']",
+    },
+    weekStartsOn: {
+      description: 'First day of the week (0 = Sunday).',
+      type: '0 | 1 | 2 | 3 | 4 | 5 | 6',
+      default: '1',
+    },
+    editable: {
+      description: 'Enables drag-to-move, resize, and drag-to-create.',
+      type: 'boolean',
+      default: 'false',
+    },
+    onEventClick: {
+      description: 'Called when an event is clicked.',
+      type: '(item: T) => void',
+    },
+    onSlotSelect: {
+      description: 'Called with the selected range when an empty slot or range is picked.',
+      type: '(range: { start: Date; end: Date; allDay: boolean }) => void',
+    },
+  }}
+/>

--- a/docs/superpowers/plans/2026-06-15-calendar-block.md
+++ b/docs/superpowers/plans/2026-06-15-calendar-block.md
@@ -1,0 +1,680 @@
+# Calendar Block Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a generic `Calendar<T>` registry block with Month/Week/Day/Agenda views, drag-to-move, resize, drag-to-create, and a responsive week→day fallback — written from scratch on the shuip stack (no react-big-calendar, no moment).
+
+**Architecture:** One published `component.tsx` (registry blocks publish a single file; the anti-circular rule forbids `component.tsx` from importing `@/components/ui/shuip/*`). The file is organized into internal sub-components: date helpers → `useIsMobile` → state plumbing → `CalendarToolbar` → `MonthView` → `TimeGridView` (week/day) → `AgendaView` → `EventBlock`. Field-mapping + hybrid-state API mirrors the existing `kanban` block. Move uses dnd-kit; resize and drag-to-create use native pointer handlers.
+
+**Tech Stack:** React 19, TypeScript 6, Tailwind v4, shadcn primitives (`button`, `select`, `dialog`, `input`), `date-fns` (catalog), `@dnd-kit/core` + `@dnd-kit/utilities` (catalog). No new dependency.
+
+**Testing note:** No test runner is configured in this repo. Verification per task = `bun registry:generate` (when the item folder changes), `bunx fumadocs-mdx` (when collections/content change), and `cd apps/docs && bunx tsc --noEmit` for the type gate, plus visual rendering of the examples in `bun dev:docs`. `bun build:docs` is the final end-to-end gate (use `NODE_OPTIONS=--max-old-space-size=6144` if it OOMs).
+
+**Reference patterns (read before starting):**
+- `packages/registry/items/blocks/kanban/component.tsx` — generic `<T>` + hybrid state + dnd-kit usage.
+- `packages/registry/items/blocks/kanban/default.example.tsx` — example import via stub alias.
+- `apps/docs/content/blocks/kanban.mdx` — block doc shape.
+- `CLAUDE.md` "Registry Items" + "Blocks doc flow" sections.
+
+---
+
+## File Structure
+
+- **Create** `packages/registry/items/blocks/calendar/component.tsx` — the entire calendar.
+- **Create** `packages/registry/items/blocks/calendar/default.example.tsx` — full demo: sample events + create/edit dialog.
+- **Create** `packages/registry/items/blocks/calendar/views.example.tsx` — controlled view switch, read-only (no `editable`).
+- **Create** `apps/docs/content/blocks/calendar.mdx` — block doc (NOT `index.mdx`).
+- **Modify** `apps/docs/content/blocks/meta.json` — only if explicit page order needs `calendar` (it uses `"..."` glob, so likely no change; verify).
+- **Auto-generated, do not hand-edit:** `registry.json`, `stubs/blocks/calendar/*`, `apps/docs/public/r/calendar*.json`.
+
+---
+
+## Task 1: Scaffold item + types + static skeleton
+
+Get the item recognized by the generator and rendering a placeholder, so the registry/docs pipeline is wired before adding logic.
+
+**Files:**
+- Create: `packages/registry/items/blocks/calendar/component.tsx`
+- Create: `packages/registry/items/blocks/calendar/default.example.tsx`
+- Create: `apps/docs/content/blocks/calendar.mdx`
+
+- [ ] **Step 1: Create `component.tsx` with types + a static skeleton**
+
+```tsx
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type CalendarView = 'month' | 'week' | 'day' | 'agenda';
+export type CalendarEventColor = 'primary' | 'blue' | 'green' | 'red' | 'amber';
+
+export type CalendarProps<T extends Record<string, unknown>> = {
+  events?: T[];
+  defaultEvents?: T[];
+  onEventsChange?: (next: T[]) => void;
+
+  idField?: keyof T;
+  titleField: keyof T;
+  startField: keyof T;
+  endField: keyof T;
+  allDayField?: keyof T;
+  color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
+
+  view?: CalendarView;
+  defaultView?: CalendarView;
+  onViewChange?: (v: CalendarView) => void;
+  date?: Date;
+  defaultDate?: Date;
+  onDateChange?: (d: Date) => void;
+
+  views?: CalendarView[];
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  editable?: boolean;
+
+  onEventClick?: (item: T) => void;
+  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+
+  className?: string;
+};
+
+export function Calendar<T extends Record<string, unknown>>(props: CalendarProps<T>) {
+  return <div className={cn('flex flex-col gap-4', props.className)}>calendar</div>;
+}
+```
+
+- [ ] **Step 2: Create `default.example.tsx` importing via the stub alias**
+
+Blocks import via `@/components/block/shuip/<name>` (flat — stubs are emitted at `stubs/blocks/<name>.tsx`, e.g. `kanban/default.example.tsx` uses `@/components/block/shuip/kanban`). Confirmed against the existing kanban example and `apps/docs/tsconfig.json`.
+
+```tsx
+'use client';
+
+import { Calendar } from '@/components/block/shuip/calendar';
+
+type Event = { id: string; title: string; start: Date; end: Date };
+
+const now = new Date();
+const at = (h: number) => new Date(now.getFullYear(), now.getMonth(), now.getDate(), h);
+
+const events: Event[] = [
+  { id: '1', title: 'Standup', start: at(9), end: at(10) },
+  { id: '2', title: 'Design review', start: at(11), end: at(12) },
+];
+
+export default function Example() {
+  return (
+    <Calendar<Event>
+      defaultEvents={events}
+      titleField='title'
+      startField='start'
+      endField='end'
+      defaultView='week'
+      editable
+    />
+  );
+}
+```
+
+- [ ] **Step 3: Create `apps/docs/content/blocks/calendar.mdx` (block doc, not index.mdx)**
+
+```mdx
+---
+title: Calendar
+description: A generic, responsive calendar with month, week, day, and agenda views, driven by your typed event model.
+registryName: calendar
+---
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+`Calendar` is a generic calendar (`Calendar<T>`) that renders any array of typed events. The
+event id, title, start, end, and all-day fields are mapped against your own data shape.
+
+## Examples
+
+<ItemExamples registryName={'calendar'} />
+```
+
+- [ ] **Step 4: Generate + verify the item is picked up**
+
+Run: `bun registry:generate`
+Expected: console shows `[generate] N items processed` with N one higher than before; `packages/registry/stubs/blocks/calendar/` now exists; `registry.json` contains a `calendar` entry.
+
+- [ ] **Step 5: Regenerate fumadocs types + typecheck**
+
+Run: `cd apps/docs && bunx fumadocs-mdx && bunx tsc --noEmit`
+Expected: no errors except the known harmless `baseUrl` TS5101 deprecation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar apps/docs/content/blocks/calendar.mdx packages/registry/registry.json packages/registry/__index__.ts packages/registry/stubs apps/docs/content/blocks/.gitignore
+git status   # verify only intended files; then add any other generated files shown
+git commit -m "feat(calendar): scaffold generic calendar block"
+```
+
+---
+
+## Task 2: Date helpers, hybrid state, toolbar
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Add date helpers (top of file, after imports)**
+
+Import from `date-fns` and write small local helpers. Use these consistently everywhere.
+
+```tsx
+import {
+  addDays, addMonths, eachDayOfInterval, endOfMonth, endOfWeek, format,
+  isSameDay, isSameMonth, startOfDay, startOfMonth, startOfWeek,
+} from 'date-fns';
+
+const SNAP_MINUTES = 15;
+const DAY_START_HOUR = 0;
+const DAY_END_HOUR = 24;
+
+function snapToMinutes(date: Date, minutes = SNAP_MINUTES): Date {
+  const ms = minutes * 60_000;
+  return new Date(Math.round(date.getTime() / ms) * ms);
+}
+
+function minutesSinceDayStart(date: Date): number {
+  return date.getHours() * 60 + date.getMinutes();
+}
+```
+
+- [ ] **Step 2: Add a `useControllableState` helper**
+
+Generic controlled/uncontrolled state used for `events`, `view`, and `date`.
+
+```tsx
+function useControllableState<V>(
+  controlled: V | undefined,
+  defaultValue: V,
+  onChange?: (v: V) => void,
+): [V, (v: V) => void] {
+  const [uncontrolled, setUncontrolled] = React.useState<V>(defaultValue);
+  const isControlled = controlled !== undefined;
+  const value = isControlled ? controlled : uncontrolled;
+  const setValue = React.useCallback(
+    (next: V) => {
+      if (!isControlled) setUncontrolled(next);
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+  return [value, setValue];
+}
+```
+
+- [ ] **Step 3: Wire state inside `Calendar` and compute the field accessors**
+
+```tsx
+const {
+  events, defaultEvents = [] as T[], onEventsChange,
+  idField = 'id' as keyof T, titleField, startField, endField, allDayField,
+  color, renderEvent,
+  view: viewProp, defaultView = 'month', onViewChange,
+  date: dateProp, defaultDate, onDateChange,
+  views = ['month', 'week', 'day', 'agenda'] as CalendarView[],
+  weekStartsOn = 1, editable = false,
+  onEventClick, onSlotSelect, className,
+} = props;
+
+const [items, setItems] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
+const [view, setView] = useControllableState<CalendarView>(viewProp, defaultView, onViewChange);
+const [date, setDate] = useControllableState<Date>(dateProp, defaultDate ?? startOfDay(new Date()), onDateChange);
+
+const getStart = React.useCallback((it: T) => it[startField] as unknown as Date, [startField]);
+const getEnd = React.useCallback((it: T) => it[endField] as unknown as Date, [endField]);
+const getTitle = React.useCallback((it: T) => String(it[titleField] ?? ''), [titleField]);
+const getId = React.useCallback((it: T) => String(it[idField]), [idField]);
+const isAllDay = React.useCallback((it: T) => (allDayField ? Boolean(it[allDayField]) : false), [allDayField]);
+```
+
+- [ ] **Step 4: Add `CalendarToolbar` sub-component + the period label**
+
+Build a `periodLabel` from `view` + `date` (e.g. month: `format(date, 'MMMM yyyy')`; week: start–end of week; day: `format(date, 'PPP')`; agenda: same as month). The toolbar renders Today / Back / Next buttons and a view `Select`. Navigation deltas: month → `addMonths(±1)`, week → `addDays(±7)`, day/agenda → `addDays(±1)`.
+
+```tsx
+function CalendarToolbar({
+  label, views, view, onView, onToday, onPrev, onNext,
+}: {
+  label: string;
+  views: CalendarView[];
+  view: CalendarView;
+  onView: (v: CalendarView) => void;
+  onToday: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div className='flex flex-wrap items-center justify-between gap-2'>
+      <div className='flex items-center gap-1'>
+        <Button variant='outline' size='sm' onClick={onToday}>Today</Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={onPrev} aria-label='Previous'>
+          <ChevronLeft className='size-4' />
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={onNext} aria-label='Next'>
+          <ChevronRight className='size-4' />
+        </Button>
+        <span className='ml-2 text-sm font-medium'>{label}</span>
+      </div>
+      {views.length > 1 ? (
+        <Select value={view} onValueChange={(v) => onView(v as CalendarView)}>
+          <SelectTrigger className='w-32' size='sm'><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {views.map((v) => (
+              <SelectItem key={v} value={v}>{v[0].toUpperCase() + v.slice(1)}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : null}
+    </div>
+  );
+}
+```
+
+Add the imports this introduces: `Button` from `@/components/ui/button`; `Select, SelectContent, SelectItem, SelectTrigger, SelectValue` from `@/components/ui/select`; `ChevronLeft, ChevronRight` from `lucide-react`.
+
+- [ ] **Step 5: Render the toolbar + a per-view switch in `Calendar`**
+
+Replace the placeholder return with the toolbar plus a `switch (view)` that renders `null` per branch for now (filled in later tasks).
+
+- [ ] **Step 6: Verify the navigation deltas helper**
+
+Confirm `bunx tsc --noEmit` passes in `apps/docs`, then `bun dev:docs` and open the calendar example: Today/Back/Next change the label, the view select switches the (still-empty) body.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): date helpers, hybrid state, toolbar"
+```
+
+---
+
+## Task 3: Month view
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Compute the visible month grid**
+
+```tsx
+function monthGrid(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date[] {
+  const start = startOfWeek(startOfMonth(date), { weekStartsOn });
+  const end = endOfWeek(endOfMonth(date), { weekStartsOn });
+  return eachDayOfInterval({ start, end });
+}
+```
+
+- [ ] **Step 2: Add `MonthView` sub-component**
+
+Render a 7-column grid. For each day cell: day number (muted if `!isSameMonth(day, date)`), then events whose start falls on that day, sorted by start. Show at most 3 pills; if more, render a `+N more` button. Each pill calls `onEventClick(item)`. Pill color via `colorClasses(color?.(item))` (a small map from `CalendarEventColor` to token classes, e.g. `primary → bg-primary text-primary-foreground`, `blue → bg-blue-500 text-white`, etc.). Empty cells with `editable` call `onSlotSelect({ start: startOfDay(day), end: addDays(startOfDay(day),1), allDay:true })` on click.
+
+```tsx
+function colorClasses(c?: CalendarEventColor): string {
+  switch (c) {
+    case 'blue': return 'bg-blue-500 text-white';
+    case 'green': return 'bg-green-600 text-white';
+    case 'red': return 'bg-red-500 text-white';
+    case 'amber': return 'bg-amber-500 text-black';
+    default: return 'bg-primary text-primary-foreground';
+  }
+}
+```
+
+(Note for the implementer: literal color utilities like `bg-blue-500` must survive Tailwind scanning — they are static strings here, so they will. Do not build class names dynamically by concatenation.)
+
+- [ ] **Step 3: Wire `MonthView` into the `view` switch**
+
+- [ ] **Step 4: Verify**
+
+`bunx tsc --noEmit` in `apps/docs`, then visually: month grid shows the current month, sample events appear as pills on the correct day, `+N more` appears when >3 events share a day.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): month view"
+```
+
+---
+
+## Task 4: Time grid (week + day) with all-day band
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Add geometry constants + event-position math**
+
+```tsx
+const HOUR_HEIGHT = 48; // px per hour
+
+function eventTop(start: Date): number {
+  return (minutesSinceDayStart(start) / 60) * HOUR_HEIGHT;
+}
+function eventHeight(start: Date, end: Date): number {
+  const mins = Math.max(15, (end.getTime() - start.getTime()) / 60_000);
+  return (mins / 60) * HOUR_HEIGHT;
+}
+```
+
+- [ ] **Step 2: Add overlap layout for a single day's timed events**
+
+Group overlapping events into columns so they sit side by side. Minimal algorithm: sort by start; greedily assign each event the first column whose last event ends at/before this event's start; track the max columns in each overlap cluster; width = `100% / columns`, left = `colIndex * width`.
+
+```tsx
+type LaidOut<T> = { item: T; col: number; cols: number };
+
+function layoutDay<T>(dayEvents: T[], getStart: (t: T) => Date, getEnd: (t: T) => Date): LaidOut<T>[] {
+  const sorted = [...dayEvents].sort((a, b) => getStart(a).getTime() - getStart(b).getTime());
+  const colEnds: number[] = [];
+  const placed = sorted.map((item) => {
+    const s = getStart(item).getTime();
+    let col = colEnds.findIndex((end) => end <= s);
+    if (col === -1) { col = colEnds.length; colEnds.push(0); }
+    colEnds[col] = getEnd(item).getTime();
+    return { item, col };
+  });
+  const cols = Math.max(1, colEnds.length);
+  return placed.map((p) => ({ ...p, cols }));
+}
+```
+
+(Implementer note: this uses a single cluster-wide column count for simplicity — acceptable for the block. Per-cluster width refinement is a non-goal.)
+
+- [ ] **Step 3: Add `TimeGridView` sub-component**
+
+Props: `days: Date[]` (7 for week, 1 for day), plus the accessors and callbacks. Layout:
+- An all-day band row at top: for each day, render all-day events (`isAllDay(item)` or events spanning ≥24h) as full-width pills.
+- A scrollable body (`max-h-[600px] overflow-y-auto`) containing:
+  - A left gutter column of hour labels (`00:00`…`23:00`), each `h-[HOUR_HEIGHT]px`.
+  - One column per day. Each column is `relative`; hour lines drawn with a repeating border. Timed events absolutely positioned via `eventTop`/`eventHeight` and `layoutDay` for left/width.
+- Each event block calls `onEventClick(item)` on click; render `getTitle(item)` + time range; color via `colorClasses`.
+
+Keep the event block as a small `EventBlock` sub-component (reused by resize/move tasks).
+
+- [ ] **Step 4: Wire `TimeGridView` into the `view` switch for `week` (days = full week) and `day` (days = [date])**
+
+```tsx
+const weekDays = React.useMemo(
+  () => eachDayOfInterval({ start: startOfWeek(date, { weekStartsOn }), end: endOfWeek(date, { weekStartsOn }) }),
+  [date, weekStartsOn],
+);
+```
+
+- [ ] **Step 5: Verify**
+
+`bunx tsc --noEmit`, then visually: week view shows 7 day columns with hour rows; sample events sit at the right time and overlap side-by-side; day view shows one column.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): week and day time grid"
+```
+
+---
+
+## Task 5: Agenda view
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Add `AgendaView` sub-component**
+
+List events from `date` forward for ~30 days, grouped by day. For each day with events: a day header (`format(day, 'EEEE, MMM d')`) then rows of `time — title`. Each row calls `onEventClick(item)`. Empty state: a muted "No events" line. Full-width layout (naturally responsive).
+
+```tsx
+const agendaDays = React.useMemo(
+  () => eachDayOfInterval({ start: startOfDay(date), end: addDays(startOfDay(date), 29) }),
+  [date],
+);
+```
+
+- [ ] **Step 2: Wire into the `view` switch**
+
+- [ ] **Step 3: Verify**
+
+`bunx tsc --noEmit`, then visually: switching to Agenda lists upcoming events grouped by day.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): agenda view"
+```
+
+---
+
+## Task 6: Responsive week→day fallback
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Add an SSR-safe `useIsMobile` hook**
+
+```tsx
+function useIsMobile(breakpoint = 768): boolean {
+  const subscribe = React.useCallback(
+    (cb: () => void) => {
+      const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+      mql.addEventListener('change', cb);
+      return () => mql.removeEventListener('change', cb);
+    },
+    [breakpoint],
+  );
+  const getSnapshot = React.useCallback(() => window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches, [breakpoint]);
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+```
+
+- [ ] **Step 2: Use it to coerce week→day on mobile**
+
+```tsx
+const isMobile = useIsMobile();
+const effectiveView = isMobile && view === 'week' ? 'day' : view;
+```
+
+Render the switch on `effectiveView`. When `effectiveView === 'day'`, `TimeGridView` gets `days={[date]}`. Navigation deltas: base the prev/next delta on `effectiveView` (so a mobile "week" navigates by day). The view `Select` still shows the user's chosen `view`.
+
+- [ ] **Step 3: Verify**
+
+`bunx tsc --noEmit`, then in `bun dev:docs` resize the viewport narrow (<768px) with Week selected → it renders a single navigable day, no horizontal overflow. Widen → returns to 7 columns.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): responsive week-to-day fallback"
+```
+
+---
+
+## Task 7: Move events (dnd-kit)
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Gate on `editable`; wrap views in `DndContext`**
+
+Import `DndContext, PointerSensor, useSensor, useSensors, type DragEndEvent, useDraggable, useDroppable` from `@dnd-kit/core` and `CSS` from `@dnd-kit/utilities`. Add a `PointerSensor` with `activationConstraint: { distance: 6 }` (so clicks still fire `onEventClick`).
+
+- [ ] **Step 2: Make `EventBlock` draggable when `editable`**
+
+Use `useDraggable({ id: getId(item) })`. Apply `CSS.Translate.toString(transform)`. On drag start, stop the click from also firing edit (guard with a ref set on drag, cleared on click).
+
+- [ ] **Step 3: Make day columns / month cells droppable + compute the new time**
+
+For the time grid: each day column is a `useDroppable` with `data: { day }`. On `onDragEnd`, read the drop column's `day` and convert the pointer's Y offset within the column to minutes (`(offsetY / HOUR_HEIGHT) * 60`), snap via `snapToMinutes`, set the new `start`, keep duration (`end = start + (oldEnd - oldStart)`). For month: droppable per day cell; moving shifts the date keeping the clock time. Emit the updated array through `setItems` (which calls `onEventsChange`).
+
+```tsx
+function moveEvent<T>(item: T, newStart: Date, getStart: (t: T) => Date, getEnd: (t: T) => Date, startField: keyof T, endField: keyof T): T {
+  const duration = getEnd(item).getTime() - getStart(item).getTime();
+  return { ...item, [startField]: newStart, [endField]: new Date(newStart.getTime() + duration) };
+}
+```
+
+- [ ] **Step 4: Verify**
+
+`bunx tsc --noEmit`, then visually: with `editable`, drag an event to another time/day in week view → it snaps and stays the same duration; a plain click still opens edit (fires `onEventClick`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): drag to move events"
+```
+
+---
+
+## Task 8: Resize events (native pointer)
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Add a bottom resize handle to `EventBlock` (time grid only, when `editable`)**
+
+A 6px-tall absolutely-positioned bottom strip with `cursor-ns-resize`. On `pointerdown`: capture the pointer, record start Y and the event's original `end`. On `pointermove`: `deltaMinutes = (currentY - startY) / HOUR_HEIGHT * 60`, compute `newEnd = snapToMinutes(originalEnd + deltaMinutes)`, clamp so `newEnd - start >= 15min`; update local "resizing" state for live preview. On `pointerup`: commit via `setItems` with `{ ...item, [endField]: newEnd }`, release capture. `stopPropagation` so it doesn't trigger drag or click.
+
+- [ ] **Step 2: Render the live preview height during resize**
+
+While resizing this item, override its `eventHeight` from the in-progress `newEnd`.
+
+- [ ] **Step 3: Verify**
+
+`bunx tsc --noEmit`, then visually: drag the bottom edge of an event down/up → its end time changes, snaps to 15 min, never shrinks below 15 min; release persists it (state updates / `onEventsChange` fires).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): resize events"
+```
+
+---
+
+## Task 9: Drag-to-create (native pointer)
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/component.tsx`
+
+- [ ] **Step 1: Add pointer handlers to the empty area of each day column (time grid, when `editable`)**
+
+On `pointerdown` on column background (not on an event): record start Y → start time. On `pointermove`: compute current time, render a provisional translucent block between the two. On `pointerup`: build `{ start, end }` (snap both; ensure `end > start` by at least 15 min), call `onSlotSelect({ start, end, allDay: false })`, clear the provisional block. A simple click without drag selects a default 1-hour slot at the clicked time.
+
+- [ ] **Step 2: Month empty-cell click already calls `onSlotSelect` (Task 3) — confirm it still works alongside dnd droppable (guard the click when a drag just happened).**
+
+- [ ] **Step 3: Verify**
+
+`bunx tsc --noEmit`, then visually: drag across empty time in week view → a provisional block follows; release → `onSlotSelect` fires with the dragged range (verify via the example dialog in Task 10).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar/component.tsx
+git commit -m "feat(calendar): drag to create slots"
+```
+
+---
+
+## Task 10: Examples, docs, full build
+
+**Files:**
+- Modify: `packages/registry/items/blocks/calendar/default.example.tsx`
+- Create: `packages/registry/items/blocks/calendar/views.example.tsx`
+- Modify: `apps/docs/content/blocks/calendar.mdx`
+
+- [ ] **Step 1: Flesh out `default.example.tsx` with a create/edit dialog**
+
+State holds `events` (controlled via `events` + `onEventsChange`) and a `draft` (the event being created/edited or null). `onEventClick` sets the draft to that event + opens the dialog; `onSlotSelect` sets a new draft with the selected range + opens the dialog. The dialog (shadcn `Dialog`) has `Input`s for title and a color `Select`, plus Save (upsert into events) and Delete. Keep it compact but real.
+
+```tsx
+'use client';
+
+import * as React from 'react';
+import { Calendar, type CalendarEventColor } from '@/components/block/shuip/calendar';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+
+type Event = { id: string; title: string; start: Date; end: Date; color?: CalendarEventColor };
+
+// ...seed events with `at(h)` helper as in Task 1...
+// ...draft state, upsert/delete handlers, Dialog with title Input + Save/Delete...
+
+export default function Example() {
+  // controlled events + onEventsChange + dialog wiring
+  return (
+    <>
+      <Calendar<Event> events={/* state */ []} onEventsChange={/* setter */ () => {}}
+        titleField='title' startField='start' endField='end'
+        color={(e) => e.color} defaultView='week' editable
+        onEventClick={/* open edit */ () => {}}
+        onSlotSelect={/* open create */ () => {}} />
+      {/* Dialog */}
+    </>
+  );
+}
+```
+
+(Implementer: write the full, working version — controlled state, `upsert`, `remove`, and the dialog body. This skeleton shows the wiring contract; do not ship placeholders.)
+
+- [ ] **Step 2: Create `views.example.tsx` — read-only, controlled view switch**
+
+A `Calendar` without `editable`, with `defaultView='agenda'` and a small set of events, to show the non-interactive case.
+
+- [ ] **Step 3: Update `calendar.mdx` — add a "Built-in features" bullet list + `## Props` `<TypeTable>`**
+
+Mirror `kanban.mdx`: a `### Built-in features` list (views, generic data model, hybrid state, drag/resize/create, responsive week→day) before `## Examples`, and a `## Props` section with `<TypeTable>` describing the main props.
+
+- [ ] **Step 4: Regenerate everything**
+
+Run: `bun registry:generate`
+Expected: `[generate] N items processed`; new `*.example.tsx` keys appear (`calendar.example`, `calendar.views.example`).
+
+Run: `cd apps/docs && bunx fumadocs-mdx`
+
+- [ ] **Step 5: Full type + build gate**
+
+Run: `cd apps/docs && bunx tsc --noEmit` (ignore the TS5101 baseUrl note)
+Run: `NODE_OPTIONS=--max-old-space-size=6144 bun build:docs`
+Expected: build succeeds; `apps/docs/public/r/calendar.json` and the example JSONs exist.
+
+- [ ] **Step 6: Visual pass in `bun dev:docs`**
+
+Confirm all four views render, the responsive week→day fallback works, and create/edit/move/resize work through the example dialog.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/registry/items/blocks/calendar apps/docs/content/blocks/calendar.mdx packages/registry/registry.json packages/registry/__index__.ts packages/registry/stubs apps/docs/public/r
+git status   # verify; add any other regenerated files shown
+git commit -m "feat(calendar): examples, docs, registry artifacts"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Views Month/Week/Day/Agenda → Tasks 3, 4, 5. ✓
+- Navigation + view switch + period label → Task 2. ✓
+- Event colors → Task 3 (`colorClasses`), used by all views. ✓
+- All-day band → Task 4. ✓
+- Create (drag-to-create) → Task 9; edit (`onEventClick`) → wired from Task 3 on. ✓
+- Move (dnd-kit) → Task 7; Resize → Task 8. ✓
+- Generic `Calendar<T>` + hybrid state → Tasks 1–2. ✓
+- Responsive week→day → Task 6. ✓
+- Single published file → all tasks modify only `component.tsx` for the component. ✓
+- Default example dialog (replaceable) → Task 10. ✓
+- date-fns + dnd-kit, no new dep → Tasks 2, 7. ✓
+- Validation via generate + build, no test runner added → every task. ✓
+
+**Type consistency:** `getStart`/`getEnd`/`getId`/`getTitle`/`isAllDay` accessors defined in Task 2 are reused in 3–9. `moveEvent`, `layoutDay`, `eventTop`, `eventHeight`, `snapToMinutes`, `colorClasses`, `useIsMobile`, `useControllableState` are each defined once and referenced consistently. `effectiveView` (Task 6) drives the render switch and the nav delta.
+
+**Resolved verification risk:** block examples import via `@/components/block/shuip/calendar` (flat stub at `stubs/blocks/calendar.tsx`) — confirmed against `kanban/default.example.tsx` and `apps/docs/tsconfig.json`.

--- a/docs/superpowers/specs/2026-06-15-calendar-block-design.md
+++ b/docs/superpowers/specs/2026-06-15-calendar-block-design.md
@@ -1,0 +1,129 @@
+# Calendar Block — Design
+
+Date: 2026-06-15
+Status: Approved (pending spec review)
+
+## Goal
+
+Ship a `calendar` registry block: a full-featured calendar inspired by the feature set of
+common shadcn calendar projects, but written from scratch against the shuip stack
+(React 19, Tailwind v4, shadcn primitives). No `react-big-calendar`, no `moment` — both
+because they bloat the install and because `react-big-calendar`'s fixed-width week grid is
+the exact reason the reference is unusable on mobile.
+
+The week view MUST be responsive: below a breakpoint it falls back to the day view.
+
+## Feature set
+
+1. **Views**: Month, Week, Day, Agenda.
+2. **Navigation**: Today / Back / Next, plus a period label.
+3. **View switcher**: Month / Week / Day / Agenda (restrictable via `views`).
+4. **Event colors**: per-event color mapped onto shuip theme tokens.
+5. **All-day events**: rendered in a band above the time grid.
+6. **Create**: drag-to-create on an empty slot (week/day) → `onSlotSelect`.
+7. **Edit**: click an event → `onEventClick` (consumer renders its own UI).
+8. **Move**: drag an event (dnd-kit). Time grid snaps to 15 min keeping duration; month moves the day.
+9. **Resize**: drag the bottom handle of an event (week/day) to change `end`.
+10. **Light/dark**: free via existing tokens.
+
+Interaction scope: drag/resize/drag-to-create apply to **week/day** only. Month supports
+day-to-day move. Agenda is read + click.
+
+## Constraint: single published file
+
+Registry blocks publish exactly one `component.tsx` (the anti-circular rule forbids
+`component.tsx` from importing `@/components/ui/shuip/*`, and `extras/` install elsewhere).
+So the whole calendar lives in `component.tsx`, organized into internal sub-components:
+`CalendarToolbar`, `MonthView`, `TimeGridView` (week/day), `AgendaView`, `EventBlock`,
+plus date helpers. This is a large file (~800–1000 lines) by nature.
+
+## API — generic `Calendar<T>`
+
+Mirrors the kanban field-mapping + hybrid-state pattern.
+
+```ts
+type CalendarView = 'month' | 'week' | 'day' | 'agenda';
+type CalendarEventColor = 'primary' | 'blue' | 'green' | 'red' | 'amber';
+
+type CalendarProps<T extends Record<string, unknown>> = {
+  // data (hybrid: controlled via events+onEventsChange, or standalone via defaultEvents)
+  events?: T[];
+  defaultEvents?: T[];
+  onEventsChange?: (next: T[]) => void;
+
+  // field mapping (start/end fields hold Date values)
+  idField?: keyof T;        // default 'id'
+  titleField: keyof T;
+  startField: keyof T;
+  endField: keyof T;
+  allDayField?: keyof T;
+  color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
+
+  // view + focused date (each controllable or standalone)
+  view?: CalendarView;
+  defaultView?: CalendarView;
+  onViewChange?: (v: CalendarView) => void;
+  date?: Date;
+  defaultDate?: Date;
+  onDateChange?: (d: Date) => void;
+
+  views?: CalendarView[];            // default: all four
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  editable?: boolean;                // gate drag/resize/create
+
+  // interaction callbacks
+  onEventClick?: (item: T) => void;                                  // edit
+  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void; // create
+
+  className?: string;
+};
+```
+
+On any move/resize, the component emits the next array via `onEventsChange` (and updates
+internal state when uncontrolled). The consumer maps that to persistence. As with kanban,
+`T` must be a `type` (not `interface`) to satisfy `T extends Record<string, unknown>`.
+
+## Editing UI
+
+The block imposes no editing UI. It emits `onEventClick` (edit) and `onSlotSelect` (create).
+The **default example** wires a simple shadcn `Dialog` (title + start/end + color) to
+demonstrate create/edit — fully replaceable by the consumer.
+
+## Interactions
+
+- **Move**: `dnd-kit` (`DndContext` + pointer/keyboard sensors), already used by kanban.
+  Time grid → snap start to 15 min keeping duration; month → reassign the day.
+- **Resize**: native pointer handlers on the event's bottom handle (week/day) → adjust `end`,
+  snap to 15 min, clamp to a minimum duration.
+- **Drag-to-create**: pointerdown on an empty time slot + drag → provisional range overlay →
+  emit `onSlotSelect` on release.
+
+## Responsive (key requirement)
+
+- `useIsMobile` hook: `matchMedia` via `useSyncExternalStore` (SSR-safe).
+- Below the breakpoint, the **Week view renders the Day view** for the focused date;
+  Back/Next navigate by day. No broken horizontal scroll.
+- Time grid scrolls vertically inside a height-bounded container.
+- Month cells show "+N more" overflow; Agenda is full-width (naturally responsive).
+
+## Files & deliverables
+
+- `packages/registry/items/blocks/calendar/component.tsx`
+- `packages/registry/items/blocks/calendar/default.example.tsx` — full demo + create/edit dialog
+- `packages/registry/items/blocks/calendar/views.example.tsx` — controlled view switch / read-only
+- `apps/docs/content/blocks/calendar.mdx` — block doc (NOT `index.mdx`; blocks rule)
+- Add `calendar` to `apps/docs/content/blocks/meta.json` order if needed
+- `registryDependencies` auto-detected from imports: `button`, `select`, `dialog`, `input`
+  (and any others used). No new external dep — `date-fns` and `dnd-kit` are already in catalog.
+
+## Validation
+
+- `bun registry:generate` → confirm item count increased.
+- `bun build:docs` (the authoritative type gate). No test runner is configured; not adding
+  one without approval. Visual check of responsive week→day fallback.
+
+## Non-goals (YAGNI)
+
+- Recurring events, timezones beyond the host's local time, multi-calendar overlay,
+  external i18n/locale switching beyond `weekStartsOn`. Can be added later if needed.

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'react-doctor';
+
+export default defineConfig({
+  ignore: {
+    overrides: [
+      {
+        // Registry items ship as a single component.tsx per the one-file-per-block
+        // contract, so their internal sub-components are intentionally not exported.
+        files: ['packages/registry/items/**'],
+        rules: ['react-doctor/only-export-components'],
+      },
+    ],
+  },
+});

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -34,8 +34,13 @@ import { cn } from '@/lib/utils';
 
 export type CalendarView = 'month' | 'week' | 'day' | 'agenda';
 export type CalendarEventColor = 'primary' | 'blue' | 'green' | 'red' | 'amber';
+export type CalendarSlot = { start: Date; end: Date; allDay: boolean };
 
-export type CalendarProps<T extends Record<string, unknown>> = {
+type CalendarEventLike = Record<string, unknown>;
+
+export type CalendarRootProps<T extends CalendarEventLike> = {
+  children: React.ReactNode;
+
   events?: T[];
   defaultEvents?: T[];
   onEventsChange?: (next: T[]) => void;
@@ -60,10 +65,45 @@ export type CalendarProps<T extends Record<string, unknown>> = {
   editable?: boolean;
 
   onEventClick?: (item: T) => void;
-  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
-
-  className?: string;
+  onSlotSelect?: (range: CalendarSlot) => void;
 };
+
+type CalendarContextValue<T extends CalendarEventLike = CalendarEventLike> = {
+  view: CalendarView;
+  setView: (v: CalendarView) => void;
+  views: CalendarView[];
+  date: Date;
+  setDate: (d: Date) => void;
+  effectiveView: CalendarView;
+  isMobile: boolean;
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  editable: boolean;
+  periodLabel: string;
+  goToToday: () => void;
+  goToPrevious: () => void;
+  goToNext: () => void;
+
+  events: T[];
+  getId: (item: T) => string;
+  getStart: (item: T) => Date;
+  getEnd: (item: T) => Date;
+  getTitle: (item: T) => string;
+  isAllDay: (item: T) => boolean;
+  getColor: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
+  onEventClick?: (item: T) => void;
+  onSlotSelect?: (range: CalendarSlot) => void;
+  resizeEvent: (id: string, end: Date) => void;
+  draggedRef: React.MutableRefObject<boolean>;
+};
+
+const CalendarContext = React.createContext<CalendarContextValue | null>(null);
+
+export function useCalendar<T extends CalendarEventLike = CalendarEventLike>(): CalendarContextValue<T> {
+  const ctx = React.useContext(CalendarContext);
+  if (!ctx) throw new Error('useCalendar must be used within <Calendar.Root>');
+  return ctx as CalendarContextValue<T>;
+}
 
 function useControllableState<V>(
   controlled: V | undefined,
@@ -99,47 +139,46 @@ function useIsMobile(breakpoint = 768): boolean {
   return React.useSyncExternalStore(subscribe, getSnapshot, () => false);
 }
 
-export function Calendar<T extends Record<string, unknown>>(props: CalendarProps<T>) {
-  const {
-    events,
-    defaultEvents = [] as T[],
-    onEventsChange,
-    idField = 'id' as keyof T,
-    titleField,
-    startField,
-    endField,
-    allDayField,
-    color,
-    renderEvent,
-    view: viewProp,
-    defaultView = 'month',
-    onViewChange,
-    date: dateProp,
-    defaultDate,
-    onDateChange,
-    views = ['month', 'week', 'day', 'agenda'] as CalendarView[],
-    weekStartsOn = 1,
-    editable = false,
-    onEventClick,
-    onSlotSelect,
-    className,
-  } = props;
-
+function CalendarRoot<T extends CalendarEventLike>({
+  children,
+  events,
+  defaultEvents = [] as T[],
+  onEventsChange,
+  idField = 'id' as keyof T,
+  titleField,
+  startField,
+  endField,
+  allDayField,
+  color,
+  renderEvent,
+  view: viewProp,
+  defaultView = 'month',
+  onViewChange,
+  date: dateProp,
+  defaultDate,
+  onDateChange,
+  views = ['month', 'week', 'day', 'agenda'],
+  weekStartsOn = 1,
+  editable = false,
+  onEventClick,
+  onSlotSelect,
+}: CalendarRootProps<T>) {
   const [view, setView] = useControllableState<CalendarView>(viewProp, defaultView, onViewChange);
   const [date, setDate] = useControllableState<Date>(dateProp, defaultDate ?? startOfDay(new Date()), onDateChange);
   const [items, setItems] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
 
   const isMobile = useIsMobile();
   const effectiveView = isMobile && view === 'week' ? 'day' : view;
+  const draggedRef = React.useRef(false);
 
   const getStart = React.useCallback((it: T) => it[startField] as unknown as Date, [startField]);
   const getEnd = React.useCallback((it: T) => it[endField] as unknown as Date, [endField]);
   const isAllDay = React.useCallback((it: T) => (allDayField ? Boolean(it[allDayField]) : false), [allDayField]);
   const getId = React.useCallback((it: T) => String(it[idField]), [idField]);
   const getTitle = React.useCallback((it: T) => String(it[titleField] ?? ''), [titleField]);
+  const getColor = React.useCallback((it: T) => color?.(it), [color]);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
-  const draggedRef = React.useRef(false);
 
   const handleDragEnd = React.useCallback(
     (e: DragEndEvent) => {
@@ -171,7 +210,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
     [items, getId, getStart, getEnd, effectiveView, startField, endField, setItems],
   );
 
-  const handleResize = React.useCallback(
+  const resizeEvent = React.useCallback(
     (id: string, newEnd: Date) => {
       setItems(items.map((it) => (getId(it) === id ? ({ ...it, [endField]: newEnd } as T) : it)));
     },
@@ -203,16 +242,139 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
         case 'week':
           setDate(addDays(date, 7 * dir));
           break;
-        case 'day':
-        case 'agenda':
+        default:
           setDate(addDays(date, dir));
-          break;
       }
     },
     [effectiveView, date, setDate],
   );
 
-  const onToday = React.useCallback(() => setDate(startOfDay(new Date())), [setDate]);
+  const goToToday = React.useCallback(() => setDate(startOfDay(new Date())), [setDate]);
+  const goToPrevious = React.useCallback(() => shift(-1), [shift]);
+  const goToNext = React.useCallback(() => shift(1), [shift]);
+
+  const value = React.useMemo<CalendarContextValue<T>>(
+    () => ({
+      view,
+      setView,
+      views,
+      date,
+      setDate,
+      effectiveView,
+      isMobile,
+      weekStartsOn,
+      editable,
+      periodLabel,
+      goToToday,
+      goToPrevious,
+      goToNext,
+      events: items,
+      getId,
+      getStart,
+      getEnd,
+      getTitle,
+      isAllDay,
+      getColor,
+      renderEvent,
+      onEventClick,
+      onSlotSelect,
+      resizeEvent,
+      draggedRef,
+    }),
+    [
+      view,
+      setView,
+      views,
+      date,
+      setDate,
+      effectiveView,
+      isMobile,
+      weekStartsOn,
+      editable,
+      periodLabel,
+      goToToday,
+      goToPrevious,
+      goToNext,
+      items,
+      getId,
+      getStart,
+      getEnd,
+      getTitle,
+      isAllDay,
+      getColor,
+      renderEvent,
+      onEventClick,
+      onSlotSelect,
+      resizeEvent,
+    ],
+  );
+
+  return (
+    <CalendarContext.Provider value={value as unknown as CalendarContextValue}>
+      {editable ? (
+        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+          {children}
+        </DndContext>
+      ) : (
+        children
+      )}
+    </CalendarContext.Provider>
+  );
+}
+
+function CalendarNav({ className }: { className?: string }) {
+  const { periodLabel, views, view, setView, goToToday, goToPrevious, goToNext } = useCalendar();
+  return (
+    <div className={cn('flex w-full flex-wrap items-center justify-between gap-2', className)}>
+      <div className='flex items-center gap-1'>
+        <Button variant='outline' size='sm' onClick={goToToday}>
+          Today
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToPrevious} aria-label='Previous'>
+          <ChevronLeft className='size-4' />
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToNext} aria-label='Next'>
+          <ChevronRight className='size-4' />
+        </Button>
+        <span className='ml-2 text-sm font-medium'>{periodLabel}</span>
+      </div>
+      {views.length > 1 ? (
+        <Select value={view} onValueChange={(v) => setView(v as CalendarView)}>
+          <SelectTrigger className='w-32' size='sm'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {views.map((v) => (
+              <SelectItem key={v} value={v}>
+                {v[0].toUpperCase() + v.slice(1)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : null}
+    </div>
+  );
+}
+
+function CalendarViewComponent({ className }: { className?: string }) {
+  const {
+    effectiveView,
+    date,
+    weekStartsOn,
+    events: items,
+    getStart,
+    getEnd,
+    getId,
+    getTitle,
+    isAllDay,
+    getColor,
+    renderEvent,
+    editable,
+    draggedRef,
+    resizeEvent,
+    onEventClick,
+    onSlotSelect,
+  } = useCalendar();
 
   const weekDays = React.useMemo(
     () => eachDayOfInterval({ start: startOfWeek(date, { weekStartsOn }), end: endOfWeek(date, { weekStartsOn }) }),
@@ -235,7 +397,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             getStart={getStart}
             getId={getId}
             getTitle={getTitle}
-            color={color}
+            color={getColor}
             renderEvent={renderEvent}
             editable={editable}
             draggedRef={draggedRef}
@@ -244,39 +406,21 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
           />
         );
       case 'week':
-        return (
-          <TimeGridView
-            days={weekDays}
-            items={items}
-            getStart={getStart}
-            getEnd={getEnd}
-            getId={getId}
-            getTitle={getTitle}
-            isAllDay={isAllDay}
-            color={color}
-            renderEvent={renderEvent}
-            editable={editable}
-            draggedRef={draggedRef}
-            onResize={editable ? handleResize : undefined}
-            onEventClick={onEventClick}
-            onSlotSelect={onSlotSelect}
-          />
-        );
       case 'day':
         return (
           <TimeGridView
-            days={[date]}
+            days={effectiveView === 'week' ? weekDays : [date]}
             items={items}
             getStart={getStart}
             getEnd={getEnd}
             getId={getId}
             getTitle={getTitle}
             isAllDay={isAllDay}
-            color={color}
+            color={getColor}
             renderEvent={renderEvent}
             editable={editable}
             draggedRef={draggedRef}
-            onResize={editable ? handleResize : undefined}
+            onResize={editable ? resizeEvent : undefined}
             onEventClick={onEventClick}
             onSlotSelect={onSlotSelect}
           />
@@ -290,7 +434,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             getEnd={getEnd}
             getId={getId}
             getTitle={getTitle}
-            color={color}
+            color={getColor}
             renderEvent={renderEvent}
             onEventClick={onEventClick}
           />
@@ -298,27 +442,14 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
     }
   })();
 
-  return (
-    <div className={cn('flex flex-col gap-4', className)}>
-      <CalendarToolbar
-        label={periodLabel}
-        views={views}
-        view={view}
-        onView={setView}
-        onToday={onToday}
-        onPrev={() => shift(-1)}
-        onNext={() => shift(1)}
-      />
-      {editable ? (
-        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-          {body}
-        </DndContext>
-      ) : (
-        body
-      )}
-    </div>
-  );
+  return <div className={cn('w-full', className)}>{body}</div>;
 }
+
+export const Calendar = {
+  Root: CalendarRoot,
+  Nav: CalendarNav,
+  View: CalendarViewComponent,
+};
 
 function monthGrid(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date[] {
   const start = startOfWeek(startOfMonth(date), { weekStartsOn });
@@ -560,6 +691,7 @@ function ResizeHandle({
       data-event=''
       className='absolute inset-x-0 bottom-0 z-20 h-1.5 cursor-ns-resize'
       onPointerDown={handlePointerDown}
+      onClick={(e) => e.stopPropagation()}
     />
   );
 }
@@ -668,7 +800,7 @@ function DroppableDayColumn<T extends Record<string, unknown>>({
   dayIndex: number;
   creating: Creating | null;
   onCreatingChange: (next: Creating | null) => void;
-  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+  onSlotSelect?: (range: CalendarSlot) => void;
   laidOut: LaidOut<T>[];
   getStart: (item: T) => Date;
   getEnd: (item: T) => Date;
@@ -802,7 +934,7 @@ function TimeGridView<T extends Record<string, unknown>>({
   draggedRef: React.MutableRefObject<boolean>;
   onResize?: (id: string, end: Date) => void;
   onEventClick?: (item: T) => void;
-  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+  onSlotSelect?: (range: CalendarSlot) => void;
 }) {
   const [resizing, setResizing] = React.useState<{ id: string; end: Date } | null>(null);
   const [creating, setCreating] = React.useState<Creating | null>(null);
@@ -813,40 +945,48 @@ function TimeGridView<T extends Record<string, unknown>>({
   );
 
   return (
-    <div className='overflow-hidden rounded-md border'>
-      <div className='flex border-b'>
-        <div className='w-14 shrink-0 border-r' />
-        {days.map((day) => (
-          <div key={day.toISOString()} className='flex-1 border-l p-2 text-center text-xs font-medium first:border-l-0'>
-            {format(day, 'EEE d')}
+    <div className='w-full overflow-hidden rounded-md border'>
+      <div className='max-h-[600px] overflow-y-auto'>
+        <div className='sticky top-0 z-30 bg-background'>
+          <div className='flex border-b'>
+            <div className='w-14 shrink-0 border-r' />
+            {days.map((day) => (
+              <div
+                key={day.toISOString()}
+                className='flex-1 border-l p-2 text-center text-xs font-medium first:border-l-0'
+              >
+                {format(day, 'EEE d')}
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
 
-      <div className='flex border-b'>
-        <div className='flex w-14 shrink-0 items-center justify-center border-r py-1 text-xs text-muted-foreground'>
-          all-day
-        </div>
-        {days.map((day) => {
-          const allDayEvents = items.filter((item) => spansAllDay(item) && isSameDay(getStart(item), day));
-          return (
-            <div key={day.toISOString()} className='flex flex-1 flex-col gap-1 border-l p-1 first:border-l-0'>
-              {allDayEvents.map((item) => (
-                <button
-                  type='button'
-                  key={getId(item)}
-                  onClick={() => onEventClick?.(item)}
-                  className={cn('w-full truncate rounded px-1 py-0.5 text-left text-xs', colorClasses(color?.(item)))}
-                >
-                  {renderEvent ? renderEvent(item) : getTitle(item)}
-                </button>
-              ))}
+          <div className='flex border-b'>
+            <div className='flex w-14 shrink-0 items-center justify-center border-r py-1 text-xs text-muted-foreground'>
+              all-day
             </div>
-          );
-        })}
-      </div>
+            {days.map((day) => {
+              const allDayEvents = items.filter((item) => spansAllDay(item) && isSameDay(getStart(item), day));
+              return (
+                <div key={day.toISOString()} className='flex flex-1 flex-col gap-1 border-l p-1 first:border-l-0'>
+                  {allDayEvents.map((item) => (
+                    <button
+                      type='button'
+                      key={getId(item)}
+                      onClick={() => onEventClick?.(item)}
+                      className={cn(
+                        'w-full truncate rounded px-1 py-0.5 text-left text-xs',
+                        colorClasses(color?.(item)),
+                      )}
+                    >
+                      {renderEvent ? renderEvent(item) : getTitle(item)}
+                    </button>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        </div>
 
-      <div className='relative max-h-[600px] overflow-y-auto'>
         <div className='flex'>
           <div className='w-14 shrink-0 border-r'>
             {HOURS.map((h) => (
@@ -958,7 +1098,7 @@ function MonthCell<T extends Record<string, unknown>>({
   renderEvent?: (item: T) => React.ReactNode;
   draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
-  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+  onSlotSelect?: (range: CalendarSlot) => void;
 }) {
   const { setNodeRef } = useDroppable({ id: `cell-${day.toISOString()}`, data: { day } });
   return (
@@ -1049,13 +1189,13 @@ function MonthView<T extends Record<string, unknown>>({
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
-  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+  onSlotSelect?: (range: CalendarSlot) => void;
 }) {
   const days = monthGrid(date, weekStartsOn);
   const weekdayLabels = days.slice(0, 7).map((day) => format(day, 'EEE'));
 
   return (
-    <div className='overflow-hidden rounded-md border'>
+    <div className='w-full overflow-hidden rounded-md border'>
       <div className='grid grid-cols-7'>
         {weekdayLabels.map((label) => (
           <div
@@ -1138,11 +1278,11 @@ function AgendaView<T extends Record<string, unknown>>({
     .filter((group) => group.events.length > 0);
 
   if (groups.length === 0) {
-    return <p className='text-sm text-muted-foreground'>No upcoming events</p>;
+    return <p className='w-full text-sm text-muted-foreground'>No upcoming events</p>;
   }
 
   return (
-    <div className='flex max-h-[600px] flex-col gap-4 overflow-y-auto'>
+    <div className='flex max-h-[600px] w-full flex-col gap-4 overflow-y-auto'>
       {groups.map((group) => (
         <div key={group.day.toISOString()} className='flex flex-col gap-1'>
           <div className='text-sm font-medium'>{format(group.day, 'EEEE, MMM d')}</div>
@@ -1162,55 +1302,6 @@ function AgendaView<T extends Record<string, unknown>>({
           ))}
         </div>
       ))}
-    </div>
-  );
-}
-
-function CalendarToolbar({
-  label,
-  views,
-  view,
-  onView,
-  onToday,
-  onPrev,
-  onNext,
-}: {
-  label: string;
-  views: CalendarView[];
-  view: CalendarView;
-  onView: (v: CalendarView) => void;
-  onToday: () => void;
-  onPrev: () => void;
-  onNext: () => void;
-}) {
-  return (
-    <div className='flex flex-wrap items-center justify-between gap-2'>
-      <div className='flex items-center gap-1'>
-        <Button variant='outline' size='sm' onClick={onToday}>
-          Today
-        </Button>
-        <Button variant='outline' size='icon' className='size-8' onClick={onPrev} aria-label='Previous'>
-          <ChevronLeft className='size-4' />
-        </Button>
-        <Button variant='outline' size='icon' className='size-8' onClick={onNext} aria-label='Next'>
-          <ChevronRight className='size-4' />
-        </Button>
-        <span className='ml-2 text-sm font-medium'>{label}</span>
-      </div>
-      {views.length > 1 ? (
-        <Select value={view} onValueChange={(v) => onView(v as CalendarView)}>
-          <SelectTrigger className='w-32' size='sm'>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {views.map((v) => (
-              <SelectItem key={v} value={v}>
-                {v[0].toUpperCase() + v.slice(1)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ) : null}
     </div>
   );
 }

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -33,7 +33,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { cn } from '@/lib/utils';
 
 export type CalendarView = 'month' | 'week' | 'day' | 'agenda';
-export type CalendarEventColor = 'primary' | 'blue' | 'green' | 'red' | 'amber';
+export type CalendarEventColor = 'primary' | 'secondary' | 'accent' | 'destructive' | 'muted';
 export type CalendarSlot = { start: Date; end: Date; allDay: boolean };
 
 type CalendarEventLike = Record<string, unknown>;
@@ -457,19 +457,16 @@ function monthGrid(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date[] 
   return eachDayOfInterval({ start, end });
 }
 
+const colorClassMap: Record<CalendarEventColor, string> = {
+  primary: 'bg-primary text-primary-foreground',
+  secondary: 'bg-secondary text-secondary-foreground',
+  accent: 'bg-accent text-accent-foreground',
+  destructive: 'bg-destructive text-destructive-foreground',
+  muted: 'bg-muted text-muted-foreground',
+};
+
 function colorClasses(c?: CalendarEventColor): string {
-  switch (c) {
-    case 'blue':
-      return 'bg-blue-500 text-white';
-    case 'green':
-      return 'bg-green-600 text-white';
-    case 'red':
-      return 'bg-red-500 text-white';
-    case 'amber':
-      return 'bg-amber-500 text-black';
-    default:
-      return 'bg-primary text-primary-foreground';
-  }
+  return c ? colorClassMap[c] : colorClassMap.primary;
 }
 
 const HOUR_HEIGHT = 48;

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -1,7 +1,18 @@
 'use client';
 
 import {
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import {
   addDays,
+  addMinutes,
   addMonths,
   eachDayOfInterval,
   endOfMonth,
@@ -9,6 +20,8 @@ import {
   format,
   isSameDay,
   isSameMonth,
+  setHours,
+  setMinutes,
   startOfDay,
   startOfMonth,
   startOfWeek,
@@ -114,7 +127,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
 
   const [view, setView] = useControllableState<CalendarView>(viewProp, defaultView, onViewChange);
   const [date, setDate] = useControllableState<Date>(dateProp, defaultDate ?? startOfDay(new Date()), onDateChange);
-  const [items] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
+  const [items, setItems] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
 
   const isMobile = useIsMobile();
   const effectiveView = isMobile && view === 'week' ? 'day' : view;
@@ -124,6 +137,39 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
   const isAllDay = React.useCallback((it: T) => (allDayField ? Boolean(it[allDayField]) : false), [allDayField]);
   const getId = React.useCallback((it: T) => String(it[idField]), [idField]);
   const getTitle = React.useCallback((it: T) => String(it[titleField] ?? ''), [titleField]);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const draggedRef = React.useRef(false);
+
+  const handleDragEnd = React.useCallback(
+    (e: DragEndEvent) => {
+      const { active, over, delta } = e;
+      draggedRef.current = Math.abs(delta.x) > 4 || Math.abs(delta.y) > 4;
+      const id = String(active.id);
+      const item = items.find((it) => getId(it) === id);
+      if (!item) return;
+      const oldStart = getStart(item);
+      const oldEnd = getEnd(item);
+      const duration = oldEnd.getTime() - oldStart.getTime();
+      const overDay = (over?.data.current?.day as Date | undefined) ?? oldStart;
+
+      let newStart: Date;
+      if (effectiveView === 'month') {
+        newStart = setMinutes(setHours(startOfDay(overDay), oldStart.getHours()), oldStart.getMinutes());
+      } else {
+        const movedMinutes = minutesSinceDayStart(oldStart) + (delta.y / HOUR_HEIGHT) * 60;
+        newStart = snapToMinutes(addMinutes(startOfDay(overDay), movedMinutes));
+      }
+      if (newStart.getTime() === oldStart.getTime()) return;
+      const next = items.map((it) =>
+        getId(it) === id
+          ? ({ ...it, [startField]: newStart, [endField]: new Date(newStart.getTime() + duration) } as T)
+          : it,
+      );
+      setItems(next);
+    },
+    [items, getId, getStart, getEnd, effectiveView, startField, endField, setItems],
+  );
 
   const periodLabel = React.useMemo(() => {
     switch (effectiveView) {
@@ -171,6 +217,74 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
     [date],
   );
 
+  const body = (() => {
+    switch (effectiveView) {
+      case 'month':
+        return (
+          <MonthView
+            date={date}
+            weekStartsOn={weekStartsOn}
+            items={items}
+            getStart={getStart}
+            getId={getId}
+            getTitle={getTitle}
+            color={color}
+            editable={editable}
+            draggedRef={draggedRef}
+            onEventClick={onEventClick}
+            onSlotSelect={onSlotSelect}
+          />
+        );
+      case 'week':
+        return (
+          <TimeGridView
+            days={weekDays}
+            items={items}
+            getStart={getStart}
+            getEnd={getEnd}
+            getId={getId}
+            getTitle={getTitle}
+            isAllDay={isAllDay}
+            color={color}
+            editable={editable}
+            draggedRef={draggedRef}
+            onEventClick={onEventClick}
+            onSlotSelect={onSlotSelect}
+          />
+        );
+      case 'day':
+        return (
+          <TimeGridView
+            days={[date]}
+            items={items}
+            getStart={getStart}
+            getEnd={getEnd}
+            getId={getId}
+            getTitle={getTitle}
+            isAllDay={isAllDay}
+            color={color}
+            editable={editable}
+            draggedRef={draggedRef}
+            onEventClick={onEventClick}
+            onSlotSelect={onSlotSelect}
+          />
+        );
+      case 'agenda':
+        return (
+          <AgendaView
+            days={agendaDays}
+            items={items}
+            getStart={getStart}
+            getEnd={getEnd}
+            getId={getId}
+            getTitle={getTitle}
+            color={color}
+            onEventClick={onEventClick}
+          />
+        );
+    }
+  })();
+
   return (
     <div className={cn('flex flex-col gap-4', className)}>
       <CalendarToolbar
@@ -182,70 +296,13 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
         onPrev={() => shift(-1)}
         onNext={() => shift(1)}
       />
-      {(() => {
-        switch (effectiveView) {
-          case 'month':
-            return (
-              <MonthView
-                date={date}
-                weekStartsOn={weekStartsOn}
-                items={items}
-                getStart={getStart}
-                getId={getId}
-                getTitle={getTitle}
-                color={color}
-                editable={editable}
-                onEventClick={onEventClick}
-                onSlotSelect={onSlotSelect}
-              />
-            );
-          case 'week':
-            return (
-              <TimeGridView
-                days={weekDays}
-                items={items}
-                getStart={getStart}
-                getEnd={getEnd}
-                getId={getId}
-                getTitle={getTitle}
-                isAllDay={isAllDay}
-                color={color}
-                editable={editable}
-                onEventClick={onEventClick}
-                onSlotSelect={onSlotSelect}
-              />
-            );
-          case 'day':
-            return (
-              <TimeGridView
-                days={[date]}
-                items={items}
-                getStart={getStart}
-                getEnd={getEnd}
-                getId={getId}
-                getTitle={getTitle}
-                isAllDay={isAllDay}
-                color={color}
-                editable={editable}
-                onEventClick={onEventClick}
-                onSlotSelect={onSlotSelect}
-              />
-            );
-          case 'agenda':
-            return (
-              <AgendaView
-                days={agendaDays}
-                items={items}
-                getStart={getStart}
-                getEnd={getEnd}
-                getId={getId}
-                getTitle={getTitle}
-                color={color}
-                onEventClick={onEventClick}
-              />
-            );
-        }
-      })()}
+      {editable ? (
+        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+          {body}
+        </DndContext>
+      ) : (
+        body
+      )}
     </div>
   );
 }
@@ -272,6 +329,12 @@ function colorClasses(c?: CalendarEventColor): string {
 }
 
 const HOUR_HEIGHT = 48;
+const SNAP_MINUTES = 15;
+
+function snapToMinutes(date: Date, minutes = SNAP_MINUTES): Date {
+  const ms = minutes * 60_000;
+  return new Date(Math.round(date.getTime() / ms) * ms);
+}
 
 function minutesSinceDayStart(date: Date): number {
   return date.getHours() * 60 + date.getMinutes();
@@ -303,6 +366,29 @@ function layoutDay<T>(dayEvents: T[], getStart: (t: T) => Date, getEnd: (t: T) =
   return placed.map((p) => ({ ...p, cols }));
 }
 
+function eventBlockStyle(start: Date, end: Date, laidOut: { col: number; cols: number }): React.CSSProperties {
+  const widthPct = 100 / laidOut.cols;
+  return {
+    top: eventTop(start),
+    height: eventHeight(start, end),
+    left: `${laidOut.col * widthPct}%`,
+    width: `calc(${widthPct}% - 2px)`,
+  };
+}
+
+function EventBlockContent({ title, start, end }: { title: string; start: Date; end: Date }) {
+  return (
+    <>
+      <span className='block truncate font-medium'>{title}</span>
+      <span className='block truncate opacity-80'>
+        {format(start, 'HH:mm')} – {format(end, 'HH:mm')}
+      </span>
+    </>
+  );
+}
+
+const eventBlockClass = 'absolute z-10 overflow-hidden rounded px-1 py-0.5 text-left text-xs';
+
 function EventBlock({
   title,
   start,
@@ -318,29 +404,164 @@ function EventBlock({
   color?: CalendarEventColor;
   onClick?: () => void;
 }) {
-  const widthPct = 100 / laidOut.cols;
   return (
     <button
       type='button'
       onClick={onClick}
-      style={{
-        top: eventTop(start),
-        height: eventHeight(start, end),
-        left: `${laidOut.col * widthPct}%`,
-        width: `calc(${widthPct}% - 2px)`,
-      }}
-      className={cn('absolute z-10 overflow-hidden rounded px-1 py-0.5 text-left text-xs', colorClasses(color))}
+      style={eventBlockStyle(start, end, laidOut)}
+      className={cn(eventBlockClass, colorClasses(color))}
     >
-      <span className='block truncate font-medium'>{title}</span>
-      <span className='block truncate opacity-80'>
-        {format(start, 'HH:mm')} – {format(end, 'HH:mm')}
-      </span>
+      <EventBlockContent title={title} start={start} end={end} />
+    </button>
+  );
+}
+
+function DraggableEventBlock({
+  id,
+  title,
+  start,
+  end,
+  laidOut,
+  color,
+  draggedRef,
+  onClick,
+}: {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  laidOut: { col: number; cols: number };
+  color?: CalendarEventColor;
+  draggedRef: React.MutableRefObject<boolean>;
+  onClick?: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id });
+  return (
+    <button
+      type='button'
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      onClick={() => {
+        if (draggedRef.current) {
+          draggedRef.current = false;
+          return;
+        }
+        onClick?.();
+      }}
+      style={{
+        ...eventBlockStyle(start, end, laidOut),
+        transform: CSS.Translate.toString(transform),
+        zIndex: isDragging ? 40 : undefined,
+        touchAction: 'none',
+      }}
+      className={cn(eventBlockClass, colorClasses(color))}
+    >
+      <EventBlockContent title={title} start={start} end={end} />
     </button>
   );
 }
 
 const HOURS = Array.from({ length: 24 }, (_, h) => h);
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function DayColumnContent<T extends Record<string, unknown>>({
+  laidOut,
+  getStart,
+  getEnd,
+  getId,
+  getTitle,
+  color,
+  editable,
+  draggedRef,
+  onEventClick,
+}: {
+  laidOut: LaidOut<T>[];
+  getStart: (item: T) => Date;
+  getEnd: (item: T) => Date;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  color?: (item: T) => CalendarEventColor | undefined;
+  editable: boolean;
+  draggedRef: React.MutableRefObject<boolean>;
+  onEventClick?: (item: T) => void;
+}) {
+  return (
+    <>
+      {HOURS.map((h) => (
+        <div key={h} className='h-12 border-t first:border-t-0' />
+      ))}
+      {laidOut.map((entry) =>
+        editable ? (
+          <DraggableEventBlock
+            key={getId(entry.item)}
+            id={getId(entry.item)}
+            title={getTitle(entry.item)}
+            start={getStart(entry.item)}
+            end={getEnd(entry.item)}
+            laidOut={entry}
+            color={color?.(entry.item)}
+            draggedRef={draggedRef}
+            onClick={() => onEventClick?.(entry.item)}
+          />
+        ) : (
+          <EventBlock
+            key={getId(entry.item)}
+            title={getTitle(entry.item)}
+            start={getStart(entry.item)}
+            end={getEnd(entry.item)}
+            laidOut={entry}
+            color={color?.(entry.item)}
+            onClick={() => onEventClick?.(entry.item)}
+          />
+        ),
+      )}
+    </>
+  );
+}
+
+const dayColumnClass = 'relative flex-1 border-l first:border-l-0';
+
+function DroppableDayColumn<T extends Record<string, unknown>>({
+  day,
+  ...content
+}: {
+  day: Date;
+  laidOut: LaidOut<T>[];
+  getStart: (item: T) => Date;
+  getEnd: (item: T) => Date;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  color?: (item: T) => CalendarEventColor | undefined;
+  editable: boolean;
+  draggedRef: React.MutableRefObject<boolean>;
+  onEventClick?: (item: T) => void;
+}) {
+  const { setNodeRef } = useDroppable({ id: `col-${day.toISOString()}`, data: { day } });
+  return (
+    <div ref={setNodeRef} className={cn(dayColumnClass, 'cursor-pointer')} style={{ height: 24 * HOUR_HEIGHT }}>
+      <DayColumnContent {...content} />
+    </div>
+  );
+}
+
+function PlainDayColumn<T extends Record<string, unknown>>(content: {
+  laidOut: LaidOut<T>[];
+  getStart: (item: T) => Date;
+  getEnd: (item: T) => Date;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  color?: (item: T) => CalendarEventColor | undefined;
+  editable: boolean;
+  draggedRef: React.MutableRefObject<boolean>;
+  onEventClick?: (item: T) => void;
+}) {
+  return (
+    <div className={dayColumnClass} style={{ height: 24 * HOUR_HEIGHT }}>
+      <DayColumnContent {...content} />
+    </div>
+  );
+}
 
 function TimeGridView<T extends Record<string, unknown>>({
   days,
@@ -352,6 +573,7 @@ function TimeGridView<T extends Record<string, unknown>>({
   isAllDay,
   color,
   editable,
+  draggedRef,
   onEventClick,
 }: {
   days: Date[];
@@ -363,6 +585,7 @@ function TimeGridView<T extends Record<string, unknown>>({
   isAllDay: (item: T) => boolean;
   color?: (item: T) => CalendarEventColor | undefined;
   editable: boolean;
+  draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
 }) {
@@ -417,31 +640,149 @@ function TimeGridView<T extends Record<string, unknown>>({
           {days.map((day) => {
             const timed = items.filter((item) => !spansAllDay(item) && isSameDay(getStart(item), day));
             const laidOut = layoutDay(timed, getStart, getEnd);
-            return (
-              <div
-                key={day.toISOString()}
-                className={cn('relative flex-1 border-l first:border-l-0', editable && 'cursor-pointer')}
-                style={{ height: 24 * HOUR_HEIGHT }}
-              >
-                {HOURS.map((h) => (
-                  <div key={h} className='h-12 border-t first:border-t-0' />
-                ))}
-                {laidOut.map((entry) => (
-                  <EventBlock
-                    key={getId(entry.item)}
-                    title={getTitle(entry.item)}
-                    start={getStart(entry.item)}
-                    end={getEnd(entry.item)}
-                    laidOut={entry}
-                    color={color?.(entry.item)}
-                    onClick={() => onEventClick?.(entry.item)}
-                  />
-                ))}
-              </div>
+            const columnProps = {
+              laidOut,
+              getStart,
+              getEnd,
+              getId,
+              getTitle,
+              color,
+              editable,
+              draggedRef,
+              onEventClick,
+            };
+            return editable ? (
+              <DroppableDayColumn key={day.toISOString()} day={day} {...columnProps} />
+            ) : (
+              <PlainDayColumn key={day.toISOString()} {...columnProps} />
             );
           })}
         </div>
       </div>
+    </div>
+  );
+}
+
+const monthPillClass = 'w-full truncate rounded px-1 py-0.5 text-left text-xs';
+
+function MonthEventPill<T>({
+  item,
+  id,
+  title,
+  color,
+  draggedRef,
+  onEventClick,
+}: {
+  item: T;
+  id: string;
+  title: string;
+  color?: CalendarEventColor;
+  draggedRef: React.MutableRefObject<boolean>;
+  onEventClick?: (item: T) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id });
+  return (
+    <button
+      type='button'
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (draggedRef.current) {
+          draggedRef.current = false;
+          return;
+        }
+        onEventClick?.(item);
+      }}
+      style={{ transform: CSS.Translate.toString(transform), zIndex: isDragging ? 40 : undefined, touchAction: 'none' }}
+      className={cn(monthPillClass, colorClasses(color))}
+    >
+      {title}
+    </button>
+  );
+}
+
+function MonthCell<T extends Record<string, unknown>>({
+  day,
+  date,
+  visible,
+  overflow,
+  getId,
+  getTitle,
+  color,
+  draggedRef,
+  onEventClick,
+  onSlotSelect,
+}: {
+  day: Date;
+  date: Date;
+  visible: T[];
+  overflow: number;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  color?: (item: T) => CalendarEventColor | undefined;
+  draggedRef: React.MutableRefObject<boolean>;
+  onEventClick?: (item: T) => void;
+  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+}) {
+  const { setNodeRef } = useDroppable({ id: `cell-${day.toISOString()}`, data: { day } });
+  return (
+    <div
+      ref={setNodeRef}
+      className='flex min-h-24 cursor-pointer flex-col gap-1 border-b border-l p-1 hover:bg-accent/50 [&:nth-child(7n+1)]:border-l-0'
+      onClick={() => onSlotSelect?.({ start: startOfDay(day), end: addDays(startOfDay(day), 1), allDay: true })}
+    >
+      <span className={cn('text-xs', !isSameMonth(day, date) && 'text-muted-foreground')}>{format(day, 'd')}</span>
+      {visible.map((item) => (
+        <MonthEventPill
+          key={getId(item)}
+          item={item}
+          id={getId(item)}
+          title={getTitle(item)}
+          color={color?.(item)}
+          draggedRef={draggedRef}
+          onEventClick={onEventClick}
+        />
+      ))}
+      {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>+{overflow} more</span> : null}
+    </div>
+  );
+}
+
+function PlainMonthCell<T extends Record<string, unknown>>({
+  day,
+  date,
+  visible,
+  overflow,
+  getId,
+  getTitle,
+  color,
+  onEventClick,
+}: {
+  day: Date;
+  date: Date;
+  visible: T[];
+  overflow: number;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  color?: (item: T) => CalendarEventColor | undefined;
+  onEventClick?: (item: T) => void;
+}) {
+  return (
+    <div className='flex min-h-24 flex-col gap-1 border-b border-l p-1 [&:nth-child(7n+1)]:border-l-0'>
+      <span className={cn('text-xs', !isSameMonth(day, date) && 'text-muted-foreground')}>{format(day, 'd')}</span>
+      {visible.map((item) => (
+        <button
+          type='button'
+          key={getId(item)}
+          className={cn(monthPillClass, colorClasses(color?.(item)))}
+          onClick={() => onEventClick?.(item)}
+        >
+          {getTitle(item)}
+        </button>
+      ))}
+      {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>+{overflow} more</span> : null}
     </div>
   );
 }
@@ -455,6 +796,7 @@ function MonthView<T extends Record<string, unknown>>({
   getTitle,
   color,
   editable,
+  draggedRef,
   onEventClick,
   onSlotSelect,
 }: {
@@ -466,6 +808,7 @@ function MonthView<T extends Record<string, unknown>>({
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
   editable: boolean;
+  draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
 }) {
@@ -490,37 +833,32 @@ function MonthView<T extends Record<string, unknown>>({
           const visible = dayEvents.slice(0, 3);
           const overflow = dayEvents.length - visible.length;
 
-          const selectSlot = editable
-            ? () => onSlotSelect?.({ start: startOfDay(day), end: addDays(startOfDay(day), 1), allDay: true })
-            : undefined;
-
-          return (
-            <div
+          return editable ? (
+            <MonthCell
               key={day.toISOString()}
-              className={cn(
-                'flex min-h-24 flex-col gap-1 border-b border-l p-1 [&:nth-child(7n+1)]:border-l-0',
-                editable && 'cursor-pointer hover:bg-accent/50',
-              )}
-              onClick={selectSlot}
-            >
-              <span className={cn('text-xs', !isSameMonth(day, date) && 'text-muted-foreground')}>
-                {format(day, 'd')}
-              </span>
-              {visible.map((item) => (
-                <button
-                  type='button'
-                  key={getId(item)}
-                  className={cn('w-full truncate rounded px-1 py-0.5 text-left text-xs', colorClasses(color?.(item)))}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onEventClick?.(item);
-                  }}
-                >
-                  {getTitle(item)}
-                </button>
-              ))}
-              {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>+{overflow} more</span> : null}
-            </div>
+              day={day}
+              date={date}
+              visible={visible}
+              overflow={overflow}
+              getId={getId}
+              getTitle={getTitle}
+              color={color}
+              draggedRef={draggedRef}
+              onEventClick={onEventClick}
+              onSlotSelect={onSlotSelect}
+            />
+          ) : (
+            <PlainMonthCell
+              key={day.toISOString()}
+              day={day}
+              date={date}
+              visible={visible}
+              overflow={overflow}
+              getId={getId}
+              getTitle={getTitle}
+              color={color}
+              onEventClick={onEventClick}
+            />
           );
         })}
       </div>

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import type * as React from 'react';
+import { addDays, addMonths, endOfWeek, format, startOfDay, startOfWeek } from 'date-fns';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
 export type CalendarView = 'month' | 'week' | 'day' | 'agenda';
@@ -36,6 +40,161 @@ export type CalendarProps<T extends Record<string, unknown>> = {
   className?: string;
 };
 
+function useControllableState<V>(
+  controlled: V | undefined,
+  defaultValue: V,
+  onChange?: (v: V) => void,
+): [V, (v: V) => void] {
+  const [uncontrolled, setUncontrolled] = React.useState<V>(defaultValue);
+  const isControlled = controlled !== undefined;
+  const value = isControlled ? controlled : uncontrolled;
+  const setValue = React.useCallback(
+    (next: V) => {
+      if (!isControlled) setUncontrolled(next);
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+  return [value, setValue];
+}
+
 export function Calendar<T extends Record<string, unknown>>(props: CalendarProps<T>) {
-  return <div className={cn('flex flex-col gap-4', props.className)}>calendar</div>;
+  const {
+    events,
+    defaultEvents = [] as T[],
+    onEventsChange,
+    idField = 'id' as keyof T,
+    titleField,
+    startField,
+    endField,
+    allDayField,
+    color,
+    renderEvent,
+    view: viewProp,
+    defaultView = 'month',
+    onViewChange,
+    date: dateProp,
+    defaultDate,
+    onDateChange,
+    views = ['month', 'week', 'day', 'agenda'] as CalendarView[],
+    weekStartsOn = 1,
+    editable = false,
+    onEventClick,
+    onSlotSelect,
+    className,
+  } = props;
+
+  const [view, setView] = useControllableState<CalendarView>(viewProp, defaultView, onViewChange);
+  const [date, setDate] = useControllableState<Date>(dateProp, defaultDate ?? startOfDay(new Date()), onDateChange);
+
+  const periodLabel = React.useMemo(() => {
+    switch (view) {
+      case 'month':
+        return format(date, 'MMMM yyyy');
+      case 'week': {
+        const weekStart = startOfWeek(date, { weekStartsOn });
+        const weekEnd = endOfWeek(date, { weekStartsOn });
+        return `${format(weekStart, 'MMM d')} – ${format(weekEnd, 'MMM d, yyyy')}`;
+      }
+      case 'day':
+        return format(date, 'PPP');
+      case 'agenda':
+        return format(date, 'MMMM yyyy');
+    }
+  }, [view, date, weekStartsOn]);
+
+  const shift = React.useCallback(
+    (dir: 1 | -1) => {
+      switch (view) {
+        case 'month':
+          setDate(addMonths(date, dir));
+          break;
+        case 'week':
+          setDate(addDays(date, 7 * dir));
+          break;
+        case 'day':
+        case 'agenda':
+          setDate(addDays(date, dir));
+          break;
+      }
+    },
+    [view, date, setDate],
+  );
+
+  const onToday = React.useCallback(() => setDate(startOfDay(new Date())), [setDate]);
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      <CalendarToolbar
+        label={periodLabel}
+        views={views}
+        view={view}
+        onView={setView}
+        onToday={onToday}
+        onPrev={() => shift(-1)}
+        onNext={() => shift(1)}
+      />
+      {(() => {
+        switch (view) {
+          case 'month':
+            return null;
+          case 'week':
+            return null;
+          case 'day':
+            return null;
+          case 'agenda':
+            return null;
+        }
+      })()}
+    </div>
+  );
+}
+
+function CalendarToolbar({
+  label,
+  views,
+  view,
+  onView,
+  onToday,
+  onPrev,
+  onNext,
+}: {
+  label: string;
+  views: CalendarView[];
+  view: CalendarView;
+  onView: (v: CalendarView) => void;
+  onToday: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div className='flex flex-wrap items-center justify-between gap-2'>
+      <div className='flex items-center gap-1'>
+        <Button variant='outline' size='sm' onClick={onToday}>
+          Today
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={onPrev} aria-label='Previous'>
+          <ChevronLeft className='size-4' />
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={onNext} aria-label='Next'>
+          <ChevronRight className='size-4' />
+        </Button>
+        <span className='ml-2 text-sm font-medium'>{label}</span>
+      </div>
+      {views.length > 1 ? (
+        <Select value={view} onValueChange={(v) => onView(v as CalendarView)}>
+          <SelectTrigger className='w-32' size='sm'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {views.map((v) => (
+              <SelectItem key={v} value={v}>
+                {v[0].toUpperCase() + v.slice(1)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : null}
+    </div>
+  );
 }

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -101,6 +101,8 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
   const [items] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
 
   const getStart = React.useCallback((it: T) => it[startField] as unknown as Date, [startField]);
+  const getEnd = React.useCallback((it: T) => it[endField] as unknown as Date, [endField]);
+  const isAllDay = React.useCallback((it: T) => (allDayField ? Boolean(it[allDayField]) : false), [allDayField]);
   const getId = React.useCallback((it: T) => String(it[idField]), [idField]);
   const getTitle = React.useCallback((it: T) => String(it[titleField] ?? ''), [titleField]);
 
@@ -140,6 +142,11 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
 
   const onToday = React.useCallback(() => setDate(startOfDay(new Date())), [setDate]);
 
+  const weekDays = React.useMemo(
+    () => eachDayOfInterval({ start: startOfWeek(date, { weekStartsOn }), end: endOfWeek(date, { weekStartsOn }) }),
+    [date, weekStartsOn],
+  );
+
   return (
     <div className={cn('flex flex-col gap-4', className)}>
       <CalendarToolbar
@@ -169,9 +176,37 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
               />
             );
           case 'week':
-            return null;
+            return (
+              <TimeGridView
+                days={weekDays}
+                items={items}
+                getStart={getStart}
+                getEnd={getEnd}
+                getId={getId}
+                getTitle={getTitle}
+                isAllDay={isAllDay}
+                color={color}
+                editable={editable}
+                onEventClick={onEventClick}
+                onSlotSelect={onSlotSelect}
+              />
+            );
           case 'day':
-            return null;
+            return (
+              <TimeGridView
+                days={[date]}
+                items={items}
+                getStart={getStart}
+                getEnd={getEnd}
+                getId={getId}
+                getTitle={getTitle}
+                isAllDay={isAllDay}
+                color={color}
+                editable={editable}
+                onEventClick={onEventClick}
+                onSlotSelect={onSlotSelect}
+              />
+            );
           case 'agenda':
             return null;
         }
@@ -199,6 +234,181 @@ function colorClasses(c?: CalendarEventColor): string {
     default:
       return 'bg-primary text-primary-foreground';
   }
+}
+
+const HOUR_HEIGHT = 48;
+
+function minutesSinceDayStart(date: Date): number {
+  return date.getHours() * 60 + date.getMinutes();
+}
+function eventTop(start: Date): number {
+  return (minutesSinceDayStart(start) / 60) * HOUR_HEIGHT;
+}
+function eventHeight(start: Date, end: Date): number {
+  const mins = Math.max(15, (end.getTime() - start.getTime()) / 60_000);
+  return (mins / 60) * HOUR_HEIGHT;
+}
+
+type LaidOut<T> = { item: T; col: number; cols: number };
+
+function layoutDay<T>(dayEvents: T[], getStart: (t: T) => Date, getEnd: (t: T) => Date): LaidOut<T>[] {
+  const sorted = [...dayEvents].sort((a, b) => getStart(a).getTime() - getStart(b).getTime());
+  const colEnds: number[] = [];
+  const placed = sorted.map((item) => {
+    const s = getStart(item).getTime();
+    let col = colEnds.findIndex((end) => end <= s);
+    if (col === -1) {
+      col = colEnds.length;
+      colEnds.push(0);
+    }
+    colEnds[col] = getEnd(item).getTime();
+    return { item, col };
+  });
+  const cols = Math.max(1, colEnds.length);
+  return placed.map((p) => ({ ...p, cols }));
+}
+
+function EventBlock({
+  title,
+  start,
+  end,
+  laidOut,
+  color,
+  onClick,
+}: {
+  title: string;
+  start: Date;
+  end: Date;
+  laidOut: { col: number; cols: number };
+  color?: CalendarEventColor;
+  onClick?: () => void;
+}) {
+  const widthPct = 100 / laidOut.cols;
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      style={{
+        top: eventTop(start),
+        height: eventHeight(start, end),
+        left: `${laidOut.col * widthPct}%`,
+        width: `calc(${widthPct}% - 2px)`,
+      }}
+      className={cn('absolute z-10 overflow-hidden rounded px-1 py-0.5 text-left text-xs', colorClasses(color))}
+    >
+      <span className='block truncate font-medium'>{title}</span>
+      <span className='block truncate opacity-80'>
+        {format(start, 'HH:mm')} – {format(end, 'HH:mm')}
+      </span>
+    </button>
+  );
+}
+
+const HOURS = Array.from({ length: 24 }, (_, h) => h);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function TimeGridView<T extends Record<string, unknown>>({
+  days,
+  items,
+  getStart,
+  getEnd,
+  getId,
+  getTitle,
+  isAllDay,
+  color,
+  editable,
+  onEventClick,
+}: {
+  days: Date[];
+  items: T[];
+  getStart: (item: T) => Date;
+  getEnd: (item: T) => Date;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  isAllDay: (item: T) => boolean;
+  color?: (item: T) => CalendarEventColor | undefined;
+  editable: boolean;
+  onEventClick?: (item: T) => void;
+  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+}) {
+  const spansAllDay = React.useCallback(
+    (item: T) => isAllDay(item) || getEnd(item).getTime() - getStart(item).getTime() >= DAY_MS,
+    [isAllDay, getEnd, getStart],
+  );
+
+  return (
+    <div className='overflow-hidden rounded-md border'>
+      <div className='flex border-b'>
+        <div className='w-14 shrink-0 border-r' />
+        {days.map((day) => (
+          <div key={day.toISOString()} className='flex-1 border-l p-2 text-center text-xs font-medium first:border-l-0'>
+            {format(day, 'EEE d')}
+          </div>
+        ))}
+      </div>
+
+      <div className='flex border-b'>
+        <div className='flex w-14 shrink-0 items-center justify-center border-r py-1 text-xs text-muted-foreground'>
+          all-day
+        </div>
+        {days.map((day) => {
+          const allDayEvents = items.filter((item) => spansAllDay(item) && isSameDay(getStart(item), day));
+          return (
+            <div key={day.toISOString()} className='flex flex-1 flex-col gap-1 border-l p-1 first:border-l-0'>
+              {allDayEvents.map((item) => (
+                <button
+                  type='button'
+                  key={getId(item)}
+                  onClick={() => onEventClick?.(item)}
+                  className={cn('w-full truncate rounded px-1 py-0.5 text-left text-xs', colorClasses(color?.(item)))}
+                >
+                  {getTitle(item)}
+                </button>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className='relative max-h-[600px] overflow-y-auto'>
+        <div className='flex'>
+          <div className='w-14 shrink-0 border-r'>
+            {HOURS.map((h) => (
+              <div key={h} className='h-12 pr-1 text-right text-xs text-muted-foreground'>
+                {`${String(h).padStart(2, '0')}:00`}
+              </div>
+            ))}
+          </div>
+          {days.map((day) => {
+            const timed = items.filter((item) => !spansAllDay(item) && isSameDay(getStart(item), day));
+            const laidOut = layoutDay(timed, getStart, getEnd);
+            return (
+              <div
+                key={day.toISOString()}
+                className={cn('relative flex-1 border-l first:border-l-0', editable && 'cursor-pointer')}
+                style={{ height: 24 * HOUR_HEIGHT }}
+              >
+                {HOURS.map((h) => (
+                  <div key={h} className='h-12 border-t first:border-t-0' />
+                ))}
+                {laidOut.map((entry) => (
+                  <EventBlock
+                    key={getId(entry.item)}
+                    title={getTitle(entry.item)}
+                    start={getStart(entry.item)}
+                    end={getEnd(entry.item)}
+                    laidOut={entry}
+                    color={color?.(entry.item)}
+                    onClick={() => onEventClick?.(entry.item)}
+                  />
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function MonthView<T extends Record<string, unknown>>({

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -147,6 +147,11 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
     [date, weekStartsOn],
   );
 
+  const agendaDays = React.useMemo(
+    () => eachDayOfInterval({ start: startOfDay(date), end: addDays(startOfDay(date), 29) }),
+    [date],
+  );
+
   return (
     <div className={cn('flex flex-col gap-4', className)}>
       <CalendarToolbar
@@ -208,7 +213,18 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
               />
             );
           case 'agenda':
-            return null;
+            return (
+              <AgendaView
+                days={agendaDays}
+                items={items}
+                getStart={getStart}
+                getEnd={getEnd}
+                getId={getId}
+                getTitle={getTitle}
+                color={color}
+                onEventClick={onEventClick}
+              />
+            );
         }
       })()}
     </div>
@@ -489,6 +505,63 @@ function MonthView<T extends Record<string, unknown>>({
           );
         })}
       </div>
+    </div>
+  );
+}
+
+function AgendaView<T extends Record<string, unknown>>({
+  days,
+  items,
+  getStart,
+  getEnd,
+  getId,
+  getTitle,
+  color,
+  onEventClick,
+}: {
+  days: Date[];
+  items: T[];
+  getStart: (item: T) => Date;
+  getEnd: (item: T) => Date;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  color?: (item: T) => CalendarEventColor | undefined;
+  onEventClick?: (item: T) => void;
+}) {
+  const groups = days
+    .map((day) => ({
+      day,
+      events: items
+        .filter((item) => isSameDay(getStart(item), day))
+        .sort((a, b) => getStart(a).getTime() - getStart(b).getTime()),
+    }))
+    .filter((group) => group.events.length > 0);
+
+  if (groups.length === 0) {
+    return <p className='text-sm text-muted-foreground'>No upcoming events</p>;
+  }
+
+  return (
+    <div className='flex max-h-[600px] flex-col gap-4 overflow-y-auto'>
+      {groups.map((group) => (
+        <div key={group.day.toISOString()} className='flex flex-col gap-1'>
+          <div className='text-sm font-medium'>{format(group.day, 'EEEE, MMM d')}</div>
+          {group.events.map((item) => (
+            <button
+              type='button'
+              key={getId(item)}
+              onClick={() => onEventClick?.(item)}
+              className='flex w-full items-center gap-2 text-left text-sm'
+            >
+              <span className={cn('size-2 rounded-full', colorClasses(color?.(item)))} />
+              <span className='text-muted-foreground'>
+                {format(getStart(item), 'HH:mm')} – {format(getEnd(item), 'HH:mm')}
+              </span>
+              <span>{getTitle(item)}</span>
+            </button>
+          ))}
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -10,6 +10,7 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
+import type { Locale } from 'date-fns';
 import {
   addDays,
   addMinutes,
@@ -35,6 +36,30 @@ import { cn } from '@/lib/utils';
 export type CalendarView = 'month' | 'week' | 'day' | 'agenda';
 export type CalendarEventColor = 'primary' | 'secondary' | 'accent' | 'destructive' | 'muted';
 export type CalendarSlot = { start: Date; end: Date; allDay: boolean };
+
+export type CalendarMessages = {
+  today: string;
+  previous: string;
+  next: string;
+  allDay: string;
+  noEvents: string;
+  more: (count: number) => string;
+  views: Record<CalendarView, string>;
+};
+
+export type CalendarMessagesInput = Partial<Omit<CalendarMessages, 'views'>> & {
+  views?: Partial<Record<CalendarView, string>>;
+};
+
+const defaultMessages: CalendarMessages = {
+  today: 'Today',
+  previous: 'Previous',
+  next: 'Next',
+  allDay: 'all-day',
+  noEvents: 'No upcoming events',
+  more: (count) => `+${count} more`,
+  views: { month: 'Month', week: 'Week', day: 'Day', agenda: 'Agenda' },
+};
 
 type CalendarEventLike = Record<string, unknown>;
 
@@ -63,6 +88,8 @@ export type CalendarRootProps<T extends CalendarEventLike> = {
   views?: CalendarView[];
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   editable?: boolean;
+  locale?: Locale;
+  messages?: CalendarMessagesInput;
 
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: CalendarSlot) => void;
@@ -78,6 +105,8 @@ type CalendarContextValue<T extends CalendarEventLike = CalendarEventLike> = {
   isMobile: boolean;
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   editable: boolean;
+  locale?: Locale;
+  messages: CalendarMessages;
   periodLabel: string;
   goToToday: () => void;
   goToPrevious: () => void;
@@ -160,9 +189,19 @@ function CalendarRoot<T extends CalendarEventLike>({
   views = ['month', 'week', 'day', 'agenda'],
   weekStartsOn = 1,
   editable = false,
+  locale,
+  messages: messagesProp,
   onEventClick,
   onSlotSelect,
 }: CalendarRootProps<T>) {
+  const messages = React.useMemo<CalendarMessages>(
+    () => ({
+      ...defaultMessages,
+      ...messagesProp,
+      views: { ...defaultMessages.views, ...messagesProp?.views },
+    }),
+    [messagesProp],
+  );
   const [view, setView] = useControllableState<CalendarView>(viewProp, defaultView, onViewChange);
   const [date, setDate] = useControllableState<Date>(dateProp, defaultDate ?? startOfDay(new Date()), onDateChange);
   const [items, setItems] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
@@ -220,18 +259,18 @@ function CalendarRoot<T extends CalendarEventLike>({
   const periodLabel = React.useMemo(() => {
     switch (effectiveView) {
       case 'month':
-        return format(date, 'MMMM yyyy');
+        return format(date, 'MMMM yyyy', { locale });
       case 'week': {
         const weekStart = startOfWeek(date, { weekStartsOn });
         const weekEnd = endOfWeek(date, { weekStartsOn });
-        return `${format(weekStart, 'MMM d')} – ${format(weekEnd, 'MMM d, yyyy')}`;
+        return `${format(weekStart, 'MMM d', { locale })} – ${format(weekEnd, 'MMM d, yyyy', { locale })}`;
       }
       case 'day':
-        return format(date, 'PPP');
+        return format(date, 'PPP', { locale });
       case 'agenda':
-        return format(date, 'MMMM yyyy');
+        return format(date, 'MMMM yyyy', { locale });
     }
-  }, [effectiveView, date, weekStartsOn]);
+  }, [effectiveView, date, weekStartsOn, locale]);
 
   const shift = React.useCallback(
     (dir: 1 | -1) => {
@@ -264,6 +303,8 @@ function CalendarRoot<T extends CalendarEventLike>({
       isMobile,
       weekStartsOn,
       editable,
+      locale,
+      messages,
       periodLabel,
       goToToday,
       goToPrevious,
@@ -291,6 +332,8 @@ function CalendarRoot<T extends CalendarEventLike>({
       isMobile,
       weekStartsOn,
       editable,
+      locale,
+      messages,
       periodLabel,
       goToToday,
       goToPrevious,
@@ -323,17 +366,17 @@ function CalendarRoot<T extends CalendarEventLike>({
 }
 
 function CalendarNav({ className }: { className?: string }) {
-  const { periodLabel, views, view, setView, goToToday, goToPrevious, goToNext } = useCalendar();
+  const { periodLabel, views, view, setView, goToToday, goToPrevious, goToNext, messages } = useCalendar();
   return (
     <div className={cn('flex w-full flex-wrap items-center justify-between gap-2', className)}>
       <div className='flex items-center gap-1'>
         <Button variant='outline' size='sm' onClick={goToToday}>
-          Today
+          {messages.today}
         </Button>
-        <Button variant='outline' size='icon' className='size-8' onClick={goToPrevious} aria-label='Previous'>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToPrevious} aria-label={messages.previous}>
           <ChevronLeft className='size-4' />
         </Button>
-        <Button variant='outline' size='icon' className='size-8' onClick={goToNext} aria-label='Next'>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToNext} aria-label={messages.next}>
           <ChevronRight className='size-4' />
         </Button>
         <span className='ml-2 text-sm font-medium'>{periodLabel}</span>
@@ -346,7 +389,7 @@ function CalendarNav({ className }: { className?: string }) {
           <SelectContent>
             {views.map((v) => (
               <SelectItem key={v} value={v}>
-                {v[0].toUpperCase() + v.slice(1)}
+                {messages.views[v]}
               </SelectItem>
             ))}
           </SelectContent>
@@ -374,6 +417,8 @@ function CalendarViewComponent({ className }: { className?: string }) {
     resizeEvent,
     onEventClick,
     onSlotSelect,
+    locale,
+    messages,
   } = useCalendar();
 
   const weekDays = React.useMemo(
@@ -403,6 +448,8 @@ function CalendarViewComponent({ className }: { className?: string }) {
             draggedRef={draggedRef}
             onEventClick={onEventClick}
             onSlotSelect={onSlotSelect}
+            locale={locale}
+            more={messages.more}
           />
         );
       case 'week':
@@ -423,6 +470,8 @@ function CalendarViewComponent({ className }: { className?: string }) {
             onResize={editable ? resizeEvent : undefined}
             onEventClick={onEventClick}
             onSlotSelect={onSlotSelect}
+            locale={locale}
+            allDayLabel={messages.allDay}
           />
         );
       case 'agenda':
@@ -437,6 +486,8 @@ function CalendarViewComponent({ className }: { className?: string }) {
             color={getColor}
             renderEvent={renderEvent}
             onEventClick={onEventClick}
+            locale={locale}
+            noEventsLabel={messages.noEvents}
           />
         );
     }
@@ -917,6 +968,8 @@ function TimeGridView<T extends Record<string, unknown>>({
   onResize,
   onEventClick,
   onSlotSelect: selectSlot,
+  locale,
+  allDayLabel,
 }: {
   days: Date[];
   items: T[];
@@ -932,6 +985,8 @@ function TimeGridView<T extends Record<string, unknown>>({
   onResize?: (id: string, end: Date) => void;
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: CalendarSlot) => void;
+  locale?: Locale;
+  allDayLabel: string;
 }) {
   const [resizing, setResizing] = React.useState<{ id: string; end: Date } | null>(null);
   const [creating, setCreating] = React.useState<Creating | null>(null);
@@ -952,14 +1007,14 @@ function TimeGridView<T extends Record<string, unknown>>({
                 key={day.toISOString()}
                 className='flex-1 border-l p-2 text-center text-xs font-medium first:border-l-0'
               >
-                {format(day, 'EEE d')}
+                {format(day, 'EEE d', { locale })}
               </div>
             ))}
           </div>
 
           <div className='flex border-b'>
             <div className='flex w-14 shrink-0 items-center justify-center border-r py-1 text-xs text-muted-foreground'>
-              all-day
+              {allDayLabel}
             </div>
             {days.map((day) => {
               const allDayEvents = items.filter((item) => spansAllDay(item) && isSameDay(getStart(item), day));
@@ -1084,6 +1139,7 @@ function MonthCell<T extends Record<string, unknown>>({
   draggedRef,
   onEventClick,
   onSlotSelect,
+  more,
 }: {
   day: Date;
   date: Date;
@@ -1096,6 +1152,7 @@ function MonthCell<T extends Record<string, unknown>>({
   draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: CalendarSlot) => void;
+  more: (count: number) => string;
 }) {
   const { setNodeRef } = useDroppable({ id: `cell-${day.toISOString()}`, data: { day } });
   return (
@@ -1117,7 +1174,7 @@ function MonthCell<T extends Record<string, unknown>>({
           onEventClick={onEventClick}
         />
       ))}
-      {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>+{overflow} more</span> : null}
+      {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>{more(overflow)}</span> : null}
     </div>
   );
 }
@@ -1132,6 +1189,7 @@ function PlainMonthCell<T extends Record<string, unknown>>({
   color,
   renderEvent,
   onEventClick,
+  more,
 }: {
   day: Date;
   date: Date;
@@ -1142,6 +1200,7 @@ function PlainMonthCell<T extends Record<string, unknown>>({
   color?: (item: T) => CalendarEventColor | undefined;
   renderEvent?: (item: T) => React.ReactNode;
   onEventClick?: (item: T) => void;
+  more: (count: number) => string;
 }) {
   return (
     <div className='flex min-h-24 flex-col gap-1 border-b border-l p-1 [&:nth-child(7n+1)]:border-l-0'>
@@ -1156,7 +1215,7 @@ function PlainMonthCell<T extends Record<string, unknown>>({
           {renderEvent ? renderEvent(item) : getTitle(item)}
         </button>
       ))}
-      {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>+{overflow} more</span> : null}
+      {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>{more(overflow)}</span> : null}
     </div>
   );
 }
@@ -1174,6 +1233,8 @@ function MonthView<T extends Record<string, unknown>>({
   draggedRef,
   onEventClick,
   onSlotSelect,
+  locale,
+  more,
 }: {
   date: Date;
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
@@ -1187,9 +1248,11 @@ function MonthView<T extends Record<string, unknown>>({
   draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: CalendarSlot) => void;
+  locale?: Locale;
+  more: (count: number) => string;
 }) {
   const days = monthGrid(date, weekStartsOn);
-  const weekdayLabels = days.slice(0, 7).map((day) => format(day, 'EEE'));
+  const weekdayLabels = days.slice(0, 7).map((day) => format(day, 'EEE', { locale }));
 
   return (
     <div className='w-full overflow-hidden rounded-md border'>
@@ -1223,6 +1286,7 @@ function MonthView<T extends Record<string, unknown>>({
               draggedRef={draggedRef}
               onEventClick={onEventClick}
               onSlotSelect={onSlotSelect}
+              more={more}
             />
           ) : (
             <PlainMonthCell
@@ -1236,6 +1300,7 @@ function MonthView<T extends Record<string, unknown>>({
               color={color}
               renderEvent={renderEvent}
               onEventClick={onEventClick}
+              more={more}
             />
           );
         })}
@@ -1254,6 +1319,8 @@ function AgendaView<T extends Record<string, unknown>>({
   color,
   renderEvent,
   onEventClick,
+  locale,
+  noEventsLabel,
 }: {
   days: Date[];
   items: T[];
@@ -1264,6 +1331,8 @@ function AgendaView<T extends Record<string, unknown>>({
   color?: (item: T) => CalendarEventColor | undefined;
   renderEvent?: (item: T) => React.ReactNode;
   onEventClick?: (item: T) => void;
+  locale?: Locale;
+  noEventsLabel: string;
 }) {
   const groups = days
     .map((day) => ({
@@ -1275,14 +1344,14 @@ function AgendaView<T extends Record<string, unknown>>({
     .filter((group) => group.events.length > 0);
 
   if (groups.length === 0) {
-    return <p className='w-full text-sm text-muted-foreground'>No upcoming events</p>;
+    return <p className='w-full text-sm text-muted-foreground'>{noEventsLabel}</p>;
   }
 
   return (
     <div className='flex max-h-[600px] w-full flex-col gap-4 overflow-y-auto'>
       {groups.map((group) => (
         <div key={group.day.toISOString()} className='flex flex-col gap-1'>
-          <div className='text-sm font-medium'>{format(group.day, 'EEEE, MMM d')}</div>
+          <div className='text-sm font-medium'>{format(group.day, 'EEEE, MMM d', { locale })}</div>
           {group.events.map((item) => (
             <button
               type='button'

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -100,7 +100,7 @@ type CalendarContextValue<T extends CalendarEventLike = CalendarEventLike> = {
 const CalendarContext = React.createContext<CalendarContextValue | null>(null);
 
 export function useCalendar<T extends CalendarEventLike = CalendarEventLike>(): CalendarContextValue<T> {
-  const ctx = React.useContext(CalendarContext);
+  const ctx = React.use(CalendarContext);
   if (!ctx) throw new Error('useCalendar must be used within <Calendar.Root>');
   return ctx as CalendarContextValue<T>;
 }

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -171,6 +171,13 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
     [items, getId, getStart, getEnd, effectiveView, startField, endField, setItems],
   );
 
+  const handleResize = React.useCallback(
+    (id: string, newEnd: Date) => {
+      setItems(items.map((it) => (getId(it) === id ? ({ ...it, [endField]: newEnd } as T) : it)));
+    },
+    [items, getId, endField, setItems],
+  );
+
   const periodLabel = React.useMemo(() => {
     switch (effectiveView) {
       case 'month':
@@ -248,6 +255,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             color={color}
             editable={editable}
             draggedRef={draggedRef}
+            onResize={editable ? handleResize : undefined}
             onEventClick={onEventClick}
             onSlotSelect={onSlotSelect}
           />
@@ -265,6 +273,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             color={color}
             editable={editable}
             draggedRef={draggedRef}
+            onResize={editable ? handleResize : undefined}
             onEventClick={onEventClick}
             onSlotSelect={onSlotSelect}
           />
@@ -421,19 +430,25 @@ function DraggableEventBlock({
   title,
   start,
   end,
+  realEnd,
   laidOut,
   color,
   draggedRef,
   onClick,
+  onResize,
+  onPreview,
 }: {
   id: string;
   title: string;
   start: Date;
   end: Date;
+  realEnd: Date;
   laidOut: { col: number; cols: number };
   color?: CalendarEventColor;
   draggedRef: React.MutableRefObject<boolean>;
   onClick?: () => void;
+  onResize?: (id: string, end: Date) => void;
+  onPreview: (end: Date | null) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id });
   return (
@@ -458,8 +473,61 @@ function DraggableEventBlock({
       className={cn(eventBlockClass, colorClasses(color))}
     >
       <EventBlockContent title={title} start={start} end={end} />
+      <ResizeHandle id={id} start={start} end={realEnd} onResize={onResize} onPreview={onPreview} />
     </button>
   );
+}
+
+function ResizeHandle({
+  id,
+  start,
+  end,
+  onResize,
+  onPreview,
+}: {
+  id: string;
+  start: Date;
+  end: Date;
+  onResize?: (id: string, end: Date) => void;
+  onPreview: (end: Date | null) => void;
+}) {
+  const handlePointerDown = (e: React.PointerEvent<HTMLSpanElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const target = e.target as HTMLElement;
+    target.setPointerCapture(e.pointerId);
+
+    const startY = e.clientY;
+    const originalEnd = end;
+    const minEnd = new Date(start.getTime() + SNAP_MINUTES * 60_000);
+    let finalEnd = originalEnd;
+
+    const compute = (clientY: number) => {
+      const deltaMin = ((clientY - startY) / HOUR_HEIGHT) * 60;
+      let proposed = snapToMinutes(new Date(originalEnd.getTime() + deltaMin * 60_000));
+      if (proposed.getTime() - start.getTime() < SNAP_MINUTES * 60_000) proposed = minEnd;
+      return proposed;
+    };
+
+    const onMove = (moveE: PointerEvent) => {
+      finalEnd = compute(moveE.clientY);
+      onPreview(finalEnd);
+    };
+
+    const onUp = (upE: PointerEvent) => {
+      finalEnd = compute(upE.clientY);
+      target.releasePointerCapture(e.pointerId);
+      target.removeEventListener('pointermove', onMove);
+      target.removeEventListener('pointerup', onUp);
+      onResize?.(id, finalEnd);
+      onPreview(null);
+    };
+
+    target.addEventListener('pointermove', onMove);
+    target.addEventListener('pointerup', onUp);
+  };
+
+  return <span className='absolute inset-x-0 bottom-0 z-20 h-1.5 cursor-ns-resize' onPointerDown={handlePointerDown} />;
 }
 
 const HOURS = Array.from({ length: 24 }, (_, h) => h);
@@ -474,6 +542,9 @@ function DayColumnContent<T extends Record<string, unknown>>({
   color,
   editable,
   draggedRef,
+  resizing,
+  onResize,
+  onPreview,
   onEventClick,
 }: {
   laidOut: LaidOut<T>[];
@@ -484,6 +555,9 @@ function DayColumnContent<T extends Record<string, unknown>>({
   color?: (item: T) => CalendarEventColor | undefined;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
+  resizing: { id: string; end: Date } | null;
+  onResize?: (id: string, end: Date) => void;
+  onPreview: (preview: { id: string; end: Date } | null) => void;
   onEventClick?: (item: T) => void;
 }) {
   return (
@@ -491,31 +565,38 @@ function DayColumnContent<T extends Record<string, unknown>>({
       {HOURS.map((h) => (
         <div key={h} className='h-12 border-t first:border-t-0' />
       ))}
-      {laidOut.map((entry) =>
-        editable ? (
+      {laidOut.map((entry) => {
+        const id = getId(entry.item);
+        const start = getStart(entry.item);
+        const realEnd = getEnd(entry.item);
+        const shownEnd = resizing?.id === id ? resizing.end : realEnd;
+        return editable ? (
           <DraggableEventBlock
-            key={getId(entry.item)}
-            id={getId(entry.item)}
+            key={id}
+            id={id}
             title={getTitle(entry.item)}
-            start={getStart(entry.item)}
-            end={getEnd(entry.item)}
+            start={start}
+            end={shownEnd}
+            realEnd={realEnd}
             laidOut={entry}
             color={color?.(entry.item)}
             draggedRef={draggedRef}
             onClick={() => onEventClick?.(entry.item)}
+            onResize={onResize}
+            onPreview={(end) => onPreview(end ? { id, end } : null)}
           />
         ) : (
           <EventBlock
-            key={getId(entry.item)}
+            key={id}
             title={getTitle(entry.item)}
-            start={getStart(entry.item)}
-            end={getEnd(entry.item)}
+            start={start}
+            end={realEnd}
             laidOut={entry}
             color={color?.(entry.item)}
             onClick={() => onEventClick?.(entry.item)}
           />
-        ),
-      )}
+        );
+      })}
     </>
   );
 }
@@ -535,6 +616,9 @@ function DroppableDayColumn<T extends Record<string, unknown>>({
   color?: (item: T) => CalendarEventColor | undefined;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
+  resizing: { id: string; end: Date } | null;
+  onResize?: (id: string, end: Date) => void;
+  onPreview: (preview: { id: string; end: Date } | null) => void;
   onEventClick?: (item: T) => void;
 }) {
   const { setNodeRef } = useDroppable({ id: `col-${day.toISOString()}`, data: { day } });
@@ -554,6 +638,9 @@ function PlainDayColumn<T extends Record<string, unknown>>(content: {
   color?: (item: T) => CalendarEventColor | undefined;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
+  resizing: { id: string; end: Date } | null;
+  onResize?: (id: string, end: Date) => void;
+  onPreview: (preview: { id: string; end: Date } | null) => void;
   onEventClick?: (item: T) => void;
 }) {
   return (
@@ -574,6 +661,7 @@ function TimeGridView<T extends Record<string, unknown>>({
   color,
   editable,
   draggedRef,
+  onResize,
   onEventClick,
 }: {
   days: Date[];
@@ -586,9 +674,12 @@ function TimeGridView<T extends Record<string, unknown>>({
   color?: (item: T) => CalendarEventColor | undefined;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
+  onResize?: (id: string, end: Date) => void;
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
 }) {
+  const [resizing, setResizing] = React.useState<{ id: string; end: Date } | null>(null);
+
   const spansAllDay = React.useCallback(
     (item: T) => isAllDay(item) || getEnd(item).getTime() - getStart(item).getTime() >= DAY_MS,
     [isAllDay, getEnd, getStart],
@@ -649,6 +740,9 @@ function TimeGridView<T extends Record<string, unknown>>({
               color,
               editable,
               draggedRef,
+              resizing,
+              onResize,
+              onPreview: setResizing,
               onEventClick,
             };
             return editable ? (

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import type * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type CalendarView = 'month' | 'week' | 'day' | 'agenda';
+export type CalendarEventColor = 'primary' | 'blue' | 'green' | 'red' | 'amber';
+
+export type CalendarProps<T extends Record<string, unknown>> = {
+  events?: T[];
+  defaultEvents?: T[];
+  onEventsChange?: (next: T[]) => void;
+
+  idField?: keyof T;
+  titleField: keyof T;
+  startField: keyof T;
+  endField: keyof T;
+  allDayField?: keyof T;
+  color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
+
+  view?: CalendarView;
+  defaultView?: CalendarView;
+  onViewChange?: (v: CalendarView) => void;
+  date?: Date;
+  defaultDate?: Date;
+  onDateChange?: (d: Date) => void;
+
+  views?: CalendarView[];
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  editable?: boolean;
+
+  onEventClick?: (item: T) => void;
+  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+
+  className?: string;
+};
+
+export function Calendar<T extends Record<string, unknown>>(props: CalendarProps<T>) {
+  return <div className={cn('flex flex-col gap-4', props.className)}>calendar</div>;
+}

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -70,6 +70,22 @@ function useControllableState<V>(
   return [value, setValue];
 }
 
+function useIsMobile(breakpoint = 768): boolean {
+  const subscribe = React.useCallback(
+    (cb: () => void) => {
+      const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+      mql.addEventListener('change', cb);
+      return () => mql.removeEventListener('change', cb);
+    },
+    [breakpoint],
+  );
+  const getSnapshot = React.useCallback(
+    () => window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches,
+    [breakpoint],
+  );
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+
 export function Calendar<T extends Record<string, unknown>>(props: CalendarProps<T>) {
   const {
     events,
@@ -100,6 +116,9 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
   const [date, setDate] = useControllableState<Date>(dateProp, defaultDate ?? startOfDay(new Date()), onDateChange);
   const [items] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
 
+  const isMobile = useIsMobile();
+  const effectiveView = isMobile && view === 'week' ? 'day' : view;
+
   const getStart = React.useCallback((it: T) => it[startField] as unknown as Date, [startField]);
   const getEnd = React.useCallback((it: T) => it[endField] as unknown as Date, [endField]);
   const isAllDay = React.useCallback((it: T) => (allDayField ? Boolean(it[allDayField]) : false), [allDayField]);
@@ -107,7 +126,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
   const getTitle = React.useCallback((it: T) => String(it[titleField] ?? ''), [titleField]);
 
   const periodLabel = React.useMemo(() => {
-    switch (view) {
+    switch (effectiveView) {
       case 'month':
         return format(date, 'MMMM yyyy');
       case 'week': {
@@ -120,11 +139,11 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
       case 'agenda':
         return format(date, 'MMMM yyyy');
     }
-  }, [view, date, weekStartsOn]);
+  }, [effectiveView, date, weekStartsOn]);
 
   const shift = React.useCallback(
     (dir: 1 | -1) => {
-      switch (view) {
+      switch (effectiveView) {
         case 'month':
           setDate(addMonths(date, dir));
           break;
@@ -137,7 +156,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
           break;
       }
     },
-    [view, date, setDate],
+    [effectiveView, date, setDate],
   );
 
   const onToday = React.useCallback(() => setDate(startOfDay(new Date())), [setDate]);
@@ -164,7 +183,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
         onNext={() => shift(1)}
       />
       {(() => {
-        switch (view) {
+        switch (effectiveView) {
           case 'month':
             return (
               <MonthView

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -996,6 +996,8 @@ function TimeGridView<T extends Record<string, unknown>>({
     [isAllDay, getEnd, getStart],
   );
 
+  const canCreateAllDay = editable && Boolean(selectSlot);
+
   return (
     <div className='w-full overflow-hidden rounded-md border'>
       <div className='max-h-[600px] overflow-y-auto'>
@@ -1019,12 +1021,26 @@ function TimeGridView<T extends Record<string, unknown>>({
             {days.map((day) => {
               const allDayEvents = items.filter((item) => spansAllDay(item) && isSameDay(getStart(item), day));
               return (
-                <div key={day.toISOString()} className='flex flex-1 flex-col gap-1 border-l p-1 first:border-l-0'>
+                <div
+                  key={day.toISOString()}
+                  className={cn(
+                    'flex min-h-7 flex-1 flex-col gap-1 border-l p-1 first:border-l-0',
+                    canCreateAllDay && 'cursor-pointer',
+                  )}
+                  onClick={
+                    canCreateAllDay
+                      ? () => selectSlot?.({ start: startOfDay(day), end: addDays(startOfDay(day), 1), allDay: true })
+                      : undefined
+                  }
+                >
                   {allDayEvents.map((item) => (
                     <button
                       type='button'
                       key={getId(item)}
-                      onClick={() => onEventClick?.(item)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onEventClick?.(item);
+                      }}
                       className={cn(
                         'w-full truncate rounded px-1 py-0.5 text-left text-xs',
                         colorClasses(color?.(item)),

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -1,6 +1,18 @@
 'use client';
 
-import { addDays, addMonths, endOfWeek, format, startOfDay, startOfWeek } from 'date-fns';
+import {
+  addDays,
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  isSameMonth,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '@/components/ui/button';
@@ -86,6 +98,11 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
 
   const [view, setView] = useControllableState<CalendarView>(viewProp, defaultView, onViewChange);
   const [date, setDate] = useControllableState<Date>(dateProp, defaultDate ?? startOfDay(new Date()), onDateChange);
+  const [items] = useControllableState<T[]>(events, defaultEvents, onEventsChange);
+
+  const getStart = React.useCallback((it: T) => it[startField] as unknown as Date, [startField]);
+  const getId = React.useCallback((it: T) => String(it[idField]), [idField]);
+  const getTitle = React.useCallback((it: T) => String(it[titleField] ?? ''), [titleField]);
 
   const periodLabel = React.useMemo(() => {
     switch (view) {
@@ -137,7 +154,20 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
       {(() => {
         switch (view) {
           case 'month':
-            return null;
+            return (
+              <MonthView
+                date={date}
+                weekStartsOn={weekStartsOn}
+                items={items}
+                getStart={getStart}
+                getId={getId}
+                getTitle={getTitle}
+                color={color}
+                editable={editable}
+                onEventClick={onEventClick}
+                onSlotSelect={onSlotSelect}
+              />
+            );
           case 'week':
             return null;
           case 'day':
@@ -146,6 +176,109 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             return null;
         }
       })()}
+    </div>
+  );
+}
+
+function monthGrid(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date[] {
+  const start = startOfWeek(startOfMonth(date), { weekStartsOn });
+  const end = endOfWeek(endOfMonth(date), { weekStartsOn });
+  return eachDayOfInterval({ start, end });
+}
+
+function colorClasses(c?: CalendarEventColor): string {
+  switch (c) {
+    case 'blue':
+      return 'bg-blue-500 text-white';
+    case 'green':
+      return 'bg-green-600 text-white';
+    case 'red':
+      return 'bg-red-500 text-white';
+    case 'amber':
+      return 'bg-amber-500 text-black';
+    default:
+      return 'bg-primary text-primary-foreground';
+  }
+}
+
+function MonthView<T extends Record<string, unknown>>({
+  date,
+  weekStartsOn,
+  items,
+  getStart,
+  getId,
+  getTitle,
+  color,
+  editable,
+  onEventClick,
+  onSlotSelect,
+}: {
+  date: Date;
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  items: T[];
+  getStart: (item: T) => Date;
+  getId: (item: T) => string;
+  getTitle: (item: T) => string;
+  color?: (item: T) => CalendarEventColor | undefined;
+  editable: boolean;
+  onEventClick?: (item: T) => void;
+  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
+}) {
+  const days = monthGrid(date, weekStartsOn);
+  const weekdayLabels = days.slice(0, 7).map((day) => format(day, 'EEE'));
+
+  return (
+    <div className='overflow-hidden rounded-md border'>
+      <div className='grid grid-cols-7'>
+        {weekdayLabels.map((label) => (
+          <div
+            key={label}
+            className='border-b border-l p-2 text-center text-xs font-medium text-muted-foreground first:border-l-0'
+          >
+            {label}
+          </div>
+        ))}
+        {days.map((day) => {
+          const dayEvents = items
+            .filter((item) => isSameDay(getStart(item), day))
+            .sort((a, b) => getStart(a).getTime() - getStart(b).getTime());
+          const visible = dayEvents.slice(0, 3);
+          const overflow = dayEvents.length - visible.length;
+
+          const selectSlot = editable
+            ? () => onSlotSelect?.({ start: startOfDay(day), end: addDays(startOfDay(day), 1), allDay: true })
+            : undefined;
+
+          return (
+            <div
+              key={day.toISOString()}
+              className={cn(
+                'flex min-h-24 flex-col gap-1 border-b border-l p-1 [&:nth-child(7n+1)]:border-l-0',
+                editable && 'cursor-pointer hover:bg-accent/50',
+              )}
+              onClick={selectSlot}
+            >
+              <span className={cn('text-xs', !isSameMonth(day, date) && 'text-muted-foreground')}>
+                {format(day, 'd')}
+              </span>
+              {visible.map((item) => (
+                <button
+                  type='button'
+                  key={getId(item)}
+                  className={cn('w-full truncate rounded px-1 py-0.5 text-left text-xs', colorClasses(color?.(item)))}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEventClick?.(item);
+                  }}
+                >
+                  {getTitle(item)}
+                </button>
+              ))}
+              {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>+{overflow} more</span> : null}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -236,6 +236,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             getId={getId}
             getTitle={getTitle}
             color={color}
+            renderEvent={renderEvent}
             editable={editable}
             draggedRef={draggedRef}
             onEventClick={onEventClick}
@@ -253,6 +254,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             getTitle={getTitle}
             isAllDay={isAllDay}
             color={color}
+            renderEvent={renderEvent}
             editable={editable}
             draggedRef={draggedRef}
             onResize={editable ? handleResize : undefined}
@@ -271,6 +273,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             getTitle={getTitle}
             isAllDay={isAllDay}
             color={color}
+            renderEvent={renderEvent}
             editable={editable}
             draggedRef={draggedRef}
             onResize={editable ? handleResize : undefined}
@@ -288,6 +291,7 @@ export function Calendar<T extends Record<string, unknown>>(props: CalendarProps
             getId={getId}
             getTitle={getTitle}
             color={color}
+            renderEvent={renderEvent}
             onEventClick={onEventClick}
           />
         );
@@ -392,7 +396,18 @@ function eventBlockStyle(start: Date, end: Date, laidOut: { col: number; cols: n
   };
 }
 
-function EventBlockContent({ title, start, end }: { title: string; start: Date; end: Date }) {
+function EventBlockContent({
+  title,
+  start,
+  end,
+  label,
+}: {
+  title: string;
+  start: Date;
+  end: Date;
+  label?: React.ReactNode;
+}) {
+  if (label !== undefined) return <>{label}</>;
   return (
     <>
       <span className='block truncate font-medium'>{title}</span>
@@ -409,6 +424,7 @@ function EventBlock({
   title,
   start,
   end,
+  label,
   laidOut,
   color,
   onClick,
@@ -416,6 +432,7 @@ function EventBlock({
   title: string;
   start: Date;
   end: Date;
+  label?: React.ReactNode;
   laidOut: { col: number; cols: number };
   color?: CalendarEventColor;
   onClick?: () => void;
@@ -428,7 +445,7 @@ function EventBlock({
       style={eventBlockStyle(start, end, laidOut)}
       className={cn(eventBlockClass, colorClasses(color))}
     >
-      <EventBlockContent title={title} start={start} end={end} />
+      <EventBlockContent title={title} start={start} end={end} label={label} />
     </button>
   );
 }
@@ -439,6 +456,7 @@ function DraggableEventBlock({
   start,
   end,
   realEnd,
+  label,
   laidOut,
   color,
   draggedRef,
@@ -451,6 +469,7 @@ function DraggableEventBlock({
   start: Date;
   end: Date;
   realEnd: Date;
+  label?: React.ReactNode;
   laidOut: { col: number; cols: number };
   color?: CalendarEventColor;
   draggedRef: React.MutableRefObject<boolean>;
@@ -481,7 +500,7 @@ function DraggableEventBlock({
       }}
       className={cn(eventBlockClass, colorClasses(color))}
     >
-      <EventBlockContent title={title} start={start} end={end} />
+      <EventBlockContent title={title} start={start} end={end} label={label} />
       <ResizeHandle id={id} start={start} end={realEnd} onResize={onResize} onPreview={onPreview} />
     </button>
   );
@@ -566,6 +585,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
   getId,
   getTitle,
   color,
+  renderEvent,
   editable,
   draggedRef,
   resizing,
@@ -580,6 +600,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
   getId: (item: T) => string;
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
   resizing: { id: string; end: Date } | null;
@@ -599,6 +620,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
         const start = getStart(entry.item);
         const realEnd = getEnd(entry.item);
         const shownEnd = resizing?.id === id ? resizing.end : realEnd;
+        const label = renderEvent ? renderEvent(entry.item) : undefined;
         return editable ? (
           <DraggableEventBlock
             key={id}
@@ -607,6 +629,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
             start={start}
             end={shownEnd}
             realEnd={realEnd}
+            label={label}
             laidOut={entry}
             color={color?.(entry.item)}
             draggedRef={draggedRef}
@@ -620,6 +643,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
             title={getTitle(entry.item)}
             start={start}
             end={realEnd}
+            label={label}
             laidOut={entry}
             color={color?.(entry.item)}
             onClick={() => onEventClick?.(entry.item)}
@@ -651,6 +675,7 @@ function DroppableDayColumn<T extends Record<string, unknown>>({
   getId: (item: T) => string;
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
   resizing: { id: string; end: Date } | null;
@@ -733,6 +758,7 @@ function PlainDayColumn<T extends Record<string, unknown>>(content: {
   getId: (item: T) => string;
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
   resizing: { id: string; end: Date } | null;
@@ -756,10 +782,12 @@ function TimeGridView<T extends Record<string, unknown>>({
   getTitle,
   isAllDay,
   color,
+  renderEvent,
   editable,
   draggedRef,
   onResize,
   onEventClick,
+  onSlotSelect: selectSlot,
 }: {
   days: Date[];
   items: T[];
@@ -769,6 +797,7 @@ function TimeGridView<T extends Record<string, unknown>>({
   getTitle: (item: T) => string;
   isAllDay: (item: T) => boolean;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
   onResize?: (id: string, end: Date) => void;
@@ -809,7 +838,7 @@ function TimeGridView<T extends Record<string, unknown>>({
                   onClick={() => onEventClick?.(item)}
                   className={cn('w-full truncate rounded px-1 py-0.5 text-left text-xs', colorClasses(color?.(item)))}
                 >
-                  {getTitle(item)}
+                  {renderEvent ? renderEvent(item) : getTitle(item)}
                 </button>
               ))}
             </div>
@@ -836,6 +865,7 @@ function TimeGridView<T extends Record<string, unknown>>({
               getId,
               getTitle,
               color,
+              renderEvent,
               editable,
               draggedRef,
               resizing,
@@ -850,7 +880,7 @@ function TimeGridView<T extends Record<string, unknown>>({
                 dayIndex={dayIndex}
                 creating={creating}
                 onCreatingChange={setCreating}
-                onSlotSelect={onSlotSelect}
+                onSlotSelect={selectSlot}
                 {...columnProps}
               />
             ) : (
@@ -869,6 +899,7 @@ function MonthEventPill<T>({
   item,
   id,
   title,
+  label,
   color,
   draggedRef,
   onEventClick,
@@ -876,6 +907,7 @@ function MonthEventPill<T>({
   item: T;
   id: string;
   title: string;
+  label?: React.ReactNode;
   color?: CalendarEventColor;
   draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
@@ -898,7 +930,7 @@ function MonthEventPill<T>({
       style={{ transform: CSS.Translate.toString(transform), zIndex: isDragging ? 40 : undefined, touchAction: 'none' }}
       className={cn(monthPillClass, colorClasses(color))}
     >
-      {title}
+      {label ?? title}
     </button>
   );
 }
@@ -911,6 +943,7 @@ function MonthCell<T extends Record<string, unknown>>({
   getId,
   getTitle,
   color,
+  renderEvent,
   draggedRef,
   onEventClick,
   onSlotSelect,
@@ -922,6 +955,7 @@ function MonthCell<T extends Record<string, unknown>>({
   getId: (item: T) => string;
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
   onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
@@ -940,6 +974,7 @@ function MonthCell<T extends Record<string, unknown>>({
           item={item}
           id={getId(item)}
           title={getTitle(item)}
+          label={renderEvent ? renderEvent(item) : undefined}
           color={color?.(item)}
           draggedRef={draggedRef}
           onEventClick={onEventClick}
@@ -958,6 +993,7 @@ function PlainMonthCell<T extends Record<string, unknown>>({
   getId,
   getTitle,
   color,
+  renderEvent,
   onEventClick,
 }: {
   day: Date;
@@ -967,6 +1003,7 @@ function PlainMonthCell<T extends Record<string, unknown>>({
   getId: (item: T) => string;
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   onEventClick?: (item: T) => void;
 }) {
   return (
@@ -979,7 +1016,7 @@ function PlainMonthCell<T extends Record<string, unknown>>({
           className={cn(monthPillClass, colorClasses(color?.(item)))}
           onClick={() => onEventClick?.(item)}
         >
-          {getTitle(item)}
+          {renderEvent ? renderEvent(item) : getTitle(item)}
         </button>
       ))}
       {overflow > 0 ? <span className='px-1 text-xs text-muted-foreground'>+{overflow} more</span> : null}
@@ -995,6 +1032,7 @@ function MonthView<T extends Record<string, unknown>>({
   getId,
   getTitle,
   color,
+  renderEvent,
   editable,
   draggedRef,
   onEventClick,
@@ -1007,6 +1045,7 @@ function MonthView<T extends Record<string, unknown>>({
   getId: (item: T) => string;
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
   onEventClick?: (item: T) => void;
@@ -1043,6 +1082,7 @@ function MonthView<T extends Record<string, unknown>>({
               getId={getId}
               getTitle={getTitle}
               color={color}
+              renderEvent={renderEvent}
               draggedRef={draggedRef}
               onEventClick={onEventClick}
               onSlotSelect={onSlotSelect}
@@ -1057,6 +1097,7 @@ function MonthView<T extends Record<string, unknown>>({
               getId={getId}
               getTitle={getTitle}
               color={color}
+              renderEvent={renderEvent}
               onEventClick={onEventClick}
             />
           );
@@ -1074,6 +1115,7 @@ function AgendaView<T extends Record<string, unknown>>({
   getId,
   getTitle,
   color,
+  renderEvent,
   onEventClick,
 }: {
   days: Date[];
@@ -1083,6 +1125,7 @@ function AgendaView<T extends Record<string, unknown>>({
   getId: (item: T) => string;
   getTitle: (item: T) => string;
   color?: (item: T) => CalendarEventColor | undefined;
+  renderEvent?: (item: T) => React.ReactNode;
   onEventClick?: (item: T) => void;
 }) {
   const groups = days
@@ -1114,7 +1157,7 @@ function AgendaView<T extends Record<string, unknown>>({
               <span className='text-muted-foreground'>
                 {format(getStart(item), 'HH:mm')} – {format(getEnd(item), 'HH:mm')}
               </span>
-              <span>{getTitle(item)}</span>
+              <span>{renderEvent ? renderEvent(item) : getTitle(item)}</span>
             </button>
           ))}
         </div>

--- a/packages/registry/items/blocks/calendar/component.tsx
+++ b/packages/registry/items/blocks/calendar/component.tsx
@@ -356,6 +356,13 @@ function eventHeight(start: Date, end: Date): number {
   return (mins / 60) * HOUR_HEIGHT;
 }
 
+function offsetToMinutes(clientY: number, columnEl: HTMLElement): number {
+  const rect = columnEl.getBoundingClientRect();
+  return ((clientY - rect.top) / HOUR_HEIGHT) * 60;
+}
+
+type Creating = { dayIndex: number; startMin: number; endMin: number };
+
 type LaidOut<T> = { item: T; col: number; cols: number };
 
 function layoutDay<T>(dayEvents: T[], getStart: (t: T) => Date, getEnd: (t: T) => Date): LaidOut<T>[] {
@@ -416,6 +423,7 @@ function EventBlock({
   return (
     <button
       type='button'
+      data-event=''
       onClick={onClick}
       style={eventBlockStyle(start, end, laidOut)}
       className={cn(eventBlockClass, colorClasses(color))}
@@ -454,6 +462,7 @@ function DraggableEventBlock({
   return (
     <button
       type='button'
+      data-event=''
       ref={setNodeRef}
       {...attributes}
       {...listeners}
@@ -527,11 +536,28 @@ function ResizeHandle({
     target.addEventListener('pointerup', onUp);
   };
 
-  return <span className='absolute inset-x-0 bottom-0 z-20 h-1.5 cursor-ns-resize' onPointerDown={handlePointerDown} />;
+  return (
+    <span
+      data-event=''
+      className='absolute inset-x-0 bottom-0 z-20 h-1.5 cursor-ns-resize'
+      onPointerDown={handlePointerDown}
+    />
+  );
 }
 
 const HOURS = Array.from({ length: 24 }, (_, h) => h);
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function CreatingOverlay({ startMin, endMin }: { startMin: number; endMin: number }) {
+  const lo = Math.min(startMin, endMin);
+  const span = Math.max(15, Math.abs(endMin - startMin));
+  return (
+    <div
+      className='pointer-events-none absolute inset-x-0 z-30 rounded border border-primary bg-primary/30'
+      style={{ top: (lo / 60) * HOUR_HEIGHT, height: (span / 60) * HOUR_HEIGHT }}
+    />
+  );
+}
 
 function DayColumnContent<T extends Record<string, unknown>>({
   laidOut,
@@ -543,6 +569,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
   editable,
   draggedRef,
   resizing,
+  creatingRange,
   onResize,
   onPreview,
   onEventClick,
@@ -556,6 +583,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
   editable: boolean;
   draggedRef: React.MutableRefObject<boolean>;
   resizing: { id: string; end: Date } | null;
+  creatingRange?: { startMin: number; endMin: number } | null;
   onResize?: (id: string, end: Date) => void;
   onPreview: (preview: { id: string; end: Date } | null) => void;
   onEventClick?: (item: T) => void;
@@ -565,6 +593,7 @@ function DayColumnContent<T extends Record<string, unknown>>({
       {HOURS.map((h) => (
         <div key={h} className='h-12 border-t first:border-t-0' />
       ))}
+      {creatingRange ? <CreatingOverlay startMin={creatingRange.startMin} endMin={creatingRange.endMin} /> : null}
       {laidOut.map((entry) => {
         const id = getId(entry.item);
         const start = getStart(entry.item);
@@ -605,9 +634,17 @@ const dayColumnClass = 'relative flex-1 border-l first:border-l-0';
 
 function DroppableDayColumn<T extends Record<string, unknown>>({
   day,
+  dayIndex,
+  creating,
+  onCreatingChange,
+  onSlotSelect,
   ...content
 }: {
   day: Date;
+  dayIndex: number;
+  creating: Creating | null;
+  onCreatingChange: (next: Creating | null) => void;
+  onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
   laidOut: LaidOut<T>[];
   getStart: (item: T) => Date;
   getEnd: (item: T) => Date;
@@ -622,9 +659,69 @@ function DroppableDayColumn<T extends Record<string, unknown>>({
   onEventClick?: (item: T) => void;
 }) {
   const { setNodeRef } = useDroppable({ id: `col-${day.toISOString()}`, data: { day } });
+  const columnRef = React.useRef<HTMLDivElement | null>(null);
+  const startMinRef = React.useRef(0);
+  const canCreate = Boolean(onSlotSelect);
+
+  const mergedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      setNodeRef(node);
+      columnRef.current = node;
+    },
+    [setNodeRef],
+  );
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!canCreate) return;
+    if ((e.target as HTMLElement).closest('[data-event]')) return;
+    const columnEl = columnRef.current;
+    if (!columnEl) return;
+    e.preventDefault();
+    columnEl.setPointerCapture(e.pointerId);
+    const startMin = offsetToMinutes(e.clientY, columnEl);
+    startMinRef.current = startMin;
+    onCreatingChange({ dayIndex, startMin, endMin: startMin });
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!creating || creating.dayIndex !== dayIndex) return;
+    const columnEl = columnRef.current;
+    if (!columnEl) return;
+    onCreatingChange({ dayIndex, startMin: startMinRef.current, endMin: offsetToMinutes(e.clientY, columnEl) });
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!creating || creating.dayIndex !== dayIndex) return;
+    const columnEl = columnRef.current;
+    if (columnEl?.hasPointerCapture(e.pointerId)) columnEl.releasePointerCapture(e.pointerId);
+    let lo = Math.min(creating.startMin, creating.endMin);
+    let hi = Math.max(creating.startMin, creating.endMin);
+    if (hi - lo < 5) {
+      lo = creating.startMin;
+      hi = creating.startMin + 60;
+    }
+    const base = startOfDay(day);
+    const start = snapToMinutes(addMinutes(base, lo));
+    let end = snapToMinutes(addMinutes(base, hi));
+    if (end.getTime() - start.getTime() < SNAP_MINUTES * 60_000) {
+      end = new Date(start.getTime() + SNAP_MINUTES * 60_000);
+    }
+    onCreatingChange(null);
+    onSlotSelect?.({ start, end, allDay: false });
+  };
+
+  const creatingRange = creating?.dayIndex === dayIndex ? creating : null;
+
   return (
-    <div ref={setNodeRef} className={cn(dayColumnClass, 'cursor-pointer')} style={{ height: 24 * HOUR_HEIGHT }}>
-      <DayColumnContent {...content} />
+    <div
+      ref={mergedRef}
+      className={cn(dayColumnClass, 'cursor-pointer')}
+      style={{ height: 24 * HOUR_HEIGHT }}
+      onPointerDown={canCreate ? handlePointerDown : undefined}
+      onPointerMove={canCreate ? handlePointerMove : undefined}
+      onPointerUp={canCreate ? handlePointerUp : undefined}
+    >
+      <DayColumnContent {...content} creatingRange={creatingRange} />
     </div>
   );
 }
@@ -679,6 +776,7 @@ function TimeGridView<T extends Record<string, unknown>>({
   onSlotSelect?: (range: { start: Date; end: Date; allDay: boolean }) => void;
 }) {
   const [resizing, setResizing] = React.useState<{ id: string; end: Date } | null>(null);
+  const [creating, setCreating] = React.useState<Creating | null>(null);
 
   const spansAllDay = React.useCallback(
     (item: T) => isAllDay(item) || getEnd(item).getTime() - getStart(item).getTime() >= DAY_MS,
@@ -728,7 +826,7 @@ function TimeGridView<T extends Record<string, unknown>>({
               </div>
             ))}
           </div>
-          {days.map((day) => {
+          {days.map((day, dayIndex) => {
             const timed = items.filter((item) => !spansAllDay(item) && isSameDay(getStart(item), day));
             const laidOut = layoutDay(timed, getStart, getEnd);
             const columnProps = {
@@ -746,7 +844,15 @@ function TimeGridView<T extends Record<string, unknown>>({
               onEventClick,
             };
             return editable ? (
-              <DroppableDayColumn key={day.toISOString()} day={day} {...columnProps} />
+              <DroppableDayColumn
+                key={day.toISOString()}
+                day={day}
+                dayIndex={dayIndex}
+                creating={creating}
+                onCreatingChange={setCreating}
+                onSlotSelect={onSlotSelect}
+                {...columnProps}
+              />
             ) : (
               <PlainDayColumn key={day.toISOString()} {...columnProps} />
             );

--- a/packages/registry/items/blocks/calendar/default.example.tsx
+++ b/packages/registry/items/blocks/calendar/default.example.tsx
@@ -3,12 +3,13 @@
 import * as React from 'react';
 import { Calendar, type CalendarEventColor, type CalendarSlot } from '@/components/block/shuip/calendar';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
-type CalEvent = { id: string; title: string; start: Date; end: Date; color?: CalendarEventColor };
+type CalEvent = { id: string; title: string; start: Date; end: Date; color?: CalendarEventColor; allDay?: boolean };
 
 const now = new Date();
 const at = (dayOffset: number, h: number, m = 0) =>
@@ -29,8 +30,8 @@ export default function Example() {
   const [open, setOpen] = React.useState(false);
   const isExisting = draft ? events.some((e) => e.id === draft.id) : false;
 
-  const handleSlotSelect = React.useCallback(({ start, end }: CalendarSlot) => {
-    setDraft({ id: crypto.randomUUID(), title: '', start, end });
+  const handleSlotSelect = React.useCallback(({ start, end, allDay }: CalendarSlot) => {
+    setDraft({ id: crypto.randomUUID(), title: '', start, end, allDay });
     setOpen(true);
   }, []);
 
@@ -42,6 +43,7 @@ export default function Example() {
         titleField='title'
         startField='start'
         endField='end'
+        allDayField='allDay'
         color={(e) => e.color}
         defaultView='week'
         editable
@@ -88,6 +90,14 @@ export default function Example() {
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+              <div className='flex items-center gap-2'>
+                <Checkbox
+                  id='cal-allday'
+                  checked={draft.allDay ?? false}
+                  onCheckedChange={(v) => setDraft({ ...draft, allDay: v === true })}
+                />
+                <Label htmlFor='cal-allday'>All day</Label>
               </div>
             </div>
           ) : null}

--- a/packages/registry/items/blocks/calendar/default.example.tsx
+++ b/packages/registry/items/blocks/calendar/default.example.tsx
@@ -15,13 +15,13 @@ const at = (dayOffset: number, h: number, m = 0) =>
   new Date(now.getFullYear(), now.getMonth(), now.getDate() + dayOffset, h, m);
 
 const seed: CalEvent[] = [
-  { id: '1', title: 'Standup', start: at(0, 9), end: at(0, 9, 30), color: 'blue' },
-  { id: '2', title: 'Design review', start: at(0, 11), end: at(0, 12), color: 'green' },
+  { id: '1', title: 'Standup', start: at(0, 9), end: at(0, 9, 30), color: 'secondary' },
+  { id: '2', title: 'Design review', start: at(0, 11), end: at(0, 12), color: 'accent' },
   { id: '3', title: 'Lunch', start: at(1, 12), end: at(1, 13) },
-  { id: '4', title: 'Offsite', start: at(2, 0), end: at(3, 0), color: 'amber' },
+  { id: '4', title: 'Offsite', start: at(2, 0), end: at(3, 0), color: 'muted' },
 ];
 
-const colors: CalendarEventColor[] = ['primary', 'blue', 'green', 'red', 'amber'];
+const colors: CalendarEventColor[] = ['primary', 'secondary', 'accent', 'destructive', 'muted'];
 
 export default function Example() {
   const [events, setEvents] = React.useState<CalEvent[]>(seed);

--- a/packages/registry/items/blocks/calendar/default.example.tsx
+++ b/packages/registry/items/blocks/calendar/default.example.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Calendar, type CalendarEventColor } from '@/components/block/shuip/calendar';
+import { Calendar, type CalendarEventColor, type CalendarSlot } from '@/components/block/shuip/calendar';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
@@ -29,6 +29,11 @@ export default function Example() {
   const [open, setOpen] = React.useState(false);
   const isExisting = draft ? events.some((e) => e.id === draft.id) : false;
 
+  const handleSlotSelect = React.useCallback(({ start, end }: CalendarSlot) => {
+    setDraft({ id: crypto.randomUUID(), title: '', start, end });
+    setOpen(true);
+  }, []);
+
   return (
     <>
       <Calendar.Root<CalEvent>
@@ -44,10 +49,7 @@ export default function Example() {
           setDraft(e);
           setOpen(true);
         }}
-        onSlotSelect={({ start, end }) => {
-          setDraft({ id: crypto.randomUUID(), title: '', start, end });
-          setOpen(true);
-        }}
+        onSlotSelect={handleSlotSelect}
       >
         <div className='flex w-full flex-col gap-4'>
           <Calendar.Nav />

--- a/packages/registry/items/blocks/calendar/default.example.tsx
+++ b/packages/registry/items/blocks/calendar/default.example.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Calendar } from '@/components/block/shuip/calendar';
+
+type Event = { id: string; title: string; start: Date; end: Date };
+
+const now = new Date();
+const at = (h: number) => new Date(now.getFullYear(), now.getMonth(), now.getDate(), h);
+
+const events: Event[] = [
+  { id: '1', title: 'Standup', start: at(9), end: at(10) },
+  { id: '2', title: 'Design review', start: at(11), end: at(12) },
+];
+
+export default function Example() {
+  return (
+    <Calendar<Event>
+      defaultEvents={events}
+      titleField='title'
+      startField='start'
+      endField='end'
+      defaultView='week'
+      editable
+    />
+  );
+}

--- a/packages/registry/items/blocks/calendar/default.example.tsx
+++ b/packages/registry/items/blocks/calendar/default.example.tsx
@@ -1,26 +1,117 @@
 'use client';
 
-import { Calendar } from '@/components/block/shuip/calendar';
+import * as React from 'react';
+import { Calendar, type CalendarEventColor } from '@/components/block/shuip/calendar';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
-type Event = { id: string; title: string; start: Date; end: Date };
+type CalEvent = { id: string; title: string; start: Date; end: Date; color?: CalendarEventColor };
 
 const now = new Date();
-const at = (h: number) => new Date(now.getFullYear(), now.getMonth(), now.getDate(), h);
+const at = (dayOffset: number, h: number, m = 0) =>
+  new Date(now.getFullYear(), now.getMonth(), now.getDate() + dayOffset, h, m);
 
-const events: Event[] = [
-  { id: '1', title: 'Standup', start: at(9), end: at(10) },
-  { id: '2', title: 'Design review', start: at(11), end: at(12) },
+const seed: CalEvent[] = [
+  { id: '1', title: 'Standup', start: at(0, 9), end: at(0, 9, 30), color: 'blue' },
+  { id: '2', title: 'Design review', start: at(0, 11), end: at(0, 12), color: 'green' },
+  { id: '3', title: 'Lunch', start: at(1, 12), end: at(1, 13) },
+  { id: '4', title: 'Offsite', start: at(2, 0), end: at(3, 0), color: 'amber' },
 ];
 
+const colors: CalendarEventColor[] = ['primary', 'blue', 'green', 'red', 'amber'];
+
 export default function Example() {
+  const [events, setEvents] = React.useState<CalEvent[]>(seed);
+  const [draft, setDraft] = React.useState<CalEvent | null>(null);
+  const [open, setOpen] = React.useState(false);
+  const isExisting = draft ? events.some((e) => e.id === draft.id) : false;
+
   return (
-    <Calendar<Event>
-      defaultEvents={events}
-      titleField='title'
-      startField='start'
-      endField='end'
-      defaultView='week'
-      editable
-    />
+    <>
+      <Calendar<CalEvent>
+        events={events}
+        onEventsChange={setEvents}
+        titleField='title'
+        startField='start'
+        endField='end'
+        color={(e) => e.color}
+        defaultView='week'
+        editable
+        onEventClick={(e) => {
+          setDraft(e);
+          setOpen(true);
+        }}
+        onSlotSelect={({ start, end }) => {
+          setDraft({ id: crypto.randomUUID(), title: '', start, end });
+          setOpen(true);
+        }}
+      />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{isExisting ? 'Edit event' : 'New event'}</DialogTitle>
+          </DialogHeader>
+          {draft ? (
+            <div className='flex flex-col gap-4'>
+              <div className='flex flex-col gap-2'>
+                <Label htmlFor='cal-title'>Title</Label>
+                <Input
+                  id='cal-title'
+                  value={draft.title}
+                  onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+                />
+              </div>
+              <div className='flex flex-col gap-2'>
+                <Label htmlFor='cal-color'>Color</Label>
+                <Select
+                  value={draft.color ?? 'primary'}
+                  onValueChange={(v) => setDraft({ ...draft, color: v as CalendarEventColor })}
+                >
+                  <SelectTrigger id='cal-color'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {colors.map((c) => (
+                      <SelectItem key={c} value={c}>
+                        {c}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          ) : null}
+          <DialogFooter>
+            {isExisting ? (
+              <Button
+                variant='outline'
+                onClick={() => {
+                  if (draft) setEvents((prev) => prev.filter((e) => e.id !== draft.id));
+                  setOpen(false);
+                }}
+              >
+                Delete
+              </Button>
+            ) : null}
+            <Button
+              onClick={() => {
+                if (!draft) return;
+                setEvents((prev) =>
+                  prev.some((e) => e.id === draft.id)
+                    ? prev.map((e) => (e.id === draft.id ? draft : e))
+                    : [...prev, draft],
+                );
+                setOpen(false);
+              }}
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/packages/registry/items/blocks/calendar/local-storage.example.tsx
+++ b/packages/registry/items/blocks/calendar/local-storage.example.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Calendar, type CalendarEventColor } from '@/components/block/shuip/calendar';
+import { Calendar, type CalendarEventColor, type CalendarSlot } from '@/components/block/shuip/calendar';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
@@ -56,6 +56,11 @@ export default function Example() {
     void saveEvents(next);
   }, []);
 
+  const handleSlotSelect = React.useCallback(({ start, end }: CalendarSlot) => {
+    setDraft({ id: crypto.randomUUID(), title: '', start, end });
+    setOpen(true);
+  }, []);
+
   if (!events) {
     return (
       <div className='flex h-72 w-full items-center justify-center text-sm text-muted-foreground'>
@@ -81,10 +86,7 @@ export default function Example() {
           setDraft(e);
           setOpen(true);
         }}
-        onSlotSelect={({ start, end }) => {
-          setDraft({ id: crypto.randomUUID(), title: '', start, end });
-          setOpen(true);
-        }}
+        onSlotSelect={handleSlotSelect}
       >
         <div className='flex w-full flex-col gap-4'>
           <Calendar.Nav />

--- a/packages/registry/items/blocks/calendar/local-storage.example.tsx
+++ b/packages/registry/items/blocks/calendar/local-storage.example.tsx
@@ -6,9 +6,11 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 type CalEvent = { id: string; title: string; start: Date; end: Date; color?: CalendarEventColor };
+type StoredEvent = { id: string; title: string; start: string; end: string; color?: CalendarEventColor };
+
+const STORAGE_KEY = 'shuip:calendar-events';
 
 const now = new Date();
 const at = (dayOffset: number, h: number, m = 0) =>
@@ -16,24 +18,59 @@ const at = (dayOffset: number, h: number, m = 0) =>
 
 const seed: CalEvent[] = [
   { id: '1', title: 'Standup', start: at(0, 9), end: at(0, 9, 30), color: 'blue' },
-  { id: '2', title: 'Design review', start: at(0, 11), end: at(0, 12), color: 'green' },
-  { id: '3', title: 'Lunch', start: at(1, 12), end: at(1, 13) },
-  { id: '4', title: 'Offsite', start: at(2, 0), end: at(3, 0), color: 'amber' },
+  { id: '2', title: 'Ship release', start: at(1, 15), end: at(1, 16), color: 'red' },
 ];
 
-const colors: CalendarEventColor[] = ['primary', 'blue', 'green', 'red', 'amber'];
+// Dates do not survive JSON, so we serialize to ISO strings and revive on read.
+// The artificial delay stands in for a real async source (an API, IndexedDB, …).
+async function loadEvents(): Promise<CalEvent[]> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return seed;
+  const stored = JSON.parse(raw) as StoredEvent[];
+  return stored.map((e) => ({ ...e, start: new Date(e.start), end: new Date(e.end) }));
+}
+
+async function saveEvents(events: CalEvent[]): Promise<void> {
+  const stored: StoredEvent[] = events.map((e) => ({ ...e, start: e.start.toISOString(), end: e.end.toISOString() }));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+}
 
 export default function Example() {
-  const [events, setEvents] = React.useState<CalEvent[]>(seed);
+  const [events, setEvents] = React.useState<CalEvent[] | null>(null);
   const [draft, setDraft] = React.useState<CalEvent | null>(null);
   const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    let active = true;
+    loadEvents().then((loaded) => {
+      if (active) setEvents(loaded);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const persist = React.useCallback((next: CalEvent[]) => {
+    setEvents(next);
+    void saveEvents(next);
+  }, []);
+
+  if (!events) {
+    return (
+      <div className='flex h-72 w-full items-center justify-center text-sm text-muted-foreground'>
+        Loading calendar…
+      </div>
+    );
+  }
+
   const isExisting = draft ? events.some((e) => e.id === draft.id) : false;
 
   return (
     <>
       <Calendar.Root<CalEvent>
         events={events}
-        onEventsChange={setEvents}
+        onEventsChange={persist}
         titleField='title'
         startField='start'
         endField='end'
@@ -60,33 +97,13 @@ export default function Example() {
             <DialogTitle>{isExisting ? 'Edit event' : 'New event'}</DialogTitle>
           </DialogHeader>
           {draft ? (
-            <div className='flex flex-col gap-4'>
-              <div className='flex flex-col gap-2'>
-                <Label htmlFor='cal-title'>Title</Label>
-                <Input
-                  id='cal-title'
-                  value={draft.title}
-                  onChange={(e) => setDraft({ ...draft, title: e.target.value })}
-                />
-              </div>
-              <div className='flex flex-col gap-2'>
-                <Label htmlFor='cal-color'>Color</Label>
-                <Select
-                  value={draft.color ?? 'primary'}
-                  onValueChange={(v) => setDraft({ ...draft, color: v as CalendarEventColor })}
-                >
-                  <SelectTrigger id='cal-color'>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {colors.map((c) => (
-                      <SelectItem key={c} value={c}>
-                        {c}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+            <div className='flex flex-col gap-2'>
+              <Label htmlFor='ls-title'>Title</Label>
+              <Input
+                id='ls-title'
+                value={draft.title}
+                onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+              />
             </div>
           ) : null}
           <DialogFooter>
@@ -94,7 +111,7 @@ export default function Example() {
               <Button
                 variant='outline'
                 onClick={() => {
-                  if (draft) setEvents((prev) => prev.filter((e) => e.id !== draft.id));
+                  if (draft) persist(events.filter((e) => e.id !== draft.id));
                   setOpen(false);
                 }}
               >
@@ -104,10 +121,10 @@ export default function Example() {
             <Button
               onClick={() => {
                 if (!draft) return;
-                setEvents((prev) =>
-                  prev.some((e) => e.id === draft.id)
-                    ? prev.map((e) => (e.id === draft.id ? draft : e))
-                    : [...prev, draft],
+                persist(
+                  events.some((e) => e.id === draft.id)
+                    ? events.map((e) => (e.id === draft.id ? draft : e))
+                    : [...events, draft],
                 );
                 setOpen(false);
               }}

--- a/packages/registry/items/blocks/calendar/local-storage.example.tsx
+++ b/packages/registry/items/blocks/calendar/local-storage.example.tsx
@@ -17,8 +17,8 @@ const at = (dayOffset: number, h: number, m = 0) =>
   new Date(now.getFullYear(), now.getMonth(), now.getDate() + dayOffset, h, m);
 
 const seed: CalEvent[] = [
-  { id: '1', title: 'Standup', start: at(0, 9), end: at(0, 9, 30), color: 'blue' },
-  { id: '2', title: 'Ship release', start: at(1, 15), end: at(1, 16), color: 'red' },
+  { id: '1', title: 'Standup', start: at(0, 9), end: at(0, 9, 30), color: 'secondary' },
+  { id: '2', title: 'Ship release', start: at(1, 15), end: at(1, 16), color: 'destructive' },
 ];
 
 // Dates do not survive JSON, so we serialize to ISO strings and revive on read.

--- a/packages/registry/items/blocks/calendar/nav-variants.example.tsx
+++ b/packages/registry/items/blocks/calendar/nav-variants.example.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
+import * as React from 'react';
+import { Calendar, type CalendarView, useCalendar } from '@/components/block/shuip/calendar';
+import { Button } from '@/components/ui/button';
+import { Calendar as DayPicker } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+type CalEvent = { id: string; title: string; start: Date; end: Date };
+
+const now = new Date();
+const at = (dayOffset: number, h: number) => new Date(now.getFullYear(), now.getMonth(), now.getDate() + dayOffset, h);
+
+const seed: CalEvent[] = [
+  { id: '1', title: 'Sprint planning', start: at(0, 10), end: at(0, 11) },
+  { id: '2', title: 'Release', start: at(1, 15), end: at(1, 16) },
+  { id: '3', title: '1:1', start: at(3, 14), end: at(3, 15) },
+];
+
+function TabsNav() {
+  const { periodLabel, views, view, setView, goToPrevious, goToNext } = useCalendar();
+  return (
+    <div className='flex flex-wrap items-center justify-between gap-2'>
+      <div className='flex items-center gap-1'>
+        <Button variant='ghost' size='icon' className='size-8' onClick={goToPrevious} aria-label='Previous'>
+          <ChevronLeft className='size-4' />
+        </Button>
+        <Button variant='ghost' size='icon' className='size-8' onClick={goToNext} aria-label='Next'>
+          <ChevronRight className='size-4' />
+        </Button>
+        <span className='ml-1 text-sm font-medium'>{periodLabel}</span>
+      </div>
+      <Tabs value={view} onValueChange={(v) => setView(v as CalendarView)}>
+        <TabsList>
+          {views.map((v) => (
+            <TabsTrigger key={v} value={v} className='capitalize'>
+              {v}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+}
+
+function CenteredNav() {
+  const { periodLabel, views, view, setView, goToToday, goToPrevious, goToNext } = useCalendar();
+  return (
+    <div className='flex flex-col items-center gap-3'>
+      <div className='flex items-center gap-4'>
+        <Button variant='ghost' size='icon' className='size-8' onClick={goToPrevious} aria-label='Previous'>
+          <ChevronLeft className='size-4' />
+        </Button>
+        <span className='min-w-52 text-center text-lg font-semibold tracking-tight'>{periodLabel}</span>
+        <Button variant='ghost' size='icon' className='size-8' onClick={goToNext} aria-label='Next'>
+          <ChevronRight className='size-4' />
+        </Button>
+      </div>
+      <div className='flex items-center gap-2'>
+        <Button variant='outline' size='sm' onClick={goToToday}>
+          Today
+        </Button>
+        <Select value={view} onValueChange={(v) => setView(v as CalendarView)}>
+          <SelectTrigger className='w-32' size='sm'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {views.map((v) => (
+              <SelectItem key={v} value={v} className='capitalize'>
+                {v}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function CompactNav() {
+  const { periodLabel, views, view, setView, goToToday, goToPrevious, goToNext } = useCalendar();
+  return (
+    <div className='flex items-center justify-between gap-2'>
+      <div className='flex items-center gap-1'>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToPrevious} aria-label='Previous'>
+          <ChevronLeft className='size-4' />
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToToday} aria-label='Today'>
+          <CalendarDays className='size-4' />
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToNext} aria-label='Next'>
+          <ChevronRight className='size-4' />
+        </Button>
+      </div>
+      <span className='min-w-0 flex-1 truncate text-center text-sm font-medium'>{periodLabel}</span>
+      <Select value={view} onValueChange={(v) => setView(v as CalendarView)}>
+        <SelectTrigger className='w-24' size='sm'>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {views.map((v) => (
+            <SelectItem key={v} value={v} className='capitalize'>
+              {v}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function DatePickerNav() {
+  const { date, setDate, periodLabel, goToToday, goToPrevious, goToNext } = useCalendar();
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className='flex flex-wrap items-center justify-between gap-2'>
+      <div className='flex items-center gap-1'>
+        <Button variant='outline' size='sm' onClick={goToToday}>
+          Today
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToPrevious} aria-label='Previous'>
+          <ChevronLeft className='size-4' />
+        </Button>
+        <Button variant='outline' size='icon' className='size-8' onClick={goToNext} aria-label='Next'>
+          <ChevronRight className='size-4' />
+        </Button>
+      </div>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant='ghost' className='gap-2 text-sm font-medium'>
+            <CalendarDays className='size-4' />
+            {periodLabel}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className='w-auto p-0' align='end'>
+          <DayPicker
+            mode='single'
+            selected={date}
+            onSelect={(d) => {
+              if (d) {
+                setDate(d);
+                setOpen(false);
+              }
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+function NavCase({ label, nav }: { label: string; nav: React.ReactNode }) {
+  return (
+    <div className='flex flex-col gap-3 rounded-lg border p-4'>
+      <span className='text-xs font-medium text-muted-foreground'>{label}</span>
+      <Calendar.Root<CalEvent>
+        defaultEvents={seed}
+        titleField='title'
+        startField='start'
+        endField='end'
+        defaultView='agenda'
+      >
+        <div className='flex flex-col gap-4'>
+          {nav}
+          <Calendar.View />
+        </div>
+      </Calendar.Root>
+    </div>
+  );
+}
+
+export default function Example() {
+  return (
+    <div className='flex w-full flex-col gap-6'>
+      <NavCase label='Segmented tabs' nav={<TabsNav />} />
+      <NavCase label='Centered' nav={<CenteredNav />} />
+      <NavCase label='Compact / mobile' nav={<CompactNav />} />
+      <NavCase label='Date picker jump' nav={<DatePickerNav />} />
+    </div>
+  );
+}

--- a/packages/registry/items/blocks/calendar/views.example.tsx
+++ b/packages/registry/items/blocks/calendar/views.example.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Calendar } from '@/components/block/shuip/calendar';
+
+type CalEvent = { id: string; title: string; start: Date; end: Date };
+
+const now = new Date();
+const at = (dayOffset: number, h: number) => new Date(now.getFullYear(), now.getMonth(), now.getDate() + dayOffset, h);
+
+const events: CalEvent[] = [
+  { id: '1', title: 'Sprint planning', start: at(0, 10), end: at(0, 11) },
+  { id: '2', title: 'Release', start: at(1, 15), end: at(1, 16) },
+  { id: '3', title: '1:1', start: at(3, 14), end: at(3, 15) },
+];
+
+export default function Example() {
+  return (
+    <Calendar<CalEvent>
+      defaultEvents={events}
+      titleField='title'
+      startField='start'
+      endField='end'
+      defaultView='agenda'
+    />
+  );
+}

--- a/packages/registry/items/blocks/calendar/views.example.tsx
+++ b/packages/registry/items/blocks/calendar/views.example.tsx
@@ -15,12 +15,17 @@ const events: CalEvent[] = [
 
 export default function Example() {
   return (
-    <Calendar<CalEvent>
+    <Calendar.Root<CalEvent>
       defaultEvents={events}
       titleField='title'
       startField='start'
       endField='end'
       defaultView='agenda'
-    />
+    >
+      <div className='flex w-full flex-col gap-4'>
+        <Calendar.Nav />
+        <Calendar.View />
+      </div>
+    </Calendar.Root>
   );
 }


### PR DESCRIPTION
## Calendar block

Adds a generic, responsive `Calendar<T>` block to the registry — a from-scratch calendar built on the shuip stack (React 19, Tailwind v4, shadcn primitives, `date-fns`, `dnd-kit`). No heavyweight calendar dependency; the markup and interactions are fully owned, which is what lets the week view degrade cleanly on small screens.

### Features
- **Four views** — month, week, day, agenda — switchable from the toolbar or controlled via `view`/`defaultView`.
- **Responsive week → day** — below a mobile breakpoint the week view renders a single navigable day (toolbar still reflects the chosen view), so there's no cramped 7-column grid or horizontal overflow on phones.
- **Generic typed event model** — works with any `T` via field mapping (`idField`/`titleField`/`startField`/`endField`/`allDayField`), like the `kanban` block.
- **Hybrid state** — standalone from `defaultEvents`, or controlled via `events` + `onEventsChange`.
- **Drag to move** (dnd-kit) — re-time an event in week/day or move it across days in month, snapped to 15 min, duration preserved.
- **Resize** — drag an event's bottom edge in week/day to change its end (snapped, min 15 min, live preview).
- **Drag to create** — drag across an empty range to emit `onSlotSelect`; a plain click selects a default slot.
- **Per-event colors** via `color(item)`, **custom content** via `renderEvent(item)`.
- **Editing is callback-driven** (`onEventClick`, `onSlotSelect`) — the block imposes no editing UI; the default example wires a simple, fully replaceable shadcn `Dialog`.

All interactions are gated behind `editable`.

### Files
- `packages/registry/items/blocks/calendar/{component,default.example,views.example}.tsx`
- `apps/docs/content/blocks/calendar.mdx`

### Verification
- `bun build:docs` passes (type + SSR gate).
- Smoke-tested in the browser: all four views render, the week→day fallback works at 390px, switching views works, and the click→edit dialog populates correctly. No console errors.

Design + plan: `docs/superpowers/specs/2026-06-15-calendar-block-design.md`, `docs/superpowers/plans/2026-06-15-calendar-block.md`.
