### PR TITLE
feat(combobox-field): searchable combobox field for rhf and tsf

### DIFF
--- a/apps/docs/content/components/react-hook-form/.gitignore
+++ b/apps/docs/content/components/react-hook-form/.gitignore
@@ -2,6 +2,7 @@
 address-field.mdx
 autocomplete-field.mdx
 checkbox-field.mdx
+combobox-field.mdx
 date-field.mdx
 date-range-field.mdx
 datetime-field.mdx

--- a/apps/docs/content/components/tanstack-form/.gitignore
+++ b/apps/docs/content/components/tanstack-form/.gitignore
@@ -1,6 +1,7 @@
 # Auto-generated symlinks — do not commit (created by packages/registry/scripts/generate.ts)
 autocomplete-field.mdx
 checkbox-field.mdx
+combobox-field.mdx
 date-field.mdx
 date-range-field.mdx
 datetime-field.mdx

--- a/docs/superpowers/specs/2026-06-16-combobox-field-design.md
+++ b/docs/superpowers/specs/2026-06-16-combobox-field-design.md
@@ -1,0 +1,244 @@
+# Combobox Field — Design
+
+**Date:** 2026-06-16
+**Branch:** `feat/combobox-field`
+**Status:** Approved
+
+## Goal
+
+Add a searchable combobox field to the shuip registry: a command-style search
+input (magnifier + result menu) where the user types to search, navigates results
+with the keyboard, and selects one (or several) entries. The committed form value
+is the selected option's **`value` (an id/key), distinct from the displayed
+`label`** — the entity-combobox pattern ("Famille B"): the value is a stable id,
+the label is for display only.
+
+It is distinct from:
+- `autocomplete-field` — free text, the committed value **is** the typed string,
+  suggestions only propose ("Famille A").
+- `select-field` — static dropdown, no search.
+- `address-field` — Google Places specialised autocomplete.
+
+A non-empty default form value (an id) renders its label immediately, via a
+`defaultSelected` prop supplied by the consumer (the component only has the id;
+the label lives with the consumer's data).
+
+## Items
+
+Two published items (one per form integration), following the existing `rhf-`/`tsf-`
+pair convention:
+
+- `packages/registry/items/react-hook-form/combobox-field/`
+- `packages/registry/items/tanstack-form/combobox-field/`
+
+Single and multi-select are **one component per form lib**, switched by a
+`multiple` prop (not separate items). This matches react-select / MUI / shadcn and
+keeps the registry lean; the cost is conditional value typing (`string` vs
+`string[]`), handled by a discriminated props union (rhf) and a documented field
+type (tsf).
+
+### Structure decision: full duplication
+
+The search / async / keyboard / chips / label-cache core is duplicated between the
+rhf and tsf `component.tsx`; only the form binding differs
+(`useController(lens.interop())` vs `useFieldContext`). This is accepted
+deliberately, exactly as for `autocomplete-field`:
+
+- It honours the registry's self-containment guarantee — `shadcn add
+  rhf-combobox-field` installs one complete, working file.
+- A shared headless base item (`dependsOn`) would force consumers to install two
+  items. Rejected for now (YAGNI); revisit only if a third consumer of the core
+  appears.
+
+## Option type
+
+```ts
+interface ComboboxOption {
+  value: string;     // committed to the form
+  label: string;     // displayed in the input / chips / list
+  sublabel?: string; // optional secondary line in the result list
+}
+```
+
+The consumer maps its own data (tRPC rows, etc.) to `ComboboxOption[]` inside
+`options` or the `onSearch` resolver — the component never owns the data shape.
+
+## Behaviour
+
+### Value semantics (Famille B)
+
+- Committed value is the option's `value` (id): `string` in single mode, `string[]`
+  in multi mode.
+- The component keeps an internal **option cache** (`Map<value, ComboboxOption>`),
+  seeded from `defaultSelected`, so a selected option's `label` keeps rendering even
+  after it leaves the live search results. This is what lets a preset default id
+  show its label at rest.
+
+### Single mode
+
+- At rest (not focused): the input displays the selected option's `label`, or the
+  placeholder when empty.
+- On focus: the input clears to an empty query and fires `onSearch('')` (see
+  "Default options on open"); the result menu opens below.
+- Selecting an option (click or `Enter` on the highlighted row) commits its
+  `value`, closes the menu, and the input reverts to showing the label.
+- Closing without selecting (blur / `Escape`) keeps the previously committed value
+  and restores its label.
+
+### Multi mode
+
+- Selected options render as **chips** (the `badge` primitive) inside the field
+  container, before the query input.
+- Selecting an option appends its `value`; the menu **stays open** so several can
+  be picked in a row. Already-selected options show a check and toggle off when
+  re-selected.
+- `Backspace` on an empty query removes the last chip.
+- The committed value is the ordered `string[]` of selected ids.
+
+### Search modes (mutually exclusive)
+
+- **Static** — `options: ComboboxOption[]`. Client-side substring filter on
+  `label`, case-insensitive.
+- **Async** — `onSearch: (query) => Promise<ComboboxOption[]>`. Debounced (default
+  300ms) fetch; results shown as-is (server already filtered). A stale-response
+  guard (`requestIdRef`) drops out-of-order responses; a `Loader2` spinner shows
+  while pending.
+- If both are passed, `onSearch` wins.
+
+### Default options on open
+
+When the menu opens with an empty query, `onSearch('')` is invoked (no debounce) so
+the consumer can return a "recent / suggested" list — e.g. the 5 last-modified
+clients — instead of an empty menu. The consumer branches on the query:
+`(q) => q ? api.search(q) : api.recent()`. No dedicated prop; `maxResults` caps the
+display. (Static mode shows `options` directly on open.)
+
+### maxResults
+
+`maxResults?: number` slices the result list before render (applies to both static
+and async results, and to the default-on-open list).
+
+### Empty / loading
+
+- `emptyText` (default `"No results"`) when a non-empty query yields nothing.
+- `"Searching…"` while an async request is pending.
+
+## Interaction implementation
+
+Built on cmdk `Command` to get the command aesthetic and keyboard nav for free:
+
+- One `<Command shouldFilter={false}>` wraps an always-visible `<CommandInput>`
+  (built-in magnifier icon — this is the "command" look) and a `<CommandList>`
+  rendered in a `Popover`/anchored dropdown when `open`.
+- cmdk provides `ArrowUp` / `ArrowDown` / `Enter` / `Escape` navigation over the
+  rendered `CommandItem`s; we do not track `selectedIndex` manually (unlike
+  `autocomplete-field`, whose plain-input model required it).
+- Popover width pinned to the field via `var(--radix-popover-trigger-width)`;
+  `onOpenAutoFocus` prevented so focus stays in the input.
+- The single-mode "label at rest vs query while focused" is handled by syncing the
+  `CommandInput` displayed value to state (selected label when blurred, live query
+  when focused) — the fiddly part of this component.
+- `CommandItem` renders `label` + optional `sublabel`, with a `Check` for selected
+  values (multi) / the active value (single).
+
+## Props
+
+### RHF — `ComboboxFieldProps`
+
+```ts
+interface ComboboxOption {
+  value: string;
+  label: string;
+  sublabel?: string;
+}
+
+type ComboboxFieldCommonProps = {
+  options?: ComboboxOption[];
+  onSearch?: (query: string) => Promise<ComboboxOption[]>;
+  maxResults?: number;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  emptyText?: string;   // default "No results"
+  debounceMs?: number;  // default 300, async mode only
+};
+
+type ComboboxFieldProps =
+  | (ComboboxFieldCommonProps & {
+      multiple?: false;
+      lens: Lens<string>;
+      defaultSelected?: ComboboxOption;
+    })
+  | (ComboboxFieldCommonProps & {
+      multiple: true;
+      lens: Lens<string[]>;
+      defaultSelected?: ComboboxOption[];
+    });
+```
+
+Binding: `const { field, fieldState } = useController(lens.interop());`,
+`aria-invalid={fieldState.invalid}`, errors via `<FieldError errors={[fieldState.error]} />`.
+
+### TSF — `ComboboxFieldProps`
+
+Same logic and feature set. Differences follow the tsf field convention:
+
+- No `lens`; binding via `useFieldContext<string>()` (single) /
+  `useFieldContext<string[]>()` (multi). The consumer declares the field value type;
+  the component reads/writes `field.state.value` and normalises internally to a
+  `string[]` working set.
+- `multiple`, `options`, `onSearch`, `defaultSelected`, `maxResults`, `label`,
+  `description`, `placeholder`, `emptyText`, `debounceMs` are top-level on the props
+  object; input/field passthrough nested under
+  `props?: React.ComponentProps<'input'>` and
+  `fieldProps?: React.ComponentProps<typeof Field>`.
+- Value/handlers via `field.handleChange`, `field.handleBlur`, validity/errors from
+  `field.state.meta`.
+
+## Files per item
+
+- `component.tsx` (REQUIRED, exact name).
+- `default.example.tsx` — single mode, static `options`, `defaultSelected` set to
+  show a preset value's label.
+- `multiple.example.tsx` — `multiple` with static `options` (chips).
+- `async.example.tsx` — `onSearch` with a simulated async fetch + a "recents on
+  empty query" branch.
+- `index.mdx` — frontmatter (`title`, `description`, `registryName`),
+  `<ItemExamples registryName={...} />`, and a `<TypeTable>` for props.
+
+Examples import the component via the stub alias
+(`@/components/ui/shuip/react-hook-form/combobox-field` /
+`@/components/ui/shuip/tanstack-form/combobox-field`), never relative.
+
+## Dependencies (auto-detected by generate.ts)
+
+- `registryDependencies`: `command`, `popover`, `field`, `input`, `badge` (chips).
+- `dependencies`: `lucide-react` (`Search`, `Check`, `Loader2`, `X`).
+- RHF additionally pulls `@hookform/lenses` + `react-hook-form`; TSF pulls
+  `@tanstack/react-form` and uses the `form-context` stub.
+
+## Verification
+
+No test runner is configured in shuip; the gate is the build pipeline:
+
+1. `bun registry:generate` — item count +2, no `skipping … no component.tsx` warning.
+2. New entries in `registry.json` with expected
+   `registryDependencies`/`dependencies`.
+3. Stubs at `stubs/react-hook-form/combobox-field.tsx` and
+   `stubs/tanstack-form/combobox-field.tsx`; MDX symlinks under
+   `content/components/react-hook-form/` and `content/components/tanstack-form/`.
+4. `bun build:docs` succeeds end-to-end.
+5. Manual check of the three examples: single label-at-rest, multi chips +
+   backspace, async search + recents-on-open + spinner, keyboard nav, defaultSelected
+   label resolution.
+
+Adding a real unit-test setup (runner + RTL) is out of scope here — it would be a
+separate infra decision.
+
+## Out of scope (YAGNI)
+
+- A dedicated `defaultOptions` prop (covered by `onSearch('')`).
+- Creating new options on the fly (tag-style free entry).
+- Grouped results / option groups.
+- A shared headless base component.
+- Virtualised result lists.

--- a/docs/superpowers/specs/2026-06-16-combobox-field-design.md
+++ b/docs/superpowers/specs/2026-06-16-combobox-field-design.md
@@ -78,22 +78,27 @@ The consumer maps its own data (tRPC rows, etc.) to `ComboboxOption[]` inside
 
 - At rest (not focused): the input displays the selected option's `label`, or the
   placeholder when empty.
-- On focus: the input clears to an empty query and fires `onSearch('')` (see
-  "Default options on open"); the result menu opens below.
-- Selecting an option (click or `Enter` on the highlighted row) commits its
-  `value`, closes the menu, and the input reverts to showing the label.
-- Closing without selecting (blur / `Escape`) keeps the previously committed value
-  and restores its label.
+- On focus: the input pre-fills the current `label` as **selected text** (so the
+  first keystroke replaces it) and opens the menu showing the **full list** with the
+  current option checked. The filter query stays empty until the user actually types
+  — pre-filled-but-untouched is treated as an empty query (so `onSearch('')` still
+  drives the "recents" list).
+- Typing replaces the selected label and filters; selecting an option (click or
+  `Enter`) commits its `value`, closes the menu, and the input shows the new label.
+- Closing without typing/selecting (blur / `Escape`) keeps the previously committed
+  value and restores its label.
 
 ### Multi mode
 
 - Selected options render as **chips** (the `badge` primitive) inside the field
-  container, before the query input.
+  container, after the magnifier and before the query input.
 - Selecting an option appends its `value`; the menu **stays open** so several can
   be picked in a row. Already-selected options show a check and toggle off when
   re-selected.
 - `Backspace` on an empty query removes the last chip.
 - The committed value is the ordered `string[]` of selected ids.
+- The container is `w-full` + `flex-wrap` with a `min-w-0` input, so chips wrap onto
+  new lines and never widen the field past its container.
 
 ### Search modes (mutually exclusive)
 
@@ -125,21 +130,42 @@ and async results, and to the default-on-open list).
 
 ## Interaction implementation
 
-Built on cmdk `Command` to get the command aesthetic and keyboard nav for free:
+cmdk-native combobox — **no Radix `Popover`**. A Radix `Popover` treats a click on
+its anchor (the field, which lives outside `PopoverContent`) as an outside-interaction
+and closes, while the input keeps focus — so `onFocus` never re-fires and the field
+gets stuck until a blur + re-click. Dropping the `Popover` removes that conflict at
+the root.
 
-- One `<Command shouldFilter={false}>` wraps an always-visible `<CommandInput>`
-  (built-in magnifier icon — this is the "command" look) and a `<CommandList>`
-  rendered in a `Popover`/anchored dropdown when `open`.
-- cmdk provides `ArrowUp` / `ArrowDown` / `Enter` / `Escape` navigation over the
-  rendered `CommandItem`s; we do not track `selectedIndex` manually (unlike
-  `autocomplete-field`, whose plain-input model required it).
-- Popover width pinned to the field via `var(--radix-popover-trigger-width)`;
-  `onOpenAutoFocus` prevented so focus stays in the input.
-- The single-mode "label at rest vs query while focused" is handled by syncing the
-  `CommandInput` displayed value to state (selected label when blurred, live query
-  when focused) — the fiddly part of this component.
+- One `<Command shouldFilter={false}>` wraps:
+  - a styled **shell** `<div>` laid out as `magnifier (always left) · chips (multi) ·
+    input`. The input is cmdk's raw `CommandPrimitive.Input` (no built-in icon
+    wrapper) so the magnifier position is fully ours; a `lucide` `Search` icon is
+    rendered explicitly at the far left.
+  - a **floating list** (`absolute`, `top-full`, `z-50`, `w-full`, bordered
+    `bg-popover`) rendered only when `open`, containing `CommandList` / `CommandEmpty`
+    / `CommandGroup` / `CommandItem`.
+- Open/close: open on input `focus` / `pointerdown`; close on input `blur` when
+  `relatedTarget` is outside the `Command` container, on `Escape`, and (single only)
+  on select. The list uses `onMouseDown` `preventDefault` so clicking an item /
+  chip-remove does not blur the input and pre-empt the select.
+- cmdk owns `ArrowUp` / `ArrowDown` / `Enter` navigation over the rendered
+  `CommandItem`s (no manual `selectedIndex`). `Escape` and multi `Backspace` are
+  handled on the input's `onKeyDown`.
+- Trade-off vs `Popover`: no automatic flip near the viewport edge — the list always
+  opens downward with an internal `max-h-60` scroll. Acceptable for now.
 - `CommandItem` renders `label` + optional `sublabel`, with a `Check` for selected
-  values (multi) / the active value (single).
+  values.
+
+## Variants
+
+Two independent axes, applied to the shell via plain class maps (the `inline-edit`
+pattern), valid in both single and multi:
+
+- `variant: 'boxed' | 'ghost'` (default `boxed`). `boxed` = bordered field with
+  focus ring; `ghost` = borderless, transparent background (multi then reads as just
+  the badges + magnifier).
+- `size: 'sm' | 'default'` (default `default`). `sm` reduces height, padding, text
+  and icon sizes.
 
 ## Props
 
@@ -156,6 +182,8 @@ type ComboboxFieldCommonProps = {
   options?: ComboboxOption[];
   onSearch?: (query: string) => Promise<ComboboxOption[]>;
   maxResults?: number;
+  variant?: 'boxed' | 'ghost'; // default "boxed"
+  size?: 'sm' | 'default';     // default "default"
   label?: string;
   description?: string;
   placeholder?: string;
@@ -203,8 +231,11 @@ Same logic and feature set. Differences follow the tsf field convention:
 - `multiple.example.tsx` — `multiple` with static `options` (chips).
 - `async.example.tsx` — `onSearch` with a simulated async fetch + a "recents on
   empty query" branch.
+- `variants.example.tsx` — `boxed` vs `ghost` (a multi `ghost` showing only badges).
+- `sizes.example.tsx` — `sm` vs `default`.
 - `index.mdx` — frontmatter (`title`, `description`, `registryName`),
-  `<ItemExamples registryName={...} />`, and a `<TypeTable>` for props.
+  `<ItemExamples registryName={...} />`, and a `<TypeTable>` for props (incl.
+  `variant` / `size`).
 
 Examples import the component via the stub alias
 (`@/components/ui/shuip/react-hook-form/combobox-field` /
@@ -212,8 +243,11 @@ Examples import the component via the stub alias
 
 ## Dependencies (auto-detected by generate.ts)
 
-- `registryDependencies`: `command`, `popover`, `field`, `input`, `badge` (chips).
-- `dependencies`: `lucide-react` (`Search`, `Check`, `Loader2`, `X`).
+- `registryDependencies`: `command`, `field`, `badge` (chips). No `popover` (the
+  cmdk-native rebuild drops it) and no `input` (the field uses cmdk's
+  `CommandPrimitive.Input`, not the shadcn `Input`).
+- `dependencies`: `lucide-react` (`Search`, `Check`, `Loader2`, `X`) and `cmdk`
+  (`CommandPrimitive.Input`).
 - RHF additionally pulls `@hookform/lenses` + `react-hook-form`; TSF pulls
   `@tanstack/react-form` and uses the `form-context` stub.
 

--- a/packages/registry/items/react-hook-form/combobox-field/async.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/async.example.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/react-hook-form/combobox-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const USERS: ComboboxOption[] = [
+  { value: 'u1', label: 'Ada Lovelace', sublabel: 'ada@example.com' },
+  { value: 'u2', label: 'Alan Turing', sublabel: 'alan@example.com' },
+  { value: 'u3', label: 'Grace Hopper', sublabel: 'grace@example.com' },
+  { value: 'u4', label: 'Katherine Johnson', sublabel: 'katherine@example.com' },
+  { value: 'u5', label: 'Margaret Hamilton', sublabel: 'margaret@example.com' },
+  { value: 'u6', label: 'Linus Torvalds', sublabel: 'linus@example.com' },
+];
+
+const RECENT_IDS = ['u3', 'u1'];
+
+async function searchUsers(query: string): Promise<ComboboxOption[]> {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  if (!query) return USERS.filter((user) => RECENT_IDS.includes(user.value));
+  return USERS.filter((user) => user.label.toLowerCase().includes(query.toLowerCase()));
+}
+
+const zodSchema = z.object({
+  assignee: z.string().nonempty({ message: 'Assignee is required' }),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function ComboboxFieldAsyncExample() {
+  const form = useForm<Values>({ defaultValues: { assignee: '' } });
+  const lens = useLens({ control: form.control });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit((values) => alert(`Assignee: ${values.assignee}`))} className='space-y-4'>
+        <ComboboxField
+          lens={lens.focus('assignee')}
+          label='Assignee'
+          description='Empty query returns recents; typing searches'
+          placeholder='Search a user…'
+          onSearch={searchUsers}
+          maxResults={5}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/combobox-field/async.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/async.example.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { Form } from '@/components/ui/form';
@@ -31,7 +32,7 @@ const zodSchema = z.object({
 type Values = z.infer<typeof zodSchema>;
 
 export default function ComboboxFieldAsyncExample() {
-  const form = useForm<Values>({ defaultValues: { assignee: '' } });
+  const form = useForm<Values>({ defaultValues: { assignee: '' }, resolver: zodResolver(zodSchema) });
   const lens = useLens({ control: form.control });
 
   return (

--- a/packages/registry/items/react-hook-form/combobox-field/component.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/component.tsx
@@ -95,7 +95,8 @@ export function ComboboxField(props: ComboboxFieldProps) {
 
   // Static options + presets, resolved during render so a value shows its label on first
   // paint; async results and manual picks live in `cacheRef`. `getOption` reads both.
-  const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
+  const cacheRef = React.useRef<Map<string, ComboboxOption> | null>(null);
+  cacheRef.current ??= new Map();
   const staticLookup = React.useMemo(() => {
     const map = new Map<string, ComboboxOption>();
     const seed = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
@@ -103,7 +104,7 @@ export function ComboboxField(props: ComboboxFieldProps) {
     return map;
   }, [defaultSelected, options]);
   const getOption = React.useCallback(
-    (value: string | undefined) => (value ? (staticLookup.get(value) ?? cacheRef.current.get(value)) : undefined),
+    (value: string | undefined) => (value ? (staticLookup.get(value) ?? cacheRef.current?.get(value)) : undefined),
     [staticLookup],
   );
 
@@ -126,7 +127,7 @@ export function ComboboxField(props: ComboboxFieldProps) {
       try {
         const res = await search$(search);
         if (requestId !== requestIdRef.current) return;
-        for (const option of res) cacheRef.current.set(option.value, option);
+        for (const option of res) cacheRef.current?.set(option.value, option);
         setResults(res);
       } catch {
         if (requestId !== requestIdRef.current) return;
@@ -198,7 +199,7 @@ export function ComboboxField(props: ComboboxFieldProps) {
   };
 
   const handleSelect = (option: ComboboxOption) => {
-    cacheRef.current.set(option.value, option);
+    cacheRef.current?.set(option.value, option);
     if (multiple) {
       const next = selectedValues.includes(option.value)
         ? selectedValues.filter((value) => value !== option.value)

--- a/packages/registry/items/react-hook-form/combobox-field/component.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/component.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import type { Lens } from '@hookform/lenses';
-import { Check, Loader2, X } from 'lucide-react';
+import { Command as CommandPrimitive } from 'cmdk';
+import { Check, Loader2, Search, X } from 'lucide-react';
 import * as React from 'react';
 import { useController } from 'react-hook-form';
 import { Badge } from '@/components/ui/badge';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
-import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
 
 const DEBOUNCE_TIME = 300;
 
@@ -17,10 +18,15 @@ export interface ComboboxOption {
   sublabel?: string;
 }
 
+type ComboboxFieldVariant = 'boxed' | 'ghost';
+type ComboboxFieldSize = 'sm' | 'default';
+
 type ComboboxFieldCommonProps = {
   options?: ComboboxOption[];
   onSearch?: (query: string) => Promise<ComboboxOption[]>;
   maxResults?: number;
+  variant?: ComboboxFieldVariant;
+  size?: ComboboxFieldSize;
   label?: string;
   description?: string;
   placeholder?: string;
@@ -40,6 +46,17 @@ export type ComboboxFieldProps =
       defaultSelected?: ComboboxOption[];
     });
 
+const shellVariants: Record<ComboboxFieldVariant, string> = {
+  boxed:
+    'rounded-md border border-input bg-transparent shadow-xs focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20',
+  ghost: 'rounded-md border border-transparent bg-transparent',
+};
+
+const shellSizes: Record<ComboboxFieldSize, string> = {
+  default: 'min-h-9 gap-1.5 px-2 py-1 text-sm',
+  sm: 'min-h-7 gap-1 px-1.5 py-0.5 text-xs',
+};
+
 function toArray(value: string | string[] | undefined | null): string[] {
   if (Array.isArray(value)) return value;
   if (value) return [value];
@@ -52,6 +69,8 @@ export function ComboboxField(props: ComboboxFieldProps) {
     options,
     onSearch,
     maxResults,
+    variant = 'boxed',
+    size = 'default',
     label,
     description,
     placeholder,
@@ -66,26 +85,31 @@ export function ComboboxField(props: ComboboxFieldProps) {
 
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState('');
+  const [typed, setTyped] = React.useState(false);
   const [results, setResults] = React.useState<ComboboxOption[]>([]);
   const [isPending, startTransition] = React.useTransition();
   const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
   const requestIdRef = React.useRef(0);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
+  // Populated during render so a preset/selected value can show its label before any
+  // search runs; async results are added in `runSearch`, manual picks in `handleSelect`.
   const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
   React.useMemo(() => {
-    const initial = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
-    for (const option of initial) cacheRef.current.set(option.value, option);
-  }, [defaultSelected]);
+    const seed = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
+    for (const option of [...seed, ...(options ?? [])]) cacheRef.current.set(option.value, option);
+  }, [defaultSelected, options]);
 
   const selectedValues = toArray(field.value);
+
+  // A pre-filled-but-untouched single label counts as an empty query, so the full list
+  // (or `onSearch('')` recents) shows on focus instead of filtering down to the label.
+  const effectiveQuery = typed ? query : '';
 
   const cacheOptions = React.useCallback((items: ComboboxOption[]) => {
     for (const option of items) cacheRef.current.set(option.value, option);
   }, []);
-
-  React.useEffect(() => {
-    if (options) cacheOptions(options);
-  }, [options, cacheOptions]);
 
   const runSearch = React.useCallback(
     (search: string) => {
@@ -111,18 +135,18 @@ export function ComboboxField(props: ComboboxFieldProps) {
 
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
-    if (!query) {
+    if (!effectiveQuery) {
       requestIdRef.current++;
       runSearch('');
       return;
     }
 
-    debounceTimerRef.current = setTimeout(() => runSearch(query), debounceMs);
+    debounceTimerRef.current = setTimeout(() => runSearch(effectiveQuery), debounceMs);
 
     return () => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     };
-  }, [query, onSearch, open, debounceMs, runSearch]);
+  }, [effectiveQuery, onSearch, open, debounceMs, runSearch]);
 
   const items = React.useMemo(() => {
     let list: ComboboxOption[];
@@ -130,16 +154,42 @@ export function ComboboxField(props: ComboboxFieldProps) {
       list = results;
     } else if (!options) {
       list = [];
-    } else if (!query) {
+    } else if (!effectiveQuery) {
       list = options;
     } else {
-      list = options.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
+      list = options.filter((option) => option.label.toLowerCase().includes(effectiveQuery.toLowerCase()));
     }
     return maxResults ? list.slice(0, maxResults) : list;
-  }, [onSearch, results, options, query, maxResults]);
+  }, [onSearch, results, options, effectiveQuery, maxResults]);
 
   const commit = (next: string[]) => {
     field.onChange(multiple ? next : (next[0] ?? ''));
+  };
+
+  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
+  const inputValue = open ? query : (singleLabel ?? '');
+
+  const closeMenu = () => {
+    setOpen(false);
+    setQuery('');
+    setTyped(false);
+  };
+
+  const handleFocus = () => {
+    setOpen(true);
+    setTyped(false);
+    if (!multiple && singleLabel) {
+      setQuery(singleLabel);
+      requestAnimationFrame(() => inputRef.current?.select());
+    } else {
+      setQuery('');
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent) => {
+    if (containerRef.current?.contains(e.relatedTarget as Node | null)) return;
+    field.onBlur();
+    closeMenu();
   };
 
   const handleSelect = (option: ComboboxOption) => {
@@ -150,105 +200,126 @@ export function ComboboxField(props: ComboboxFieldProps) {
         : [...selectedValues, option.value];
       commit(next);
       setQuery('');
+      setTyped(false);
+      inputRef.current?.focus();
       return;
     }
     commit([option.value]);
-    setQuery('');
-    setOpen(false);
+    closeMenu();
+    inputRef.current?.blur();
   };
 
   const removeValue = (value: string) => {
     commit(selectedValues.filter((current) => current !== value));
   };
 
-  const handleOpenChange = (next: boolean) => {
-    setOpen(next);
-    setQuery('');
-    if (!next) field.onBlur();
+  const handleValueChange = (value: string) => {
+    setQuery(value);
+    setTyped(true);
+    setOpen(true);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeMenu();
+      inputRef.current?.blur();
+      return;
+    }
     if (multiple && e.key === 'Backspace' && query === '' && selectedValues.length > 0) {
       removeValue(selectedValues[selectedValues.length - 1]);
     }
   };
 
   const id = field.name;
-  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
-  const inputValue = open ? query : (singleLabel ?? '');
+  const iconSize = size === 'sm' ? 'size-3.5' : 'size-4';
+  const showPlaceholder = multiple ? selectedValues.length === 0 : true;
 
   return (
     <Field className='gap-2' data-invalid={fieldState.invalid}>
       {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
-      <Popover open={open} onOpenChange={handleOpenChange}>
-        <Command shouldFilter={false} className='overflow-visible bg-transparent'>
-          <PopoverAnchor asChild>
-            <div
-              className='border-input flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-2 py-1 shadow-xs focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_[data-slot=command-input-wrapper]]:flex-1 [&_[data-slot=command-input-wrapper]]:border-0 [&_[data-slot=command-input-wrapper]]:px-0'
-              aria-invalid={fieldState.invalid}
-            >
-              {multiple &&
-                selectedValues.map((value) => (
-                  <Badge key={value} variant='secondary' className='gap-1'>
-                    {cacheRef.current.get(value)?.label ?? value}
-                    <button
-                      type='button'
-                      className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        removeValue(value);
-                      }}
-                      aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
-                    >
-                      <X className='size-3' />
-                    </button>
-                  </Badge>
-                ))}
-              <CommandInput
-                id={id}
-                value={inputValue}
-                placeholder={multiple && selectedValues.length > 0 ? undefined : placeholder}
-                onValueChange={setQuery}
-                onFocus={() => setOpen(true)}
-                onKeyDown={handleKeyDown}
-                aria-invalid={fieldState.invalid}
-                className='h-7'
-              />
-              {isPending && <Loader2 className='size-4 shrink-0 animate-spin text-muted-foreground' />}
-            </div>
-          </PopoverAnchor>
-          <PopoverContent
-            className='p-0'
-            align='start'
-            onOpenAutoFocus={(e) => e.preventDefault()}
-            style={{ width: 'var(--radix-popover-trigger-width)' }}
+      <Command shouldFilter={false} className='relative h-auto overflow-visible bg-transparent'>
+        <div
+          ref={containerRef}
+          aria-invalid={fieldState.invalid || undefined}
+          className={cn('flex w-full flex-wrap items-center', shellVariants[variant], shellSizes[size])}
+          onMouseDown={(e) => {
+            if (e.target !== inputRef.current) {
+              e.preventDefault();
+              inputRef.current?.focus();
+            }
+          }}
+        >
+          <Search className={cn('shrink-0 text-muted-foreground', iconSize)} aria-hidden />
+          {multiple &&
+            selectedValues.map((value) => (
+              <Badge key={value} variant='secondary' className='gap-1'>
+                {cacheRef.current.get(value)?.label ?? value}
+                <button
+                  type='button'
+                  className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    removeValue(value);
+                  }}
+                  aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
+                >
+                  <X className='size-3' />
+                </button>
+              </Badge>
+            ))}
+          <CommandPrimitive.Input
+            ref={inputRef}
+            id={id}
+            value={inputValue}
+            placeholder={showPlaceholder ? placeholder : undefined}
+            autoComplete='off'
+            aria-invalid={fieldState.invalid || undefined}
+            aria-expanded={open}
+            onValueChange={handleValueChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            className='min-w-20 flex-1 bg-transparent outline-hidden placeholder:text-muted-foreground'
+          />
+          {isPending && <Loader2 className={cn('shrink-0 animate-spin text-muted-foreground', iconSize)} />}
+        </div>
+        {open && (
+          <div
+            className='absolute top-full left-0 z-50 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md'
+            onMouseDown={(e) => e.preventDefault()}
           >
             <CommandList className='max-h-60'>
-              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
-              <CommandGroup>
-                {items.map((option) => {
-                  const isSelected = selectedValues.includes(option.value);
-                  return (
-                    <CommandItem
-                      key={option.value}
-                      value={option.value}
-                      keywords={[option.label]}
-                      onSelect={() => handleSelect(option)}
-                      className='cursor-pointer'
-                    >
-                      <Check className={isSelected ? 'opacity-100' : 'opacity-0'} />
-                      <div className='flex flex-col'>
-                        <span>{option.label}</span>
-                        {option.sublabel && <span className='text-xs text-muted-foreground'>{option.sublabel}</span>}
-                      </div>
-                    </CommandItem>
-                  );
-                })}
-              </CommandGroup>
+              {items.length === 0 ? (
+                <div className='py-6 text-center text-sm text-muted-foreground'>
+                  {isPending ? 'Searching…' : emptyText}
+                </div>
+              ) : (
+                <CommandGroup>
+                  {items.map((option) => {
+                    const isSelected = selectedValues.includes(option.value);
+                    return (
+                      <CommandItem
+                        key={option.value}
+                        value={option.value}
+                        keywords={[option.label]}
+                        onSelect={() => handleSelect(option)}
+                        className='cursor-pointer'
+                      >
+                        <Check className={isSelected ? 'opacity-100' : 'opacity-0'} />
+                        <div className='flex flex-col'>
+                          <span>{option.label}</span>
+                          {option.sublabel && <span className='text-xs text-muted-foreground'>{option.sublabel}</span>}
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              )}
             </CommandList>
-          </PopoverContent>
-        </Command>
-      </Popover>
+          </div>
+        )}
+      </Command>
       {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
       {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
     </Field>

--- a/packages/registry/items/react-hook-form/combobox-field/component.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/component.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import type { Lens } from '@hookform/lenses';
+import { Check, Loader2, X } from 'lucide-react';
+import * as React from 'react';
+import { useController } from 'react-hook-form';
+import { Badge } from '@/components/ui/badge';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+
+const DEBOUNCE_TIME = 300;
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  sublabel?: string;
+}
+
+type ComboboxFieldCommonProps = {
+  options?: ComboboxOption[];
+  onSearch?: (query: string) => Promise<ComboboxOption[]>;
+  maxResults?: number;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  emptyText?: string;
+  debounceMs?: number;
+};
+
+export type ComboboxFieldProps =
+  | (ComboboxFieldCommonProps & {
+      multiple?: false;
+      lens: Lens<string>;
+      defaultSelected?: ComboboxOption;
+    })
+  | (ComboboxFieldCommonProps & {
+      multiple: true;
+      lens: Lens<string[]>;
+      defaultSelected?: ComboboxOption[];
+    });
+
+function toArray(value: string | string[] | undefined | null): string[] {
+  if (Array.isArray(value)) return value;
+  if (value) return [value];
+  return [];
+}
+
+export function ComboboxField(props: ComboboxFieldProps) {
+  const {
+    multiple = false,
+    options,
+    onSearch,
+    maxResults,
+    label,
+    description,
+    placeholder,
+    emptyText = 'No results',
+    debounceMs = DEBOUNCE_TIME,
+    defaultSelected,
+  } = props;
+
+  // The discriminated union ties the lens type to `multiple`; values are normalised through
+  // `toArray`, so the interop binding is widened to the shared string | string[] shape here.
+  const { field, fieldState } = useController((props.lens as Lens<string | string[]>).interop());
+
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [results, setResults] = React.useState<ComboboxOption[]>([]);
+  const [isPending, startTransition] = React.useTransition();
+  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  const requestIdRef = React.useRef(0);
+
+  const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
+  React.useMemo(() => {
+    const initial = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
+    for (const option of initial) cacheRef.current.set(option.value, option);
+  }, [defaultSelected]);
+
+  const selectedValues = toArray(field.value);
+
+  const cacheOptions = React.useCallback((items: ComboboxOption[]) => {
+    for (const option of items) cacheRef.current.set(option.value, option);
+  }, []);
+
+  React.useEffect(() => {
+    if (options) cacheOptions(options);
+  }, [options, cacheOptions]);
+
+  const runSearch = React.useCallback(
+    (search: string) => {
+      if (!onSearch) return;
+      const requestId = ++requestIdRef.current;
+      startTransition(async () => {
+        try {
+          const res = await onSearch(search);
+          if (requestId !== requestIdRef.current) return;
+          cacheOptions(res);
+          setResults(res);
+        } catch {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+        }
+      });
+    },
+    [onSearch, cacheOptions],
+  );
+
+  React.useEffect(() => {
+    if (!onSearch || !open) return;
+
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+
+    if (!query) {
+      requestIdRef.current++;
+      runSearch('');
+      return;
+    }
+
+    debounceTimerRef.current = setTimeout(() => runSearch(query), debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, [query, onSearch, open, debounceMs, runSearch]);
+
+  const items = React.useMemo(() => {
+    let list: ComboboxOption[];
+    if (onSearch) {
+      list = results;
+    } else if (!options) {
+      list = [];
+    } else if (!query) {
+      list = options;
+    } else {
+      list = options.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
+    }
+    return maxResults ? list.slice(0, maxResults) : list;
+  }, [onSearch, results, options, query, maxResults]);
+
+  const commit = (next: string[]) => {
+    field.onChange(multiple ? next : (next[0] ?? ''));
+  };
+
+  const handleSelect = (option: ComboboxOption) => {
+    cacheRef.current.set(option.value, option);
+    if (multiple) {
+      const next = selectedValues.includes(option.value)
+        ? selectedValues.filter((value) => value !== option.value)
+        : [...selectedValues, option.value];
+      commit(next);
+      setQuery('');
+      return;
+    }
+    commit([option.value]);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const removeValue = (value: string) => {
+    commit(selectedValues.filter((current) => current !== value));
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    setQuery('');
+    if (!next) field.onBlur();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (multiple && e.key === 'Backspace' && query === '' && selectedValues.length > 0) {
+      removeValue(selectedValues[selectedValues.length - 1]);
+    }
+  };
+
+  const id = field.name;
+  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
+  const inputValue = open ? query : (singleLabel ?? '');
+
+  return (
+    <Field className='gap-2' data-invalid={fieldState.invalid}>
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <Command shouldFilter={false} className='overflow-visible bg-transparent'>
+          <PopoverAnchor asChild>
+            <div
+              className='border-input flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-2 py-1 shadow-xs focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_[data-slot=command-input-wrapper]]:flex-1 [&_[data-slot=command-input-wrapper]]:border-0 [&_[data-slot=command-input-wrapper]]:px-0'
+              aria-invalid={fieldState.invalid}
+            >
+              {multiple &&
+                selectedValues.map((value) => (
+                  <Badge key={value} variant='secondary' className='gap-1'>
+                    {cacheRef.current.get(value)?.label ?? value}
+                    <button
+                      type='button'
+                      className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        removeValue(value);
+                      }}
+                      aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
+                    >
+                      <X className='size-3' />
+                    </button>
+                  </Badge>
+                ))}
+              <CommandInput
+                id={id}
+                value={inputValue}
+                placeholder={multiple && selectedValues.length > 0 ? undefined : placeholder}
+                onValueChange={setQuery}
+                onFocus={() => setOpen(true)}
+                onKeyDown={handleKeyDown}
+                aria-invalid={fieldState.invalid}
+                className='h-7'
+              />
+              {isPending && <Loader2 className='size-4 shrink-0 animate-spin text-muted-foreground' />}
+            </div>
+          </PopoverAnchor>
+          <PopoverContent
+            className='p-0'
+            align='start'
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            style={{ width: 'var(--radix-popover-trigger-width)' }}
+          >
+            <CommandList className='max-h-60'>
+              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
+              <CommandGroup>
+                {items.map((option) => {
+                  const isSelected = selectedValues.includes(option.value);
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      value={option.value}
+                      keywords={[option.label]}
+                      onSelect={() => handleSelect(option)}
+                      className='cursor-pointer'
+                    >
+                      <Check className={isSelected ? 'opacity-100' : 'opacity-0'} />
+                      <div className='flex flex-col'>
+                        <span>{option.label}</span>
+                        {option.sublabel && <span className='text-xs text-muted-foreground'>{option.sublabel}</span>}
+                      </div>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </PopoverContent>
+        </Command>
+      </Popover>
+      {fieldState.invalid && <FieldError className='text-xs text-left' errors={[fieldState.error]} />}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}

--- a/packages/registry/items/react-hook-form/combobox-field/component.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/component.tsx
@@ -93,13 +93,19 @@ export function ComboboxField(props: ComboboxFieldProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  // Populated during render so a preset/selected value can show its label before any
-  // search runs; async results are added in `runSearch`, manual picks in `handleSelect`.
+  // Static options + presets, resolved during render so a value shows its label on first
+  // paint; async results and manual picks live in `cacheRef`. `getOption` reads both.
   const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
-  React.useMemo(() => {
+  const staticLookup = React.useMemo(() => {
+    const map = new Map<string, ComboboxOption>();
     const seed = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
-    for (const option of [...seed, ...(options ?? [])]) cacheRef.current.set(option.value, option);
+    for (const option of [...seed, ...(options ?? [])]) map.set(option.value, option);
+    return map;
   }, [defaultSelected, options]);
+  const getOption = React.useCallback(
+    (value: string | undefined) => (value ? (staticLookup.get(value) ?? cacheRef.current.get(value)) : undefined),
+    [staticLookup],
+  );
 
   const selectedValues = toArray(field.value);
 
@@ -107,36 +113,34 @@ export function ComboboxField(props: ComboboxFieldProps) {
   // (or `onSearch('')` recents) shows on focus instead of filtering down to the label.
   const effectiveQuery = typed ? query : '';
 
-  const cacheOptions = React.useCallback((items: ComboboxOption[]) => {
-    for (const option of items) cacheRef.current.set(option.value, option);
+  // Held in a ref so an inline `onSearch` prop doesn't re-trigger the search effect every render.
+  const onSearchRef = React.useRef(onSearch);
+  onSearchRef.current = onSearch;
+  const hasSearch = Boolean(onSearch);
+
+  const runSearch = React.useCallback((search: string) => {
+    const search$ = onSearchRef.current;
+    if (!search$) return;
+    const requestId = ++requestIdRef.current;
+    startTransition(async () => {
+      try {
+        const res = await search$(search);
+        if (requestId !== requestIdRef.current) return;
+        for (const option of res) cacheRef.current.set(option.value, option);
+        setResults(res);
+      } catch {
+        if (requestId !== requestIdRef.current) return;
+        setResults([]);
+      }
+    });
   }, []);
 
-  const runSearch = React.useCallback(
-    (search: string) => {
-      if (!onSearch) return;
-      const requestId = ++requestIdRef.current;
-      startTransition(async () => {
-        try {
-          const res = await onSearch(search);
-          if (requestId !== requestIdRef.current) return;
-          cacheOptions(res);
-          setResults(res);
-        } catch {
-          if (requestId !== requestIdRef.current) return;
-          setResults([]);
-        }
-      });
-    },
-    [onSearch, cacheOptions],
-  );
-
   React.useEffect(() => {
-    if (!onSearch || !open) return;
+    if (!hasSearch || !open) return;
 
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
     if (!effectiveQuery) {
-      requestIdRef.current++;
       runSearch('');
       return;
     }
@@ -146,7 +150,7 @@ export function ComboboxField(props: ComboboxFieldProps) {
     return () => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     };
-  }, [effectiveQuery, onSearch, open, debounceMs, runSearch]);
+  }, [effectiveQuery, hasSearch, open, debounceMs, runSearch]);
 
   const items = React.useMemo(() => {
     let list: ComboboxOption[];
@@ -166,8 +170,9 @@ export function ComboboxField(props: ComboboxFieldProps) {
     field.onChange(multiple ? next : (next[0] ?? ''));
   };
 
-  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
-  const inputValue = open ? query : (singleLabel ?? '');
+  const firstValue = selectedValues[0];
+  const singleLabel = !multiple ? getOption(firstValue)?.label : undefined;
+  const inputValue = open ? query : multiple ? '' : (singleLabel ?? firstValue ?? '');
 
   const closeMenu = () => {
     setOpen(false);
@@ -231,13 +236,12 @@ export function ComboboxField(props: ComboboxFieldProps) {
     }
   };
 
-  const id = field.name;
   const iconSize = size === 'sm' ? 'size-3.5' : 'size-4';
   const showPlaceholder = multiple ? selectedValues.length === 0 : true;
 
   return (
     <Field className='gap-2' data-invalid={fieldState.invalid}>
-      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      {label && <FieldLabel>{label}</FieldLabel>}
       <Command shouldFilter={false} className='relative h-auto overflow-visible bg-transparent'>
         <div
           ref={containerRef}
@@ -254,7 +258,7 @@ export function ComboboxField(props: ComboboxFieldProps) {
           {multiple &&
             selectedValues.map((value) => (
               <Badge key={value} variant='secondary' className='gap-1'>
-                {cacheRef.current.get(value)?.label ?? value}
+                {getOption(value)?.label ?? value}
                 <button
                   type='button'
                   className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
@@ -262,7 +266,7 @@ export function ComboboxField(props: ComboboxFieldProps) {
                     e.preventDefault();
                     removeValue(value);
                   }}
-                  aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
+                  aria-label={`Remove ${getOption(value)?.label ?? value}`}
                 >
                   <X className='size-3' />
                 </button>
@@ -270,12 +274,10 @@ export function ComboboxField(props: ComboboxFieldProps) {
             ))}
           <CommandPrimitive.Input
             ref={inputRef}
-            id={id}
             value={inputValue}
             placeholder={showPlaceholder ? placeholder : undefined}
-            autoComplete='off'
+            aria-label={label}
             aria-invalid={fieldState.invalid || undefined}
-            aria-expanded={open}
             onValueChange={handleValueChange}
             onFocus={handleFocus}
             onBlur={handleBlur}
@@ -302,7 +304,6 @@ export function ComboboxField(props: ComboboxFieldProps) {
                       <CommandItem
                         key={option.value}
                         value={option.value}
-                        keywords={[option.label]}
                         onSelect={() => handleSelect(option)}
                         className='cursor-pointer'
                       >

--- a/packages/registry/items/react-hook-form/combobox-field/default.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/default.example.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/react-hook-form/combobox-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const COUNTRIES: ComboboxOption[] = [
+  { value: 'fr', label: 'France' },
+  { value: 'de', label: 'Germany' },
+  { value: 'es', label: 'Spain' },
+  { value: 'it', label: 'Italy' },
+  { value: 'pt', label: 'Portugal' },
+  { value: 'nl', label: 'Netherlands' },
+  { value: 'be', label: 'Belgium' },
+];
+
+const zodSchema = z.object({
+  country: z.string().nonempty({ message: 'Country is required' }),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function ComboboxFieldExample() {
+  const form = useForm<Values>({
+    defaultValues: { country: 'fr' },
+    resolver: zodResolver(zodSchema),
+  });
+  const lens = useLens({ control: form.control });
+
+  function onSubmit(values: Values) {
+    alert(`Country: ${values.country}`);
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <ComboboxField
+          lens={lens.focus('country')}
+          label='Country'
+          description='The preset value resolves its label at rest'
+          placeholder='Search a country…'
+          options={COUNTRIES}
+          defaultSelected={{ value: 'fr', label: 'France' }}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/combobox-field/default.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/default.example.tsx
@@ -24,16 +24,16 @@ const zodSchema = z.object({
 
 type Values = z.infer<typeof zodSchema>;
 
+function onSubmit(values: Values) {
+  alert(`Country: ${values.country}`);
+}
+
 export default function ComboboxFieldExample() {
   const form = useForm<Values>({
     defaultValues: { country: 'fr' },
     resolver: zodResolver(zodSchema),
   });
   const lens = useLens({ control: form.control });
-
-  function onSubmit(values: Values) {
-    alert(`Country: ${values.country}`);
-  }
 
   return (
     <Form {...form}>

--- a/packages/registry/items/react-hook-form/combobox-field/index.mdx
+++ b/packages/registry/items/react-hook-form/combobox-field/index.mdx
@@ -15,6 +15,7 @@ It binds to React Hook Form through `@hookform/lenses` (`lens` prop). A preset i
 - **Two search modes**: static `options` (client-side substring filter on `label`) or async `onSearch` (debounced fetch). `onSearch` wins when both are passed.
 - **Recents on open**: `onSearch('')` fires when the menu opens empty, so you can return a suggested list.
 - **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close, Backspace to remove the last chip (multi).
+- **Variants**: `variant` (`boxed` or borderless `ghost`) and `size` (`sm` or `default`).
 
 import { TypeTable } from 'fumadocs-ui/components/type-table';
 
@@ -50,6 +51,16 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
     maxResults: {
       description: 'Caps the number of options shown in the list',
       type: 'number?',
+    },
+    variant: {
+      description: 'Field shell style. "ghost" is borderless and transparent, so multi reads as just the chips.',
+      type: "'boxed' | 'ghost'",
+      default: "'boxed'",
+    },
+    size: {
+      description: 'Field density. "sm" reduces height, padding and text.',
+      type: "'sm' | 'default'",
+      default: "'default'",
     },
     label: {
       description: 'Field label text',

--- a/packages/registry/items/react-hook-form/combobox-field/index.mdx
+++ b/packages/registry/items/react-hook-form/combobox-field/index.mdx
@@ -1,0 +1,77 @@
+---
+title: Combobox Field
+description: Command-style search field that commits an option's id while displaying its label. Binds to React Hook Form, supports single or multiple selection, static options or async search.
+registryName: rhf-combobox-field
+---
+
+`ComboboxField` is a searchable select: the user types to filter, navigates results with the keyboard, and picks one (or several) entries. The committed form value is the option's `value` (a stable id) while the `label` is shown for display — distinct from `autocomplete-field`, where the committed value *is* the typed string.
+
+It binds to React Hook Form through `@hookform/lenses` (`lens` prop). A preset id renders its label immediately via `defaultSelected`, since the component only knows the id and the label lives with your data.
+
+#### Built-in features
+
+- **Id / label split**: commits `value`, displays `label` — map your own rows to `ComboboxOption[]`.
+- **Single or multiple**: toggle with `multiple`; multi renders chips and toggles selection with a check.
+- **Two search modes**: static `options` (client-side substring filter on `label`) or async `onSearch` (debounced fetch). `onSearch` wins when both are passed.
+- **Recents on open**: `onSearch('')` fires when the menu opens empty, so you can return a suggested list.
+- **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close, Backspace to remove the last chip (multi).
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'rhf-combobox-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    lens: {
+      description: 'React Hook Form lens (@hookform/lenses). Lens<string> in single mode, Lens<string[]> when multiple.',
+      type: 'Lens<string> | Lens<string[]>',
+    },
+    multiple: {
+      description: 'Switch to multi-select. Changes the committed value from a string to a string[].',
+      type: 'boolean?',
+      default: 'false',
+    },
+    options: {
+      description: 'Static option list, filtered client-side on label. Ignored when onSearch is provided.',
+      type: 'ComboboxOption[]?',
+    },
+    onSearch: {
+      description: 'Async resolver called with the current query (and with an empty string on open for recents). Takes precedence over options.',
+      type: '((query: string) => Promise<ComboboxOption[]>)?',
+    },
+    defaultSelected: {
+      description: 'Preset option(s) used to render the label of an already-committed value at rest. ComboboxOption in single mode, ComboboxOption[] when multiple.',
+      type: 'ComboboxOption | ComboboxOption[] | undefined',
+    },
+    maxResults: {
+      description: 'Caps the number of options shown in the list',
+      type: 'number?',
+    },
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the field',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Input placeholder',
+      type: 'string?',
+    },
+    emptyText: {
+      description: 'Message shown when a non-empty query has no matches',
+      type: 'string?',
+      default: "'No results'",
+    },
+    debounceMs: {
+      description: 'Debounce delay before calling onSearch (async mode only)',
+      type: 'number?',
+      default: '300',
+    },
+  }}
+/>

--- a/packages/registry/items/react-hook-form/combobox-field/multiple.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/multiple.example.tsx
@@ -23,16 +23,16 @@ const zodSchema = z.object({
 
 type Values = z.infer<typeof zodSchema>;
 
+function onSubmit(values: Values) {
+  alert(`Frameworks: ${values.frameworks.join(', ')}`);
+}
+
 export default function ComboboxFieldMultipleExample() {
   const form = useForm<Values>({
     defaultValues: { frameworks: ['next'] },
     resolver: zodResolver(zodSchema),
   });
   const lens = useLens({ control: form.control });
-
-  function onSubmit(values: Values) {
-    alert(`Frameworks: ${values.frameworks.join(', ')}`);
-  }
 
   return (
     <Form {...form}>

--- a/packages/registry/items/react-hook-form/combobox-field/multiple.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/multiple.example.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Form } from '@/components/ui/form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/react-hook-form/combobox-field';
+import { SubmitButton } from '@/components/ui/shuip/submit-button';
+
+const FRAMEWORKS: ComboboxOption[] = [
+  { value: 'next', label: 'Next.js', sublabel: 'React framework' },
+  { value: 'remix', label: 'Remix', sublabel: 'React framework' },
+  { value: 'astro', label: 'Astro', sublabel: 'Content-driven' },
+  { value: 'svelte', label: 'SvelteKit', sublabel: 'Svelte framework' },
+  { value: 'nuxt', label: 'Nuxt', sublabel: 'Vue framework' },
+  { value: 'solid', label: 'SolidStart', sublabel: 'Solid framework' },
+];
+
+const zodSchema = z.object({
+  frameworks: z.array(z.string()).min(1, { message: 'Pick at least one framework' }),
+});
+
+type Values = z.infer<typeof zodSchema>;
+
+export default function ComboboxFieldMultipleExample() {
+  const form = useForm<Values>({
+    defaultValues: { frameworks: ['next'] },
+    resolver: zodResolver(zodSchema),
+  });
+  const lens = useLens({ control: form.control });
+
+  function onSubmit(values: Values) {
+    alert(`Frameworks: ${values.frameworks.join(', ')}`);
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+        <ComboboxField
+          multiple
+          lens={lens.focus('frameworks')}
+          label='Frameworks'
+          description='Pick several; backspace removes the last chip'
+          placeholder='Search frameworks…'
+          options={FRAMEWORKS}
+          defaultSelected={[{ value: 'next', label: 'Next.js', sublabel: 'React framework' }]}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/combobox-field/sizes.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/sizes.example.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { useForm } from 'react-hook-form';
+import { Form } from '@/components/ui/form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/react-hook-form/combobox-field';
+
+const COUNTRIES: ComboboxOption[] = [
+  { value: 'fr', label: 'France' },
+  { value: 'de', label: 'Germany' },
+  { value: 'es', label: 'Spain' },
+  { value: 'it', label: 'Italy' },
+  { value: 'pt', label: 'Portugal' },
+];
+
+type Values = { small: string; normal: string };
+
+export default function ComboboxFieldSizesExample() {
+  const form = useForm<Values>({
+    defaultValues: { small: 'fr', normal: 'fr' },
+  });
+  const lens = useLens({ control: form.control });
+  const preset: ComboboxOption = { value: 'fr', label: 'France' };
+
+  return (
+    <Form {...form}>
+      <form className='space-y-4'>
+        <ComboboxField
+          size='sm'
+          lens={lens.focus('small')}
+          label='Small'
+          placeholder='Search a country…'
+          options={COUNTRIES}
+          defaultSelected={preset}
+        />
+        <ComboboxField
+          size='default'
+          lens={lens.focus('normal')}
+          label='Default'
+          placeholder='Search a country…'
+          options={COUNTRIES}
+          defaultSelected={preset}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/react-hook-form/combobox-field/sizes.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/sizes.example.tsx
@@ -15,12 +15,13 @@ const COUNTRIES: ComboboxOption[] = [
 
 type Values = { small: string; normal: string };
 
+const PRESET: ComboboxOption = { value: 'fr', label: 'France' };
+
 export default function ComboboxFieldSizesExample() {
   const form = useForm<Values>({
     defaultValues: { small: 'fr', normal: 'fr' },
   });
   const lens = useLens({ control: form.control });
-  const preset: ComboboxOption = { value: 'fr', label: 'France' };
 
   return (
     <Form {...form}>
@@ -31,7 +32,7 @@ export default function ComboboxFieldSizesExample() {
           label='Small'
           placeholder='Search a country…'
           options={COUNTRIES}
-          defaultSelected={preset}
+          defaultSelected={PRESET}
         />
         <ComboboxField
           size='default'
@@ -39,7 +40,7 @@ export default function ComboboxFieldSizesExample() {
           label='Default'
           placeholder='Search a country…'
           options={COUNTRIES}
-          defaultSelected={preset}
+          defaultSelected={PRESET}
         />
       </form>
     </Form>

--- a/packages/registry/items/react-hook-form/combobox-field/variants.example.tsx
+++ b/packages/registry/items/react-hook-form/combobox-field/variants.example.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useLens } from '@hookform/lenses';
+import { useForm } from 'react-hook-form';
+import { Form } from '@/components/ui/form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/react-hook-form/combobox-field';
+
+const FRAMEWORKS: ComboboxOption[] = [
+  { value: 'next', label: 'Next.js' },
+  { value: 'remix', label: 'Remix' },
+  { value: 'astro', label: 'Astro' },
+  { value: 'svelte', label: 'SvelteKit' },
+  { value: 'nuxt', label: 'Nuxt' },
+  { value: 'solid', label: 'SolidStart' },
+];
+
+type Values = { boxed: string[]; ghost: string[] };
+
+export default function ComboboxFieldVariantsExample() {
+  const form = useForm<Values>({
+    defaultValues: { boxed: ['next'], ghost: ['next', 'remix'] },
+  });
+  const lens = useLens({ control: form.control });
+
+  return (
+    <Form {...form}>
+      <form className='space-y-4'>
+        <ComboboxField
+          multiple
+          variant='boxed'
+          lens={lens.focus('boxed')}
+          label='Boxed (default)'
+          placeholder='Search frameworks…'
+          options={FRAMEWORKS}
+          defaultSelected={[{ value: 'next', label: 'Next.js' }]}
+        />
+        <ComboboxField
+          multiple
+          variant='ghost'
+          lens={lens.focus('ghost')}
+          label='Ghost (borderless — chips only)'
+          placeholder='Search frameworks…'
+          options={FRAMEWORKS}
+          defaultSelected={[
+            { value: 'next', label: 'Next.js' },
+            { value: 'remix', label: 'Remix' },
+          ]}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/packages/registry/items/tanstack-form/combobox-field/async.example.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/async.example.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/tanstack-form/combobox-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const USERS: ComboboxOption[] = [
+  { value: 'u1', label: 'Ada Lovelace', sublabel: 'ada@example.com' },
+  { value: 'u2', label: 'Alan Turing', sublabel: 'alan@example.com' },
+  { value: 'u3', label: 'Grace Hopper', sublabel: 'grace@example.com' },
+  { value: 'u4', label: 'Katherine Johnson', sublabel: 'katherine@example.com' },
+  { value: 'u5', label: 'Margaret Hamilton', sublabel: 'margaret@example.com' },
+  { value: 'u6', label: 'Linus Torvalds', sublabel: 'linus@example.com' },
+];
+
+const RECENT_IDS = ['u3', 'u1'];
+
+async function searchUsers(query: string): Promise<ComboboxOption[]> {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  if (!query) return USERS.filter((user) => RECENT_IDS.includes(user.value));
+  return USERS.filter((user) => user.label.toLowerCase().includes(query.toLowerCase()));
+}
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { ComboboxField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfComboboxFieldAsyncExample() {
+  const form = useAppForm({
+    defaultValues: {
+      assignee: '',
+    },
+    onSubmit: async ({ value }) => {
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='assignee'
+        validators={{
+          onChange: ({ value }) => (value.length === 0 ? 'Assignee is required' : undefined),
+        }}
+        children={(field) => (
+          <field.ComboboxField
+            label='Assignee'
+            description='Empty query returns recents; typing searches'
+            placeholder='Search a user…'
+            onSearch={searchUsers}
+            maxResults={5}
+          />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/combobox-field/component.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/component.tsx
@@ -81,13 +81,19 @@ export function ComboboxField({
   const containerRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  // Populated during render so a preset/selected value can show its label before any
-  // search runs; async results are added in `runSearch`, manual picks in `handleSelect`.
+  // Static options + presets, resolved during render so a value shows its label on first
+  // paint; async results and manual picks live in `cacheRef`. `getOption` reads both.
   const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
-  React.useMemo(() => {
+  const staticLookup = React.useMemo(() => {
+    const map = new Map<string, ComboboxOption>();
     const seed = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
-    for (const option of [...seed, ...(options ?? [])]) cacheRef.current.set(option.value, option);
+    for (const option of [...seed, ...(options ?? [])]) map.set(option.value, option);
+    return map;
   }, [defaultSelected, options]);
+  const getOption = React.useCallback(
+    (value: string | undefined) => (value ? (staticLookup.get(value) ?? cacheRef.current.get(value)) : undefined),
+    [staticLookup],
+  );
 
   const selectedValues = toArray(field.state.value);
 
@@ -95,36 +101,34 @@ export function ComboboxField({
   // (or `onSearch('')` recents) shows on focus instead of filtering down to the label.
   const effectiveQuery = typed ? query : '';
 
-  const cacheOptions = React.useCallback((items: ComboboxOption[]) => {
-    for (const option of items) cacheRef.current.set(option.value, option);
+  // Held in a ref so an inline `onSearch` prop doesn't re-trigger the search effect every render.
+  const onSearchRef = React.useRef(onSearch);
+  onSearchRef.current = onSearch;
+  const hasSearch = Boolean(onSearch);
+
+  const runSearch = React.useCallback((search: string) => {
+    const search$ = onSearchRef.current;
+    if (!search$) return;
+    const requestId = ++requestIdRef.current;
+    startTransition(async () => {
+      try {
+        const res = await search$(search);
+        if (requestId !== requestIdRef.current) return;
+        for (const option of res) cacheRef.current.set(option.value, option);
+        setResults(res);
+      } catch {
+        if (requestId !== requestIdRef.current) return;
+        setResults([]);
+      }
+    });
   }, []);
 
-  const runSearch = React.useCallback(
-    (search: string) => {
-      if (!onSearch) return;
-      const requestId = ++requestIdRef.current;
-      startTransition(async () => {
-        try {
-          const res = await onSearch(search);
-          if (requestId !== requestIdRef.current) return;
-          cacheOptions(res);
-          setResults(res);
-        } catch {
-          if (requestId !== requestIdRef.current) return;
-          setResults([]);
-        }
-      });
-    },
-    [onSearch, cacheOptions],
-  );
-
   React.useEffect(() => {
-    if (!onSearch || !open) return;
+    if (!hasSearch || !open) return;
 
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
     if (!effectiveQuery) {
-      requestIdRef.current++;
       runSearch('');
       return;
     }
@@ -134,7 +138,7 @@ export function ComboboxField({
     return () => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     };
-  }, [effectiveQuery, onSearch, open, debounceMs, runSearch]);
+  }, [effectiveQuery, hasSearch, open, debounceMs, runSearch]);
 
   const items = React.useMemo(() => {
     let list: ComboboxOption[];
@@ -154,8 +158,9 @@ export function ComboboxField({
     field.handleChange(multiple ? next : (next[0] ?? ''));
   };
 
-  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
-  const inputValue = open ? query : (singleLabel ?? '');
+  const firstValue = selectedValues[0];
+  const singleLabel = !multiple ? getOption(firstValue)?.label : undefined;
+  const inputValue = open ? query : multiple ? '' : (singleLabel ?? firstValue ?? '');
 
   const closeMenu = () => {
     setOpen(false);
@@ -219,13 +224,12 @@ export function ComboboxField({
     }
   };
 
-  const id = field.name;
   const iconSize = size === 'sm' ? 'size-3.5' : 'size-4';
   const showPlaceholder = multiple ? selectedValues.length === 0 : true;
 
   return (
     <Field className='gap-2' data-invalid={!isValid}>
-      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      {label && <FieldLabel>{label}</FieldLabel>}
       <Command shouldFilter={false} className='relative h-auto overflow-visible bg-transparent'>
         <div
           ref={containerRef}
@@ -242,7 +246,7 @@ export function ComboboxField({
           {multiple &&
             selectedValues.map((value) => (
               <Badge key={value} variant='secondary' className='gap-1'>
-                {cacheRef.current.get(value)?.label ?? value}
+                {getOption(value)?.label ?? value}
                 <button
                   type='button'
                   className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
@@ -250,7 +254,7 @@ export function ComboboxField({
                     e.preventDefault();
                     removeValue(value);
                   }}
-                  aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
+                  aria-label={`Remove ${getOption(value)?.label ?? value}`}
                 >
                   <X className='size-3' />
                 </button>
@@ -258,12 +262,10 @@ export function ComboboxField({
             ))}
           <CommandPrimitive.Input
             ref={inputRef}
-            id={id}
             value={inputValue}
             placeholder={showPlaceholder ? placeholder : undefined}
-            autoComplete='off'
+            aria-label={label}
             aria-invalid={!isValid || undefined}
-            aria-expanded={open}
             onValueChange={handleValueChange}
             onFocus={handleFocus}
             onBlur={handleBlur}
@@ -290,7 +292,6 @@ export function ComboboxField({
                       <CommandItem
                         key={option.value}
                         value={option.value}
-                        keywords={[option.label]}
                         onSelect={() => handleSelect(option)}
                         className='cursor-pointer'
                       >

--- a/packages/registry/items/tanstack-form/combobox-field/component.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/component.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Check, Loader2, X } from 'lucide-react';
+import { Command as CommandPrimitive } from 'cmdk';
+import { Check, Loader2, Search, X } from 'lucide-react';
 import * as React from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
-import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { useFieldContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { cn } from '@/lib/utils';
 
 const DEBOUNCE_TIME = 300;
 
@@ -16,20 +17,34 @@ export interface ComboboxOption {
   sublabel?: string;
 }
 
+type ComboboxFieldVariant = 'boxed' | 'ghost';
+type ComboboxFieldSize = 'sm' | 'default';
+
 export interface ComboboxFieldProps {
   multiple?: boolean;
   options?: ComboboxOption[];
   onSearch?: (query: string) => Promise<ComboboxOption[]>;
-  defaultSelected?: ComboboxOption | ComboboxOption[];
   maxResults?: number;
+  variant?: ComboboxFieldVariant;
+  size?: ComboboxFieldSize;
   label?: string;
   description?: string;
   placeholder?: string;
   emptyText?: string;
   debounceMs?: number;
-  fieldProps?: React.ComponentProps<typeof Field>;
-  props?: Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>;
+  defaultSelected?: ComboboxOption | ComboboxOption[];
 }
+
+const shellVariants: Record<ComboboxFieldVariant, string> = {
+  boxed:
+    'rounded-md border border-input bg-transparent shadow-xs focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20',
+  ghost: 'rounded-md border border-transparent bg-transparent',
+};
+
+const shellSizes: Record<ComboboxFieldSize, string> = {
+  default: 'min-h-9 gap-1.5 px-2 py-1 text-sm',
+  sm: 'min-h-7 gap-1 px-1.5 py-0.5 text-xs',
+};
 
 function toArray(value: string | string[] | undefined | null): string[] {
   if (Array.isArray(value)) return value;
@@ -41,43 +56,48 @@ export function ComboboxField({
   multiple = false,
   options,
   onSearch,
-  defaultSelected,
   maxResults,
+  variant = 'boxed',
+  size = 'default',
   label,
   description,
   placeholder,
   emptyText = 'No results',
   debounceMs = DEBOUNCE_TIME,
-  fieldProps,
-  props,
+  defaultSelected,
 }: ComboboxFieldProps) {
-  // The consumer declares the field value type (string single / string[] multi); both shapes
-  // are normalised through `toArray`, so the context is read at the shared union here.
+  // The consumer's field type (string vs string[]) decides single vs multi; the context is
+  // widened to the shared shape and values are normalised through `toArray`.
   const field = useFieldContext<string | string[]>();
   const { isValid, errors } = field.state.meta;
 
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState('');
+  const [typed, setTyped] = React.useState(false);
   const [results, setResults] = React.useState<ComboboxOption[]>([]);
   const [isPending, startTransition] = React.useTransition();
-  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  const debounceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const requestIdRef = React.useRef(0);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
+  // Populated during render so a preset/selected value can show its label before any
+  // search runs; async results are added in `runSearch`, manual picks in `handleSelect`.
   const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
   React.useMemo(() => {
-    const initial = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
-    for (const option of initial) cacheRef.current.set(option.value, option);
-  }, [defaultSelected]);
+    const seed = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
+    for (const option of [...seed, ...(options ?? [])]) cacheRef.current.set(option.value, option);
+  }, [defaultSelected, options]);
 
   const selectedValues = toArray(field.state.value);
+
+  // A pre-filled-but-untouched single label counts as an empty query, so the full list
+  // (or `onSearch('')` recents) shows on focus instead of filtering down to the label.
+  const effectiveQuery = typed ? query : '';
 
   const cacheOptions = React.useCallback((items: ComboboxOption[]) => {
     for (const option of items) cacheRef.current.set(option.value, option);
   }, []);
-
-  React.useEffect(() => {
-    if (options) cacheOptions(options);
-  }, [options, cacheOptions]);
 
   const runSearch = React.useCallback(
     (search: string) => {
@@ -103,18 +123,18 @@ export function ComboboxField({
 
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
-    if (!query) {
+    if (!effectiveQuery) {
       requestIdRef.current++;
       runSearch('');
       return;
     }
 
-    debounceTimerRef.current = setTimeout(() => runSearch(query), debounceMs);
+    debounceTimerRef.current = setTimeout(() => runSearch(effectiveQuery), debounceMs);
 
     return () => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     };
-  }, [query, onSearch, open, debounceMs, runSearch]);
+  }, [effectiveQuery, onSearch, open, debounceMs, runSearch]);
 
   const items = React.useMemo(() => {
     let list: ComboboxOption[];
@@ -122,16 +142,42 @@ export function ComboboxField({
       list = results;
     } else if (!options) {
       list = [];
-    } else if (!query) {
+    } else if (!effectiveQuery) {
       list = options;
     } else {
-      list = options.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
+      list = options.filter((option) => option.label.toLowerCase().includes(effectiveQuery.toLowerCase()));
     }
     return maxResults ? list.slice(0, maxResults) : list;
-  }, [onSearch, results, options, query, maxResults]);
+  }, [onSearch, results, options, effectiveQuery, maxResults]);
 
   const commit = (next: string[]) => {
     field.handleChange(multiple ? next : (next[0] ?? ''));
+  };
+
+  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
+  const inputValue = open ? query : (singleLabel ?? '');
+
+  const closeMenu = () => {
+    setOpen(false);
+    setQuery('');
+    setTyped(false);
+  };
+
+  const handleFocus = () => {
+    setOpen(true);
+    setTyped(false);
+    if (!multiple && singleLabel) {
+      setQuery(singleLabel);
+      requestAnimationFrame(() => inputRef.current?.select());
+    } else {
+      setQuery('');
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent) => {
+    if (containerRef.current?.contains(e.relatedTarget as Node | null)) return;
+    field.handleBlur();
+    closeMenu();
   };
 
   const handleSelect = (option: ComboboxOption) => {
@@ -142,106 +188,126 @@ export function ComboboxField({
         : [...selectedValues, option.value];
       commit(next);
       setQuery('');
+      setTyped(false);
+      inputRef.current?.focus();
       return;
     }
     commit([option.value]);
-    setQuery('');
-    setOpen(false);
+    closeMenu();
+    inputRef.current?.blur();
   };
 
   const removeValue = (value: string) => {
     commit(selectedValues.filter((current) => current !== value));
   };
 
-  const handleOpenChange = (next: boolean) => {
-    setOpen(next);
-    setQuery('');
-    if (!next) field.handleBlur();
+  const handleValueChange = (value: string) => {
+    setQuery(value);
+    setTyped(true);
+    setOpen(true);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeMenu();
+      inputRef.current?.blur();
+      return;
+    }
     if (multiple && e.key === 'Backspace' && query === '' && selectedValues.length > 0) {
       removeValue(selectedValues[selectedValues.length - 1]);
     }
   };
 
-  const id = props?.id ?? field.name;
-  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
-  const inputValue = open ? query : (singleLabel ?? '');
+  const id = field.name;
+  const iconSize = size === 'sm' ? 'size-3.5' : 'size-4';
+  const showPlaceholder = multiple ? selectedValues.length === 0 : true;
 
   return (
-    <Field className='gap-2' data-invalid={!isValid} {...fieldProps}>
+    <Field className='gap-2' data-invalid={!isValid}>
       {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
-      <Popover open={open} onOpenChange={handleOpenChange}>
-        <Command shouldFilter={false} className='overflow-visible bg-transparent'>
-          <PopoverAnchor asChild>
-            <div
-              className='border-input flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-2 py-1 shadow-xs focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_[data-slot=command-input-wrapper]]:flex-1 [&_[data-slot=command-input-wrapper]]:border-0 [&_[data-slot=command-input-wrapper]]:px-0'
-              aria-invalid={!isValid}
-            >
-              {multiple &&
-                selectedValues.map((value) => (
-                  <Badge key={value} variant='secondary' className='gap-1'>
-                    {cacheRef.current.get(value)?.label ?? value}
-                    <button
-                      type='button'
-                      className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        removeValue(value);
-                      }}
-                      aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
-                    >
-                      <X className='size-3' />
-                    </button>
-                  </Badge>
-                ))}
-              <CommandInput
-                {...props}
-                id={id}
-                value={inputValue}
-                placeholder={multiple && selectedValues.length > 0 ? undefined : placeholder}
-                onValueChange={setQuery}
-                onFocus={() => setOpen(true)}
-                onKeyDown={handleKeyDown}
-                aria-invalid={!isValid}
-                className='h-7'
-              />
-              {isPending && <Loader2 className='size-4 shrink-0 animate-spin text-muted-foreground' />}
-            </div>
-          </PopoverAnchor>
-          <PopoverContent
-            className='p-0'
-            align='start'
-            onOpenAutoFocus={(e) => e.preventDefault()}
-            style={{ width: 'var(--radix-popover-trigger-width)' }}
+      <Command shouldFilter={false} className='relative h-auto overflow-visible bg-transparent'>
+        <div
+          ref={containerRef}
+          aria-invalid={!isValid || undefined}
+          className={cn('flex w-full flex-wrap items-center', shellVariants[variant], shellSizes[size])}
+          onMouseDown={(e) => {
+            if (e.target !== inputRef.current) {
+              e.preventDefault();
+              inputRef.current?.focus();
+            }
+          }}
+        >
+          <Search className={cn('shrink-0 text-muted-foreground', iconSize)} aria-hidden />
+          {multiple &&
+            selectedValues.map((value) => (
+              <Badge key={value} variant='secondary' className='gap-1'>
+                {cacheRef.current.get(value)?.label ?? value}
+                <button
+                  type='button'
+                  className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    removeValue(value);
+                  }}
+                  aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
+                >
+                  <X className='size-3' />
+                </button>
+              </Badge>
+            ))}
+          <CommandPrimitive.Input
+            ref={inputRef}
+            id={id}
+            value={inputValue}
+            placeholder={showPlaceholder ? placeholder : undefined}
+            autoComplete='off'
+            aria-invalid={!isValid || undefined}
+            aria-expanded={open}
+            onValueChange={handleValueChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            className='min-w-20 flex-1 bg-transparent outline-hidden placeholder:text-muted-foreground'
+          />
+          {isPending && <Loader2 className={cn('shrink-0 animate-spin text-muted-foreground', iconSize)} />}
+        </div>
+        {open && (
+          <div
+            className='absolute top-full left-0 z-50 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md'
+            onMouseDown={(e) => e.preventDefault()}
           >
             <CommandList className='max-h-60'>
-              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
-              <CommandGroup>
-                {items.map((option) => {
-                  const isSelected = selectedValues.includes(option.value);
-                  return (
-                    <CommandItem
-                      key={option.value}
-                      value={option.value}
-                      keywords={[option.label]}
-                      onSelect={() => handleSelect(option)}
-                      className='cursor-pointer'
-                    >
-                      <Check className={isSelected ? 'opacity-100' : 'opacity-0'} />
-                      <div className='flex flex-col'>
-                        <span>{option.label}</span>
-                        {option.sublabel && <span className='text-xs text-muted-foreground'>{option.sublabel}</span>}
-                      </div>
-                    </CommandItem>
-                  );
-                })}
-              </CommandGroup>
+              {items.length === 0 ? (
+                <div className='py-6 text-center text-sm text-muted-foreground'>
+                  {isPending ? 'Searching…' : emptyText}
+                </div>
+              ) : (
+                <CommandGroup>
+                  {items.map((option) => {
+                    const isSelected = selectedValues.includes(option.value);
+                    return (
+                      <CommandItem
+                        key={option.value}
+                        value={option.value}
+                        keywords={[option.label]}
+                        onSelect={() => handleSelect(option)}
+                        className='cursor-pointer'
+                      >
+                        <Check className={isSelected ? 'opacity-100' : 'opacity-0'} />
+                        <div className='flex flex-col'>
+                          <span>{option.label}</span>
+                          {option.sublabel && <span className='text-xs text-muted-foreground'>{option.sublabel}</span>}
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              )}
             </CommandList>
-          </PopoverContent>
-        </Command>
-      </Popover>
+          </div>
+        )}
+      </Command>
       {!isValid && (
         <FieldError
           className='text-xs text-left'

--- a/packages/registry/items/tanstack-form/combobox-field/component.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/component.tsx
@@ -83,7 +83,8 @@ export function ComboboxField({
 
   // Static options + presets, resolved during render so a value shows its label on first
   // paint; async results and manual picks live in `cacheRef`. `getOption` reads both.
-  const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
+  const cacheRef = React.useRef<Map<string, ComboboxOption> | null>(null);
+  cacheRef.current ??= new Map();
   const staticLookup = React.useMemo(() => {
     const map = new Map<string, ComboboxOption>();
     const seed = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
@@ -91,7 +92,7 @@ export function ComboboxField({
     return map;
   }, [defaultSelected, options]);
   const getOption = React.useCallback(
-    (value: string | undefined) => (value ? (staticLookup.get(value) ?? cacheRef.current.get(value)) : undefined),
+    (value: string | undefined) => (value ? (staticLookup.get(value) ?? cacheRef.current?.get(value)) : undefined),
     [staticLookup],
   );
 
@@ -114,7 +115,7 @@ export function ComboboxField({
       try {
         const res = await search$(search);
         if (requestId !== requestIdRef.current) return;
-        for (const option of res) cacheRef.current.set(option.value, option);
+        for (const option of res) cacheRef.current?.set(option.value, option);
         setResults(res);
       } catch {
         if (requestId !== requestIdRef.current) return;
@@ -186,7 +187,7 @@ export function ComboboxField({
   };
 
   const handleSelect = (option: ComboboxOption) => {
-    cacheRef.current.set(option.value, option);
+    cacheRef.current?.set(option.value, option);
     if (multiple) {
       const next = selectedValues.includes(option.value)
         ? selectedValues.filter((value) => value !== option.value)

--- a/packages/registry/items/tanstack-form/combobox-field/component.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/component.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { Check, Loader2, X } from 'lucide-react';
+import * as React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import { useFieldContext } from '@/components/ui/shuip/tanstack-form/form-context';
+
+const DEBOUNCE_TIME = 300;
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  sublabel?: string;
+}
+
+export interface ComboboxFieldProps {
+  multiple?: boolean;
+  options?: ComboboxOption[];
+  onSearch?: (query: string) => Promise<ComboboxOption[]>;
+  defaultSelected?: ComboboxOption | ComboboxOption[];
+  maxResults?: number;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  emptyText?: string;
+  debounceMs?: number;
+  fieldProps?: React.ComponentProps<typeof Field>;
+  props?: Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>;
+}
+
+function toArray(value: string | string[] | undefined | null): string[] {
+  if (Array.isArray(value)) return value;
+  if (value) return [value];
+  return [];
+}
+
+export function ComboboxField({
+  multiple = false,
+  options,
+  onSearch,
+  defaultSelected,
+  maxResults,
+  label,
+  description,
+  placeholder,
+  emptyText = 'No results',
+  debounceMs = DEBOUNCE_TIME,
+  fieldProps,
+  props,
+}: ComboboxFieldProps) {
+  // The consumer declares the field value type (string single / string[] multi); both shapes
+  // are normalised through `toArray`, so the context is read at the shared union here.
+  const field = useFieldContext<string | string[]>();
+  const { isValid, errors } = field.state.meta;
+
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [results, setResults] = React.useState<ComboboxOption[]>([]);
+  const [isPending, startTransition] = React.useTransition();
+  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  const requestIdRef = React.useRef(0);
+
+  const cacheRef = React.useRef<Map<string, ComboboxOption>>(new Map());
+  React.useMemo(() => {
+    const initial = Array.isArray(defaultSelected) ? defaultSelected : defaultSelected ? [defaultSelected] : [];
+    for (const option of initial) cacheRef.current.set(option.value, option);
+  }, [defaultSelected]);
+
+  const selectedValues = toArray(field.state.value);
+
+  const cacheOptions = React.useCallback((items: ComboboxOption[]) => {
+    for (const option of items) cacheRef.current.set(option.value, option);
+  }, []);
+
+  React.useEffect(() => {
+    if (options) cacheOptions(options);
+  }, [options, cacheOptions]);
+
+  const runSearch = React.useCallback(
+    (search: string) => {
+      if (!onSearch) return;
+      const requestId = ++requestIdRef.current;
+      startTransition(async () => {
+        try {
+          const res = await onSearch(search);
+          if (requestId !== requestIdRef.current) return;
+          cacheOptions(res);
+          setResults(res);
+        } catch {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+        }
+      });
+    },
+    [onSearch, cacheOptions],
+  );
+
+  React.useEffect(() => {
+    if (!onSearch || !open) return;
+
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+
+    if (!query) {
+      requestIdRef.current++;
+      runSearch('');
+      return;
+    }
+
+    debounceTimerRef.current = setTimeout(() => runSearch(query), debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, [query, onSearch, open, debounceMs, runSearch]);
+
+  const items = React.useMemo(() => {
+    let list: ComboboxOption[];
+    if (onSearch) {
+      list = results;
+    } else if (!options) {
+      list = [];
+    } else if (!query) {
+      list = options;
+    } else {
+      list = options.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
+    }
+    return maxResults ? list.slice(0, maxResults) : list;
+  }, [onSearch, results, options, query, maxResults]);
+
+  const commit = (next: string[]) => {
+    field.handleChange(multiple ? next : (next[0] ?? ''));
+  };
+
+  const handleSelect = (option: ComboboxOption) => {
+    cacheRef.current.set(option.value, option);
+    if (multiple) {
+      const next = selectedValues.includes(option.value)
+        ? selectedValues.filter((value) => value !== option.value)
+        : [...selectedValues, option.value];
+      commit(next);
+      setQuery('');
+      return;
+    }
+    commit([option.value]);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const removeValue = (value: string) => {
+    commit(selectedValues.filter((current) => current !== value));
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    setQuery('');
+    if (!next) field.handleBlur();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (multiple && e.key === 'Backspace' && query === '' && selectedValues.length > 0) {
+      removeValue(selectedValues[selectedValues.length - 1]);
+    }
+  };
+
+  const id = props?.id ?? field.name;
+  const singleLabel = !multiple ? cacheRef.current.get(selectedValues[0])?.label : undefined;
+  const inputValue = open ? query : (singleLabel ?? '');
+
+  return (
+    <Field className='gap-2' data-invalid={!isValid} {...fieldProps}>
+      {label && <FieldLabel htmlFor={id}>{label}</FieldLabel>}
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <Command shouldFilter={false} className='overflow-visible bg-transparent'>
+          <PopoverAnchor asChild>
+            <div
+              className='border-input flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-2 py-1 shadow-xs focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_[data-slot=command-input-wrapper]]:flex-1 [&_[data-slot=command-input-wrapper]]:border-0 [&_[data-slot=command-input-wrapper]]:px-0'
+              aria-invalid={!isValid}
+            >
+              {multiple &&
+                selectedValues.map((value) => (
+                  <Badge key={value} variant='secondary' className='gap-1'>
+                    {cacheRef.current.get(value)?.label ?? value}
+                    <button
+                      type='button'
+                      className='cursor-pointer rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        removeValue(value);
+                      }}
+                      aria-label={`Remove ${cacheRef.current.get(value)?.label ?? value}`}
+                    >
+                      <X className='size-3' />
+                    </button>
+                  </Badge>
+                ))}
+              <CommandInput
+                {...props}
+                id={id}
+                value={inputValue}
+                placeholder={multiple && selectedValues.length > 0 ? undefined : placeholder}
+                onValueChange={setQuery}
+                onFocus={() => setOpen(true)}
+                onKeyDown={handleKeyDown}
+                aria-invalid={!isValid}
+                className='h-7'
+              />
+              {isPending && <Loader2 className='size-4 shrink-0 animate-spin text-muted-foreground' />}
+            </div>
+          </PopoverAnchor>
+          <PopoverContent
+            className='p-0'
+            align='start'
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            style={{ width: 'var(--radix-popover-trigger-width)' }}
+          >
+            <CommandList className='max-h-60'>
+              <CommandEmpty>{isPending ? 'Searching…' : emptyText}</CommandEmpty>
+              <CommandGroup>
+                {items.map((option) => {
+                  const isSelected = selectedValues.includes(option.value);
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      value={option.value}
+                      keywords={[option.label]}
+                      onSelect={() => handleSelect(option)}
+                      className='cursor-pointer'
+                    >
+                      <Check className={isSelected ? 'opacity-100' : 'opacity-0'} />
+                      <div className='flex flex-col'>
+                        <span>{option.label}</span>
+                        {option.sublabel && <span className='text-xs text-muted-foreground'>{option.sublabel}</span>}
+                      </div>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </PopoverContent>
+        </Command>
+      </Popover>
+      {!isValid && (
+        <FieldError
+          className='text-xs text-left'
+          errors={errors.map((error) => ({ message: typeof error === 'string' ? error : error?.message }))}
+        />
+      )}
+      {description && <FieldDescription className='text-xs'>{description}</FieldDescription>}
+    </Field>
+  );
+}

--- a/packages/registry/items/tanstack-form/combobox-field/default.example.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/default.example.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/tanstack-form/combobox-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const COUNTRIES: ComboboxOption[] = [
+  { value: 'fr', label: 'France' },
+  { value: 'de', label: 'Germany' },
+  { value: 'es', label: 'Spain' },
+  { value: 'it', label: 'Italy' },
+  { value: 'pt', label: 'Portugal' },
+  { value: 'nl', label: 'Netherlands' },
+  { value: 'be', label: 'Belgium' },
+];
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { ComboboxField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfComboboxFieldExample() {
+  const form = useAppForm({
+    defaultValues: {
+      country: 'fr',
+    },
+    onSubmit: async ({ value }) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='country'
+        validators={{
+          onChange: ({ value }) => (value.length === 0 ? 'Country is required' : undefined),
+        }}
+        children={(field) => (
+          <field.ComboboxField
+            label='Country'
+            description='The preset value resolves its label at rest'
+            placeholder='Search a country…'
+            options={COUNTRIES}
+            defaultSelected={{ value: 'fr', label: 'France' }}
+          />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/combobox-field/index.mdx
+++ b/packages/registry/items/tanstack-form/combobox-field/index.mdx
@@ -1,0 +1,102 @@
+---
+title: Combobox Field
+description: Command-style search field that commits an option's id while displaying its label, integrated with TanStack Form via React context. Supports single or multiple selection, static options or async search.
+registryName: tsf-combobox-field
+---
+
+`ComboboxField` is a searchable select: the user types to filter, navigates results with the keyboard, and picks one (or several) entries. The committed form value is the option's `value` (a stable id) while the `label` is shown for display — distinct from `autocomplete-field`, where the committed value *is* the typed string.
+
+It reads the surrounding field via `useFieldContext`, so you compose it inside a `<form.AppField>` rather than passing a `form` instance by prop. The field value type you declare drives single (`string`) vs multiple (`string[]`); a preset id renders its label immediately via `defaultSelected`.
+
+#### Built-in features
+
+- **Id / label split**: commits `value`, displays `label` — map your own rows to `ComboboxOption[]`.
+- **Single or multiple**: toggle with `multiple`; multi renders chips and toggles selection with a check.
+- **Two search modes**: static `options` (client-side substring filter on `label`) or async `onSearch` (debounced fetch). `onSearch` wins when both are passed.
+- **Recents on open**: `onSearch('')` fires when the menu opens empty, so you can return a suggested list.
+- **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close, Backspace to remove the last chip (multi).
+
+## Setup
+
+Field components are bound via React context. In your project, create `lib/form.ts` once:
+
+```tsx
+// lib/form.ts
+import { createFormHook } from '@tanstack/react-form';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { ComboboxField } from '@/components/ui/shuip/tanstack-form/combobox-field';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+export const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { ComboboxField },
+  formComponents: { SubmitButton },
+});
+```
+
+See the [`form-context`](/components/tanstack-form/form-context) item for details.
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+## Examples
+
+<ItemExamples registryName={'tsf-combobox-field'} />
+
+## Props
+
+<TypeTable
+  type={{
+    multiple: {
+      description: 'Switch to multi-select. The field value type should be string[] instead of string.',
+      type: 'boolean?',
+      default: 'false',
+    },
+    options: {
+      description: 'Static option list, filtered client-side on label. Ignored when onSearch is provided.',
+      type: 'ComboboxOption[]?',
+    },
+    onSearch: {
+      description: 'Async resolver called with the current query (and with an empty string on open for recents). Takes precedence over options.',
+      type: '((query: string) => Promise<ComboboxOption[]>)?',
+    },
+    defaultSelected: {
+      description: 'Preset option(s) used to render the label of an already-committed value at rest.',
+      type: 'ComboboxOption | ComboboxOption[] | undefined',
+    },
+    maxResults: {
+      description: 'Caps the number of options shown in the list',
+      type: 'number?',
+    },
+    label: {
+      description: 'Field label text',
+      type: 'string?',
+    },
+    description: {
+      description: 'Helper text displayed below the field',
+      type: 'string?',
+    },
+    placeholder: {
+      description: 'Input placeholder',
+      type: 'string?',
+    },
+    emptyText: {
+      description: 'Message shown when a non-empty query has no matches',
+      type: 'string?',
+      default: "'No results'",
+    },
+    debounceMs: {
+      description: 'Debounce delay before calling onSearch (async mode only)',
+      type: 'number?',
+      default: '300',
+    },
+    fieldProps: {
+      description: 'Props passed to the Field wrapper component',
+      type: 'React.ComponentProps<typeof Field>?',
+    },
+    props: {
+      description: 'Native HTML input props (id, disabled, etc.)',
+      type: "Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>?",
+    },
+  }}
+/>

--- a/packages/registry/items/tanstack-form/combobox-field/index.mdx
+++ b/packages/registry/items/tanstack-form/combobox-field/index.mdx
@@ -15,6 +15,7 @@ It reads the surrounding field via `useFieldContext`, so you compose it inside a
 - **Two search modes**: static `options` (client-side substring filter on `label`) or async `onSearch` (debounced fetch). `onSearch` wins when both are passed.
 - **Recents on open**: `onSearch('')` fires when the menu opens empty, so you can return a suggested list.
 - **Keyboard navigation**: ArrowUp/ArrowDown to move, Enter to select, Escape to close, Backspace to remove the last chip (multi).
+- **Variants**: `variant` (`boxed` or borderless `ghost`) and `size` (`sm` or `default`).
 
 ## Setup
 
@@ -68,6 +69,16 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
       description: 'Caps the number of options shown in the list',
       type: 'number?',
     },
+    variant: {
+      description: 'Field shell style. "ghost" is borderless and transparent, so multi reads as just the chips.',
+      type: "'boxed' | 'ghost'",
+      default: "'boxed'",
+    },
+    size: {
+      description: 'Field density. "sm" reduces height, padding and text.',
+      type: "'sm' | 'default'",
+      default: "'default'",
+    },
     label: {
       description: 'Field label text',
       type: 'string?',
@@ -89,14 +100,6 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
       description: 'Debounce delay before calling onSearch (async mode only)',
       type: 'number?',
       default: '300',
-    },
-    fieldProps: {
-      description: 'Props passed to the Field wrapper component',
-      type: 'React.ComponentProps<typeof Field>?',
-    },
-    props: {
-      description: 'Native HTML input props (id, disabled, etc.)',
-      type: "Omit<React.ComponentProps<'input'>, 'value' | 'onChange'>?",
     },
   }}
 />

--- a/packages/registry/items/tanstack-form/combobox-field/multiple.example.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/multiple.example.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/tanstack-form/combobox-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+import { SubmitButton } from '@/components/ui/shuip/tanstack-form/submit-button';
+
+const FRAMEWORKS: ComboboxOption[] = [
+  { value: 'next', label: 'Next.js', sublabel: 'React framework' },
+  { value: 'remix', label: 'Remix', sublabel: 'React framework' },
+  { value: 'astro', label: 'Astro', sublabel: 'Content-driven' },
+  { value: 'svelte', label: 'SvelteKit', sublabel: 'Svelte framework' },
+  { value: 'nuxt', label: 'Nuxt', sublabel: 'Vue framework' },
+  { value: 'solid', label: 'SolidStart', sublabel: 'Solid framework' },
+];
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { ComboboxField },
+  formComponents: { SubmitButton },
+});
+
+export default function TsfComboboxFieldMultipleExample() {
+  const form = useAppForm({
+    defaultValues: {
+      frameworks: ['next'] as string[],
+    },
+    onSubmit: async ({ value }) => {
+      alert(JSON.stringify(value, null, 2));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className='space-y-4'
+    >
+      <form.AppField
+        name='frameworks'
+        validators={{
+          onChange: ({ value }) => (value.length === 0 ? 'Pick at least one framework' : undefined),
+        }}
+        children={(field) => (
+          <field.ComboboxField
+            multiple
+            label='Frameworks'
+            description='Pick several; backspace removes the last chip'
+            placeholder='Search frameworks…'
+            options={FRAMEWORKS}
+            defaultSelected={[{ value: 'next', label: 'Next.js', sublabel: 'React framework' }]}
+          />
+        )}
+      />
+
+      <form.AppForm>
+        <form.SubmitButton>Submit</form.SubmitButton>
+      </form.AppForm>
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/combobox-field/sizes.example.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/sizes.example.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/tanstack-form/combobox-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+
+const COUNTRIES: ComboboxOption[] = [
+  { value: 'fr', label: 'France' },
+  { value: 'de', label: 'Germany' },
+  { value: 'es', label: 'Spain' },
+  { value: 'it', label: 'Italy' },
+  { value: 'pt', label: 'Portugal' },
+];
+
+const PRESET: ComboboxOption = { value: 'fr', label: 'France' };
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { ComboboxField },
+  formComponents: {},
+});
+
+export default function TsfComboboxFieldSizesExample() {
+  const form = useAppForm({
+    defaultValues: {
+      small: 'fr',
+      normal: 'fr',
+    },
+  });
+
+  return (
+    <form className='space-y-4'>
+      <form.AppField
+        name='small'
+        children={(field) => (
+          <field.ComboboxField
+            size='sm'
+            label='Small'
+            placeholder='Search a country…'
+            options={COUNTRIES}
+            defaultSelected={PRESET}
+          />
+        )}
+      />
+      <form.AppField
+        name='normal'
+        children={(field) => (
+          <field.ComboboxField
+            size='default'
+            label='Default'
+            placeholder='Search a country…'
+            options={COUNTRIES}
+            defaultSelected={PRESET}
+          />
+        )}
+      />
+    </form>
+  );
+}

--- a/packages/registry/items/tanstack-form/combobox-field/variants.example.tsx
+++ b/packages/registry/items/tanstack-form/combobox-field/variants.example.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { createFormHook } from '@tanstack/react-form';
+import { ComboboxField, type ComboboxOption } from '@/components/ui/shuip/tanstack-form/combobox-field';
+import { fieldContext, formContext } from '@/components/ui/shuip/tanstack-form/form-context';
+
+const FRAMEWORKS: ComboboxOption[] = [
+  { value: 'next', label: 'Next.js' },
+  { value: 'remix', label: 'Remix' },
+  { value: 'astro', label: 'Astro' },
+  { value: 'svelte', label: 'SvelteKit' },
+  { value: 'nuxt', label: 'Nuxt' },
+  { value: 'solid', label: 'SolidStart' },
+];
+
+const { useAppForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: { ComboboxField },
+  formComponents: {},
+});
+
+export default function TsfComboboxFieldVariantsExample() {
+  const form = useAppForm({
+    defaultValues: {
+      boxed: ['next'] as string[],
+      ghost: ['next', 'remix'] as string[],
+    },
+  });
+
+  return (
+    <form className='space-y-4'>
+      <form.AppField
+        name='boxed'
+        children={(field) => (
+          <field.ComboboxField
+            multiple
+            variant='boxed'
+            label='Boxed (default)'
+            placeholder='Search frameworks…'
+            options={FRAMEWORKS}
+            defaultSelected={[{ value: 'next', label: 'Next.js' }]}
+          />
+        )}
+      />
+      <form.AppField
+        name='ghost'
+        children={(field) => (
+          <field.ComboboxField
+            multiple
+            variant='ghost'
+            label='Ghost (borderless — chips only)'
+            placeholder='Search frameworks…'
+            options={FRAMEWORKS}
+            defaultSelected={[
+              { value: 'next', label: 'Next.js' },
+              { value: 'remix', label: 'Remix' },
+            ]}
+          />
+        )}
+      />
+    </form>
+  );
+}

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span';
+
+  return <Comp data-slot='badge' className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## Summary

Adds `rhf-combobox-field` and `tsf-combobox-field` to the registry: a command-style search field where the user types, results appear in a navigable dropdown (arrows + Enter), and selecting commits the option's `value` (an id) while displaying its `label`.

## Features

- **Single & multi-select** via a `multiple` prop — value is `string` (single) or `string[]` (multi, rendered as removable chips).
- **Static or async search** — `options` (client-side filter) or `onSearch(query) => Promise<ComboboxOption[]>`; `onSearch` is invoked with an empty query on open so consumers can return a "recents" list.
- **`maxResults`** caps the displayed results.
- **`defaultSelected`** resolves and displays the label of a preset form value at rest.
- Built on cmdk `Command` / `CommandInput` (magnifier + keyboard nav) inside a `Popover`.

## Items

- `packages/registry/items/react-hook-form/combobox-field/`
- `packages/registry/items/tanstack-form/combobox-field/`

Each ships `component.tsx`, three examples (`default` / `multiple` / `async`) and `index.mdx`.

## Notes

- Adds the shadcn `badge` primitive (`packages/ui/src/components/ui/badge.tsx`), used for the multi-select chips.
- Design spec: `docs/superpowers/specs/2026-06-16-combobox-field-design.md`.

## Verification

- `bun registry:generate` → +2 items, no skip warnings; deps detected (`badge`, `command`, `field`, `popover`).
- `NODE_OPTIONS=--max-old-space-size=6144 bun build:docs` → green.